### PR TITLE
Set right format for asciidoctor code blocks

### DIFF
--- a/guides/micronaut-error-handling/micronaut-error-handling.adoc
+++ b/guides/micronaut-error-handling/micronaut-error-handling.adoc
@@ -30,11 +30,7 @@ Micronaut ships out-of-the-box with support for http://velocity.apache.org/[Apac
 
 Create a `notFound.vm` view:
 
-[source,html]
-.src/main/resources/views/notFound.vm
-----
-include::{sourceDir}/@sourceDir@/src/main/resources/views/notFound.vm[]
-----
+resource:views/notFound.vm[]
 
 Create a `NotFoundController`:
 
@@ -54,30 +50,11 @@ Then create a view to display a form:
 
 image::createbook.png[]
 
-[source,html]
-.src/main/resources/views/bookscreate.vm
-----
-include::{sourceDir}/@sourceDir@/src/main/resources/views/bookscreate.vm[]
-----
+resource:views/bookscreate.vm[]
 
 Create a controller to map the form submission:
 
-[source,@lang@]
-.src/main/@lang@/example/micronaut/BookController.@languageextension@
-----
-include::{sourceDir}/@sourceDir@/src/main/@lang@/example/micronaut/BookController.@languageextension@[tag=package]
-
-include::{sourceDir}/@sourceDir@/src/main/@lang@/example/micronaut/BookController.@languageextension@[tag=imports]
-
-include::{sourceDir}/@sourceDir@/src/main/@lang@/example/micronaut/BookController.@languageextension@[tag=clazz]
-
-include::{sourceDir}/@sourceDir@/src/main/@lang@/example/micronaut/BookController.@languageextension@[tag=create]
-
-include::{sourceDir}/@sourceDir@/src/main/@lang@/example/micronaut/BookController.@languageextension@[tag=save]
-
-include::{sourceDir}/@sourceDir@/src/main/@lang@/example/micronaut/BookController.@languageextension@[tag=createModelWithBlankValues]
-
-----
+source:BookController[tags=package|imports|clazz|create|save|createModelWithBlankValues]
 
 <1> The class is defined as a controller with the `@Controller` annotation mapped to the path `/books`
 <2> Use `@View` annotation to indicate the view name which should be used to render a view for the route.


### PR DESCRIPTION
This PRs sets the format for asciidoctor code blocks based on filename extension, so yaml, xml, html files are rendered properly. 
It also refactors the code a little bit to remove duplication.

### Before
![image](https://user-images.githubusercontent.com/559192/108191497-79665900-7113-11eb-86c4-2ad67459876c.png)

### After

![image](https://user-images.githubusercontent.com/559192/108191591-9d299f00-7113-11eb-9b7c-be7555b04a6f.png)
