### PR TITLE
New workflow for testing Micronaut Snapshot

### DIFF
--- a/.github/workflows/gradle-snapshot.yml
+++ b/.github/workflows/gradle-snapshot.yml
@@ -1,11 +1,7 @@
-name: Java CI
+name: Java CI for Micronaut SNAPSHOT
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  schedule:
+    - cron: '0 5 * * SUN'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,6 +22,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Use next snapshot version
+        run: ./increment_version.sh -p
       - name: Build with Gradle
         run: ./gradlew build
       - name: Execute tests

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,6 +12,7 @@ repositories {
     mavenCentral()
     jcenter()
     maven { url "https://repo.grails.org/grails/core" }
+    maven { url "https://oss.jfrog.org/oss-snapshot-local" }
 }
 
 dependencies {

--- a/increment_version.sh
+++ b/increment_version.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Increment a version string using Semantic Versioning (SemVer) terminology.
+# Source: https://github.com/fmahnke/shell-semver
+
+# Parse command line options.
+
+while getopts ":Mmp" Option
+do
+  case $Option in
+    M ) major=true;;
+    m ) minor=true;;
+    p ) patch=true;;
+  esac
+done
+
+shift $(($OPTIND - 1))
+
+version=`cat version.txt`
+
+# Build array from version string.
+
+a=( ${version//./ } )
+
+# Increment version numbers as requested.
+
+if [ ! -z $major ]
+then
+  ((a[0]++))
+  a[1]=0
+  a[2]=0
+fi
+
+if [ ! -z $minor ]
+then
+  ((a[1]++))
+  a[2]=0
+fi
+
+if [ ! -z $patch ] && ! [[ "${a[3]}" =~ ^M.*|^RC.* ]]
+then
+  ((a[2]++))
+fi
+
+NEW_VERSION="${a[0]}.${a[1]}.${a[2]}-SNAPSHOT"
+
+echo "New version is: ${NEW_VERSION}"
+echo -n $NEW_VERSION > version.txt


### PR DESCRIPTION
Finally have it working with the approach of modifying the `version.txt` file with the same bash script we use in our Github Actions for setting the next snapshot. Then I just run the build and the generated `test.sh`.

The job runs properly: https://github.com/micronaut-projects/micronaut-guides-poc/runs/1864357635?check_suite_focus=true#step:5:1

I've modified the job to set a cron on Sundays at 05:00 and force the push.

---
@sdelamo I've also tried a different approach. Modify the version file in as part of a gradle task. The problem with this approach is that we can't start with 2.3.1 and in the same "run" modify the file. Gradle won't see the changes. So this is basically a two step task: first modify the version and then run the build. That's why I decided to go with the script approach because it is easier.
I have a couple of local branches with the things I've tried in case you want to take a look at them.
