### PR TITLE
Fix single and multi-tags

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -201,9 +201,15 @@ class GuideAsciidocGenerator {
     static List<String> extractTags(String line, String tagSeparator = '|') {
         String attributeValue = extractFromParametersLine(line, 'tags')
         if (attributeValue) {
-            return attributeValue?.split(tagSeparator) as List<String>
+            return attributeValue.tokenize(tagSeparator)
         }
-        [extractTagName(line)]
+
+        String singleTag = extractTagName(line)
+        if (singleTag.isEmpty()) {
+            return []
+        } else {
+            return [singleTag]
+        }
     }
 
     static String extractFromParametersLine(String line, String attributeName) {

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -204,12 +204,7 @@ class GuideAsciidocGenerator {
             return attributeValue.tokenize(tagSeparator)
         }
 
-        String singleTag = extractTagName(line)
-        if (singleTag.isEmpty()) {
-            return []
-        } else {
-            return [singleTag]
-        }
+        [extractTagName(line)].findAll { it }
     }
 
     static String extractFromParametersLine(String line, String attributeName) {


### PR DESCRIPTION
This PR fixes two things:

- Multi-tags: Use `tokenize` instead of `split` because the latter receives a regex you using `|` doesn't work. It was splitting all the characters in the tag.
- Single tag: When there wasn't a tag defined the previous code added a `tag=` to every include.