### PR TITLE
Add new macro to group dependencies in same block

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -44,6 +44,8 @@ class GuideAsciidocGenerator {
             List<String> lines = []
             boolean excludeLineForLanguage = false
             boolean excludeLineForBuild = false
+            boolean groupDependencies = false
+            List<String> groupedDependencies = []
             for (String line : rawLines) {
                 if (shouldProcessLine(line, 'source:')) {
                     lines.addAll(sourceIncludeLines(extractName(line, 'source:'), extractAppName(line), null, extractTags(line)))
@@ -57,8 +59,20 @@ class GuideAsciidocGenerator {
                 } else if (shouldProcessLine(line, 'testResource:')) {
                     lines.addAll(testResourceIncludeLines(extractName(line, 'testResource:'), extractAppName(line), extractTags(line)))
 
+                } else if (line == ':dependencies:') {
+                    groupDependencies = !groupDependencies
+                    if (!groupDependencies) {
+                        // closing tag. Group and output them all together
+                        lines.addAll(DependencyLines.asciidoc(groupedDependencies, guidesOption.buildTool))
+                        groupedDependencies = []
+                    }
+
                 } else if (shouldProcessLine(line, 'dependency:')) {
-                    lines.addAll(DependencyLines.asciidoc(line, guidesOption.buildTool))
+                    if (groupDependencies) {
+                        groupedDependencies.add(line)
+                    } else {
+                        lines.addAll(DependencyLines.asciidoc(line, guidesOption.buildTool))
+                    }
 
                 } else if (line == ':exclude-for-build:') {
                     excludeLineForBuild = false

--- a/buildSrc/src/main/java/io/micronaut/guides/DependencyLines.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/DependencyLines.java
@@ -3,6 +3,7 @@ package io.micronaut.guides;
 import io.micronaut.starter.options.BuildTool;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,41 +53,55 @@ public class DependencyLines {
     }
 
     public static List<String> asciidoc(String line, BuildTool buildTool) {
-        String artifactId = line.substring("dependency:".length(), line.indexOf("["));
-        Map<String, String> attributes = new HashMap<>();
-        String attributesStr = line.substring(line.indexOf("[") + "[".length(), line.indexOf("]"));
-        String[] attrs = attributesStr.split(",");
-        for (String att : attrs) {
-            String[] keyValues = att.split("=");
-            if (keyValues.length == 2) {
-                attributes.put(keyValues[0], keyValues[1]);
-            }
-        }
-        String groupId = attributes.getOrDefault("groupId", "io.micronaut");
-        String scope = attributes.getOrDefault("scope", "implementation");
-        String gradleScope = toGradleScope(attributes) != null ? toGradleScope(attributes) : SCOPE_IMPLEMENTATION;
-        String mavenScope = toMavenScope(attributes) != null ? toMavenScope(attributes) : SCOPE_COMPILE;
+        return asciidoc(Collections.singletonList(line), buildTool);
+    }
+
+    public static List<String> asciidoc(List<String> lines, BuildTool buildTool) {
         List<String> dependencyLines = new ArrayList<>();
 
+        // Open Asciidoctor code block
         if (buildTool == BuildTool.GRADLE) {
             dependencyLines.add("[source, groovy]");
             dependencyLines.add(".build.gradle");
-            dependencyLines.add("----");
-            dependencyLines.add(gradleScope + "(\"" + groupId + ":" + artifactId + "\")");
             dependencyLines.add("----");
         } else if (buildTool == BuildTool.MAVEN) {
             dependencyLines.add("[source, xml]");
             dependencyLines.add(".pom.xml");
             dependencyLines.add("----");
-            dependencyLines.add("<dependency>");
-            dependencyLines.add("    <groupId>" + groupId + "</groupId>");
-            dependencyLines.add("    <artifactId>" + artifactId + "</artifactId>");
-            if (!mavenScope.equals(SCOPE_COMPILE)) {
-                dependencyLines.add("    <scope>" + mavenScope + "</scope>");
-            }
-            dependencyLines.add("</dependency>");
-            dependencyLines.add("----");
         }
+
+        for (String line: lines) {
+            String artifactId = line.substring("dependency:".length(), line.indexOf("["));
+            Map<String, String> attributes = new HashMap<>();
+            String attributesStr = line.substring(line.indexOf("[") + "[".length(), line.indexOf("]"));
+            String[] attrs = attributesStr.split(",");
+            for (String att : attrs) {
+                String[] keyValues = att.split("=");
+                if (keyValues.length == 2) {
+                    attributes.put(keyValues[0], keyValues[1]);
+                }
+            }
+            String groupId = attributes.getOrDefault("groupId", "io.micronaut");
+            String scope = attributes.getOrDefault("scope", "implementation");
+            String gradleScope = toGradleScope(attributes) != null ? toGradleScope(attributes) : SCOPE_IMPLEMENTATION;
+            String mavenScope = toMavenScope(attributes) != null ? toMavenScope(attributes) : SCOPE_COMPILE;
+
+            if (buildTool == BuildTool.GRADLE) {
+                dependencyLines.add(gradleScope + "(\"" + groupId + ":" + artifactId + "\")");
+            } else if (buildTool == BuildTool.MAVEN) {
+                dependencyLines.add("<dependency>");
+                dependencyLines.add("    <groupId>" + groupId + "</groupId>");
+                dependencyLines.add("    <artifactId>" + artifactId + "</artifactId>");
+                if (!mavenScope.equals(SCOPE_COMPILE)) {
+                    dependencyLines.add("    <scope>" + mavenScope + "</scope>");
+                }
+                dependencyLines.add("</dependency>");
+            }
+        }
+
+        // Close Asciidoctor code block
+        dependencyLines.add("----");
+
         return dependencyLines;
     }
 }


### PR DESCRIPTION
This PRs adds the possibility to group a list of dependencies in the same group. This is used in the Zipkin guide (and probably in others):

The following code:

```
:dependencies:

dependency:micronaut-tracing[groupId=io.opentracing.brave]
dependency:brave-instrumentation-http[groupId=io.zipkin.brave,scope=runtimeOnly]
dependency:zipkin-reporter[groupId=io.zipkin.reporter,scope=runtimeOnly]

:dependencies:
```

Generates all the dependencies inside the same block (right screenshot) instead of in separate blocks (left screenshot):

![DeepinScreenshot_select-area_20210217132439](https://user-images.githubusercontent.com/559192/108204371-01ecf580-7124-11eb-9608-6803f5376561.png)
