### PR TITLE
code micronaut-scheduled

### DIFF
--- a/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/Application.groovy
+++ b/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/Application.groovy
@@ -1,0 +1,34 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.runtime.Micronaut
+import io.micronaut.runtime.server.event.ServerStartupEvent
+
+import javax.inject.Singleton
+
+@CompileStatic
+@Singleton // <1>
+class Application implements ApplicationEventListener<ServerStartupEvent> {  // <2>
+
+    private final RegisterUseCase registerUseCase
+
+    Application(RegisterUseCase registerUseCase) { // <3>
+        this.registerUseCase = registerUseCase
+    }
+
+    static void main(String[] args) {
+        Micronaut.run(Application.class)
+    }
+
+    @Override
+    void onApplicationEvent(ServerStartupEvent event) { // <4>
+        try {
+            registerUseCase.register("harry@micronaut.example")
+            Thread.sleep(20000)
+            registerUseCase.register("ron@micronaut.example")
+        } catch (InterruptedException e) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/DailyEmailJob.groovy
+++ b/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/DailyEmailJob.groovy
@@ -1,0 +1,22 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.scheduling.annotation.Scheduled
+
+import javax.inject.Singleton
+
+@CompileStatic
+@Singleton // <1>
+class DailyEmailJob {
+
+    protected final EmailUseCase emailUseCase
+
+    DailyEmailJob(EmailUseCase emailUseCase) { // <2>
+        this.emailUseCase = emailUseCase
+    }
+
+    @Scheduled(cron = "0 30 4 1/1 * ?") // <3>
+    void execute() {
+        emailUseCase.send("john.doe@micronaut.example", "Test Message") // <4>
+    }
+}

--- a/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/EmailTask.groovy
+++ b/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/EmailTask.groovy
@@ -1,0 +1,16 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class EmailTask implements Runnable {
+
+    String email
+    String message
+    EmailUseCase emailUseCase
+
+    @Override
+    void run() {
+        emailUseCase.send(email, message)
+    }
+}

--- a/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/EmailUseCase.groovy
+++ b/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/EmailUseCase.groovy
@@ -1,0 +1,17 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+
+import javax.inject.Singleton
+import java.text.SimpleDateFormat
+
+@Slf4j
+@CompileStatic
+@Singleton
+class EmailUseCase {
+
+    void send(String user, String message) {
+        log.info("Sending email to {}: {} at {}", user, message, new SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(new Date()))
+    }
+}

--- a/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/HelloWorldJob.groovy
+++ b/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/HelloWorldJob.groovy
@@ -1,0 +1,24 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.micronaut.scheduling.annotation.Scheduled
+
+import javax.inject.Singleton
+import java.text.SimpleDateFormat
+
+@CompileStatic
+@Singleton // <1>
+@Slf4j // <2>
+class HelloWorldJob {
+
+    @Scheduled(fixedDelay = "10s") // <3>
+    void executeEveryTen() {
+        log.info("Simple Job every 10 seconds: {}", new SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(new Date()))
+    }
+
+    @Scheduled(fixedDelay = "45s", initialDelay = "5s") // <4>
+    void executeEveryFortyFive() {
+        log.info("Simple Job every 45 seconds: {}", new SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(new Date()))
+    }
+}

--- a/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/RegisterUseCase.groovy
+++ b/guides/micronaut-scheduled/groovy/src/main/groovy/example/micronaut/RegisterUseCase.groovy
@@ -1,0 +1,36 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.TaskScheduler
+
+import javax.inject.Named
+import javax.inject.Singleton
+import java.text.SimpleDateFormat
+import java.time.Duration
+
+@CompileStatic
+@Slf4j
+@Singleton
+class RegisterUseCase {
+
+    protected final TaskScheduler taskScheduler
+    protected final EmailUseCase emailUseCase
+
+    RegisterUseCase(EmailUseCase emailUseCase, // <1>
+                    @Named(TaskExecutors.SCHEDULED) TaskScheduler taskScheduler) { // <2>
+        this.emailUseCase = emailUseCase
+        this.taskScheduler = taskScheduler
+    }
+
+    void register(String email) {
+        log.info("saving {} at {}", email, new SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(new Date()))
+        scheduleFollowupEmail(email, "Welcome to Micronaut")
+    }
+
+    private void scheduleFollowupEmail(String email, String message) {
+        EmailTask task = new EmailTask(emailUseCase: emailUseCase, email: email, message: message) // <3>
+        taskScheduler.schedule(Duration.ofMinutes(1), task) // <4>
+    }
+}

--- a/guides/micronaut-scheduled/groovy/src/main/resources/logback.xml
+++ b/guides/micronaut-scheduled/groovy/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="example.micronaut" level="TRACE"/>
+    <!-- tag::logger[] -->
+    <logger name="example.micronaut" level="info"/>
+    <!-- end::logger[] -->
+</configuration>

--- a/guides/micronaut-scheduled/java/src/main/java/example/micronaut/Application.java
+++ b/guides/micronaut-scheduled/java/src/main/java/example/micronaut/Application.java
@@ -1,0 +1,33 @@
+package example.micronaut;
+
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.runtime.Micronaut;
+import io.micronaut.runtime.server.event.ServerStartupEvent;
+
+import javax.inject.Singleton;
+
+@Singleton // <1>
+public class Application implements ApplicationEventListener<ServerStartupEvent> {  // <2>
+
+    private final RegisterUseCase registerUseCase;
+
+    public Application(RegisterUseCase registerUseCase) {  // <3>
+        this.registerUseCase = registerUseCase;
+    }
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class);
+    }
+
+
+    @Override
+    public void onApplicationEvent(ServerStartupEvent event) {  // <4>
+        try {
+            registerUseCase.register("harry@micronaut.example");
+            Thread.sleep(20000);
+            registerUseCase.register("ron@micronaut.example");
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/guides/micronaut-scheduled/java/src/main/java/example/micronaut/DailyEmailJob.java
+++ b/guides/micronaut-scheduled/java/src/main/java/example/micronaut/DailyEmailJob.java
@@ -1,0 +1,20 @@
+package example.micronaut;
+
+import io.micronaut.scheduling.annotation.Scheduled;
+
+import javax.inject.Singleton;
+
+@Singleton // <1>
+public class DailyEmailJob {
+
+    protected final EmailUseCase emailUseCase;
+
+    public DailyEmailJob(EmailUseCase emailUseCase) {  // <2>
+        this.emailUseCase = emailUseCase;
+    }
+
+    @Scheduled(cron = "0 30 4 1/1 * ?") // <3>
+    void execute() {
+        emailUseCase.send("john.doe@micronaut.example", "Test Message"); // <4>
+    }
+}

--- a/guides/micronaut-scheduled/java/src/main/java/example/micronaut/EmailTask.java
+++ b/guides/micronaut-scheduled/java/src/main/java/example/micronaut/EmailTask.java
@@ -1,0 +1,20 @@
+package example.micronaut;
+
+public class EmailTask implements Runnable {
+
+    private String email;
+    private String message;
+    private EmailUseCase emailUseCase;
+
+    public EmailTask(EmailUseCase emailUseCase, String email, String message) {
+        this.email = email;
+        this.message = message;
+        this.emailUseCase = emailUseCase;
+    }
+
+    @Override
+    public void run() {
+        emailUseCase.send(email, message);
+    }
+
+}

--- a/guides/micronaut-scheduled/java/src/main/java/example/micronaut/EmailUseCase.java
+++ b/guides/micronaut-scheduled/java/src/main/java/example/micronaut/EmailUseCase.java
@@ -1,0 +1,17 @@
+package example.micronaut;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Singleton
+public class EmailUseCase {
+    private static final Logger LOG = LoggerFactory.getLogger(EmailUseCase.class); // <2>
+
+    void send(String user, String message) {
+        LOG.info("Sending email to {}: {} at {}", user, message, new SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(new Date()));
+    }
+}

--- a/guides/micronaut-scheduled/java/src/main/java/example/micronaut/HelloWorldJob.java
+++ b/guides/micronaut-scheduled/java/src/main/java/example/micronaut/HelloWorldJob.java
@@ -1,0 +1,24 @@
+package example.micronaut;
+
+import io.micronaut.scheduling.annotation.Scheduled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@Singleton // <1>
+public class HelloWorldJob {
+    private static final Logger LOG = LoggerFactory.getLogger(HelloWorldJob.class); // <2>
+
+    @Scheduled(fixedDelay = "10s") // <3>
+    void executeEveryTen() {
+        LOG.info("Simple Job every 10 seconds: {}", new SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(new Date()));
+    }
+
+    @Scheduled(fixedDelay = "45s", initialDelay = "5s") // <4>
+    void executeEveryFourtyFive() {
+        LOG.info("Simple Job every 45 seconds: {}", new SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(new Date()));
+    }
+}

--- a/guides/micronaut-scheduled/java/src/main/java/example/micronaut/RegisterUseCase.java
+++ b/guides/micronaut-scheduled/java/src/main/java/example/micronaut/RegisterUseCase.java
@@ -1,0 +1,37 @@
+package example.micronaut;
+
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.TaskScheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.Date;
+
+@Singleton
+public class RegisterUseCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RegisterUseCase.class);
+
+    protected final TaskScheduler taskScheduler;
+    protected final EmailUseCase emailUseCase;
+
+    public RegisterUseCase(EmailUseCase emailUseCase, // <1>
+                           @Named(TaskExecutors.SCHEDULED) TaskScheduler taskScheduler) {  // <2>
+        this.emailUseCase = emailUseCase;
+        this.taskScheduler = taskScheduler;
+    }
+
+    public void register(String email) {
+        LOG.info("saving {} at {}", email, new SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(new Date()));
+        scheduleFollowupEmail(email, "Welcome to Micronaut");
+    }
+
+    private void scheduleFollowupEmail(String email, String message) {
+        EmailTask task = new EmailTask(emailUseCase, email, message); // <3>
+        taskScheduler.schedule(Duration.ofMinutes(1), task);  // <4>
+    }
+}

--- a/guides/micronaut-scheduled/java/src/main/resources/logback.xml
+++ b/guides/micronaut-scheduled/java/src/main/resources/logback.xml
@@ -1,0 +1,21 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="example.micronaut" level="TRACE"/>
+    <!-- tag::logger[] -->
+    <logger name="example.micronaut" level="info"/>
+    <!-- end::logger[] -->
+
+</configuration>

--- a/guides/micronaut-scheduled/java/src/test/java/example/micronaut/CompleteTest.java
+++ b/guides/micronaut-scheduled/java/src/test/java/example/micronaut/CompleteTest.java
@@ -1,0 +1,21 @@
+package example.micronaut;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import javax.inject.Inject;
+
+@MicronautTest
+public class CompleteTest {
+
+    @Inject
+    EmbeddedApplication application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/BootStrap.kt
+++ b/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/BootStrap.kt
@@ -1,0 +1,20 @@
+package example.micronaut
+
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.runtime.server.event.ServerStartupEvent
+import javax.inject.Singleton
+
+@Singleton // <1>
+class BootStrap(val registerUseCase: RegisterUseCase) // <2>
+    : ApplicationEventListener<ServerStartupEvent> { // <3>
+
+    override fun onApplicationEvent(event: ServerStartupEvent) {  // <4>
+        try {
+            registerUseCase.register("harry@micronaut.example")
+            Thread.sleep(20000)
+            registerUseCase.register("ron@micronaut.example")
+        } catch (e: InterruptedException) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/DailyEmailJob.kt
+++ b/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/DailyEmailJob.kt
@@ -1,0 +1,13 @@
+package example.micronaut
+
+import io.micronaut.scheduling.annotation.Scheduled
+import javax.inject.Singleton
+
+@Singleton // <1>
+class DailyEmailJob(protected val emailUseCase: EmailUseCase) { // <2>
+
+    @Scheduled(cron = "0 30 4 1/1 * ?") // <3>
+    fun execute() {
+        emailUseCase.send("john.doe@micronaut.example", "Test Message") // <4>
+    }
+}

--- a/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/EmailTask.kt
+++ b/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/EmailTask.kt
@@ -1,0 +1,9 @@
+package example.micronaut
+
+class EmailTask(private val emailUseCase: EmailUseCase, private val email: String, private val message: String) : Runnable {
+
+    override fun run() {
+        emailUseCase.send(email, message)
+    }
+
+}

--- a/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/EmailUseCase.kt
+++ b/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/EmailUseCase.kt
@@ -1,0 +1,18 @@
+package example.micronaut
+
+import org.slf4j.LoggerFactory
+import java.text.SimpleDateFormat
+import java.util.*
+import javax.inject.Singleton
+
+@Singleton
+class EmailUseCase {
+
+    fun send(user: String, message: String) {
+        LOG.info("Sending email to {} : {} at {}", user, message, SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(Date()))
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(EmailUseCase::class.java)
+    }
+}

--- a/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/HelloWorldJob.kt
+++ b/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/HelloWorldJob.kt
@@ -1,0 +1,25 @@
+package example.micronaut
+
+import io.micronaut.scheduling.annotation.Scheduled
+import org.slf4j.LoggerFactory
+import java.text.SimpleDateFormat
+import java.util.*
+import javax.inject.Singleton
+
+@Singleton // <1>
+class HelloWorldJob {
+
+    @Scheduled(fixedDelay = "10s") // <3>
+    fun executeEveryTen() {
+        LOG.info("Simple Job every 10 seconds: {}", SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(Date()))
+    }
+
+    @Scheduled(fixedDelay = "45s", initialDelay = "5s") // <4>
+    fun executeEveryFourtyFive() {
+        LOG.info("Simple Job every 45 seconds: {}", SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(Date()))
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(HelloWorldJob::class.java) // <2>
+    }
+}

--- a/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/RegisterUseCase.kt
+++ b/guides/micronaut-scheduled/kotlin/src/main/kotlin/example/micronaut/RegisterUseCase.kt
@@ -1,0 +1,29 @@
+package example.micronaut
+
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.TaskScheduler
+import org.slf4j.LoggerFactory
+import java.text.SimpleDateFormat
+import java.time.Duration
+import java.util.*
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class RegisterUseCase(private val emailUseCase: EmailUseCase, // <1>
+                      @param:Named(TaskExecutors.SCHEDULED) private val taskScheduler: TaskScheduler) { // <2>
+
+    fun register(email: String) {
+        LOG.info("saving {} at {}", email, SimpleDateFormat("dd/M/yyyy hh:mm:ss").format(Date()))
+        scheduleFollowupEmail(email, "Welcome to Micronaut")
+    }
+
+    private fun scheduleFollowupEmail(email: String, message: String) {
+        val task = EmailTask(emailUseCase, email, message) // <3>
+        taskScheduler.schedule(Duration.ofMinutes(1), task)  // <4>
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(RegisterUseCase::class.java)
+    }
+}

--- a/guides/micronaut-scheduled/kotlin/src/main/resources/logback.xml
+++ b/guides/micronaut-scheduled/kotlin/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <!-- tag::logger[] -->
+    <logger name="example.micronaut" level="info" />
+    <!-- end::logger[] -->
+</configuration>

--- a/guides/micronaut-scheduled/kotlin/src/test/kotlin/example/micronaut/CompleteTest.kt
+++ b/guides/micronaut-scheduled/kotlin/src/test/kotlin/example/micronaut/CompleteTest.kt
@@ -1,0 +1,19 @@
+package example.micronaut
+import io.micronaut.runtime.EmbeddedApplication
+import io.micronaut.test.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MicronautTest
+class CompleteTest {
+
+    @Inject
+    lateinit var application: EmbeddedApplication<*>
+
+    @Test
+    fun testItWorks() {
+        Assertions.assertTrue(application.isRunning)
+    }
+
+}

--- a/guides/micronaut-scheduled/metadata.json
+++ b/guides/micronaut-scheduled/metadata.json
@@ -1,0 +1,13 @@
+{
+  "asciidoctor": "micronaut-scheduled.adoc",
+  "slug": "micronaut-scheduled",
+  "title": "Schedule periodic tasks inside your Micronaut applications",
+  "intro": "Learn how to schedule periodic tasks inside your Micronaut microservices.",
+  "authors": ["Sergio del Amo"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["graalvm"]
+    }
+  ]
+}


### PR DESCRIPTION
See: https://github.com/micronaut-projects/micronaut-guides-poc/issues/17

The Kotlin guide has a `BootStrap` and a default Application while the other guides have the server startup event directly in the Kotlin guide. We need to align the Kotlin guide. 

I have left the comment in the issue as well. 