### PR TITLE
Expand all common includes before substitute own macros

### DIFF
--- a/src/docs/common/common-create-app.adoc
+++ b/src/docs/common/common-create-app.adoc
@@ -12,8 +12,4 @@ NOTE: If you don't specify the `--build` argument, Gradle is used as a build too
 
 The previous command creates a micronaut app with the default package `example.micronaut` in a folder named `complete`.
 
-:exclude-for-languages:groovy
-
 include::{commondir}/common-annotationprocessors.adoc[]
-
-:exclude-for-languages:


### PR DESCRIPTION
This PR changes how we process the original asciidoctor files we write for the guides. First we "expand" all the common snippets recursively and then we process every line and the some replacements of our own macros.

The problem was that our macros like `:exclude-for-languages:` only were processed if they were at the first level, i.e: in the guide asciidoctor we write, but not in any common snippet nested into another one.

So, when we did in our guide the following `include::xxx` in line 15:

![image](https://user-images.githubusercontent.com/559192/108721117-ecac0880-7521-11eb-865e-fe198f75b413.png)

The content of the `common-annotationprocessors.adoc` file was not included (we kept the `include::`) so in the second step of our processing we didn't found the `:excludes-for-languages:` tag included in that file, and it appeared in the final html generated:


![image](https://user-images.githubusercontent.com/559192/108721049-d736de80-7521-11eb-90d3-216cc92dc4d9.png)


![image](https://user-images.githubusercontent.com/559192/108720925-b2db0200-7521-11eb-9fac-84c3e1544e13.png)


After this PR all the content of all the snippets are resolved and included into a list with all the lines, then we find and replace our macros (and all of them are found), and finally the final content is rendered properly.

When expanding and including the content of the common snippets I've surrounded them with start/end comments so we can trace them back if needed to the original file. Also pay attention to the last block that doesn't include anything because it is for Groovy and that snippet contains a `:exclude-for-languages:groovy` macro. This is the temporarily generated file that is rendered by asciidoctor (there are no `include::` blocks for common snippets (we kept unchanged the ones that include source files, tests,...)

![image](https://user-images.githubusercontent.com/559192/108721899-d0f53200-7522-11eb-9135-81b6318a1880.png)
