### PR TITLE
guide: adds Micronaut Cache for al three languages [#19]

### DIFF
--- a/guides/micronaut-cache/groovy/src/main/groovy/example/micronaut/News.groovy
+++ b/guides/micronaut-cache/groovy/src/main/groovy/example/micronaut/News.groovy
@@ -1,0 +1,13 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.core.annotation.Introspected
+
+import java.time.Month
+
+@CompileStatic
+@Introspected
+class News {
+    Month month
+    List<String> headlines
+}

--- a/guides/micronaut-cache/groovy/src/main/groovy/example/micronaut/NewsController.groovy
+++ b/guides/micronaut-cache/groovy/src/main/groovy/example/micronaut/NewsController.groovy
@@ -1,0 +1,23 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+import java.time.Month
+
+@CompileStatic
+@Controller
+class NewsController {
+
+    private final NewsService newsService
+
+    NewsController(NewsService newsService) {
+        this.newsService = newsService
+    }
+
+    @Get('/{month}')
+    News index(Month month) {
+        new News(month: month, headlines: newsService.headlines(month))
+    }
+}

--- a/guides/micronaut-cache/groovy/src/main/groovy/example/micronaut/NewsService.groovy
+++ b/guides/micronaut-cache/groovy/src/main/groovy/example/micronaut/NewsService.groovy
@@ -1,0 +1,49 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.cache.annotation.CacheConfig
+import io.micronaut.cache.annotation.CacheInvalidate
+import io.micronaut.cache.annotation.CachePut
+import io.micronaut.cache.annotation.Cacheable
+import javax.inject.Singleton
+import java.time.Month
+import java.util.concurrent.TimeUnit
+
+@CompileStatic
+@Singleton // <1>
+@CacheConfig("headlines") // <2>
+class NewsService {
+
+    Map<Month, List<String>> headlines = [
+        (Month.NOVEMBER): ["Micronaut Graduates to Trial Level in Thoughtworks technology radar Vol.1",
+                "Micronaut AOP: Awesome flexibility without the complexity"],
+        (Month.OCTOBER): ["Micronaut AOP: Awesome flexibility without the complexity"]
+    ]
+
+    @Cacheable // <3>
+    List<String> headlines(Month month) {
+        TimeUnit.SECONDS.sleep(3) // <4>
+        headlines[month]
+    }
+
+    @CachePut(parameters = ["month"]) // <5>
+    List<String> addHeadline(Month month, String headline) {
+        if (headlines.containsKey(month)) {
+            List<String> lines = headlines[month]
+            lines << headline
+            headlines.put(month, lines)
+        } else {
+            headlines[month] = [headline]
+        }
+        headlines[month]
+    }
+
+    @CacheInvalidate(parameters = ["month"]) // <6>
+    void removeHeadline(Month month, String headline) {
+        if (headlines.containsKey(month)) {
+            List<String> lines = headlines[month]
+            lines -= headline
+            headlines.put(month, lines)
+        }
+    }
+}

--- a/guides/micronaut-cache/groovy/src/main/resources/application.yml
+++ b/guides/micronaut-cache/groovy/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+#tag::config[]
+micronaut:
+  caches:
+    headlines: # <1>
+      charset: 'UTF-8'
+#end::config[]

--- a/guides/micronaut-cache/groovy/src/test/groovy/example/micronaut/NewsControllerSpec.groovy
+++ b/guides/micronaut-cache/groovy/src/test/groovy/example/micronaut/NewsControllerSpec.groovy
@@ -5,7 +5,7 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.uri.UriBuilder
 import io.micronaut.runtime.server.EmbeddedServer
-import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Specification
 import spock.lang.Timeout
 

--- a/guides/micronaut-cache/groovy/src/test/groovy/example/micronaut/NewsControllerSpec.groovy
+++ b/guides/micronaut-cache/groovy/src/test/groovy/example/micronaut/NewsControllerSpec.groovy
@@ -1,0 +1,45 @@
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.annotation.MicronautTest
+import spock.lang.Specification
+import spock.lang.Timeout
+
+import javax.inject.Inject
+import java.time.Month
+
+@MicronautTest
+class NewsControllerSpec extends Specification {
+
+    @Inject
+    EmbeddedServer server
+
+    @Inject
+    @Client("/")
+    HttpClient client
+
+    @Timeout(4) // <1>
+    void "fetching october headlines uses cache"() {
+        given:
+        String expected = "Micronaut AOP: Awesome flexibility without the complexity"
+
+        when:
+        HttpRequest request = HttpRequest.GET(UriBuilder.of("/")
+                .path(Month.OCTOBER.toString())
+                .build())
+        News news = client.toBlocking().retrieve(request, News)
+
+        then:
+        [expected] == news.headlines
+
+        when:
+        news = client.toBlocking().retrieve(request, News)
+
+        then:
+        [expected] == news.headlines
+    }
+}

--- a/guides/micronaut-cache/groovy/src/test/groovy/example/micronaut/NewsServiceSpec.groovy
+++ b/guides/micronaut-cache/groovy/src/test/groovy/example/micronaut/NewsServiceSpec.groovy
@@ -1,6 +1,6 @@
 package example.micronaut
 
-import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Specification
 import spock.lang.Stepwise
 import spock.lang.Timeout

--- a/guides/micronaut-cache/groovy/src/test/groovy/example/micronaut/NewsServiceSpec.groovy
+++ b/guides/micronaut-cache/groovy/src/test/groovy/example/micronaut/NewsServiceSpec.groovy
@@ -1,0 +1,98 @@
+package example.micronaut
+
+import io.micronaut.test.annotation.MicronautTest
+import spock.lang.Specification
+import spock.lang.Stepwise
+import spock.lang.Timeout
+
+import javax.inject.Inject
+import java.time.Month
+
+@Stepwise // <1>
+@MicronautTest // <2>
+class NewsServiceSpec extends Specification {
+
+    @Inject // <3>
+    NewsService newsService;
+
+    @Timeout(4) // <4>
+    void "first invocation of November does not hit cache"() {
+        when:
+        List<String> headlines = newsService.headlines(Month.NOVEMBER)
+
+        then:
+        2 == headlines.size()
+    }
+
+    @Timeout(1) // <4>
+    void "second invocation of November hits Cache"() {
+        when:
+        List<String> headlines = newsService.headlines(Month.NOVEMBER)
+
+        then:
+        2 == headlines.size()
+    }
+
+    @Timeout(4) // <4>
+    void "first invocation of October does not hit Cache"() {
+        when:
+        List<String> headlines = newsService.headlines(Month.OCTOBER)
+
+        then:
+        1 == headlines.size()
+    }
+
+    @Timeout(1) // <4>
+    void "second invocation of october hits cache"() {
+        when:
+        List<String> headlines = newsService.headlines(Month.OCTOBER)
+
+        then:
+        1 == headlines.size()
+    }
+
+    @Timeout(1) // <4>
+    void "adding a headline to november updates cache"() {
+        when:
+        List<String> headlines = newsService.addHeadline(Month.NOVEMBER, "Micronaut 1.3 Milestone 1 Released")
+
+        then:
+        3 == headlines.size()
+    }
+
+    @Timeout(1) // <4>
+    void "november cache was updated by cache put and thus the value is retrieved from the cache"() {
+        when:
+        List<String> headlines = newsService.headlines(Month.NOVEMBER)
+
+        then:
+        3 == headlines.size()
+    }
+
+    @Timeout(1) // <4>
+    void "invalidate november cache with cache invalidate"() {
+        when:
+        newsService.removeHeadline(Month.NOVEMBER, "Micronaut 1.3 Milestone 1 Released")
+
+        then:
+        noExceptionThrown()
+    }
+
+    @Timeout(1) // <4>
+    void "october cache is still valid"() {
+        when:
+        List<String> headlines = newsService.headlines(Month.OCTOBER)
+
+        then:
+        1 == headlines.size()
+    }
+
+    @Timeout(4) // <4>
+    void "november cache was invalidated"() {
+        when:
+        List<String> headlines = newsService.headlines(Month.NOVEMBER)
+
+        then:
+        2 == headlines.size()
+    }
+}

--- a/guides/micronaut-cache/java/src/main/java/example/micronaut/News.java
+++ b/guides/micronaut-cache/java/src/main/java/example/micronaut/News.java
@@ -1,0 +1,38 @@
+package example.micronaut;
+
+import io.micronaut.core.annotation.Introspected;
+
+import java.time.Month;
+import java.util.List;
+
+@Introspected
+public class News {
+    private Month month;
+
+    private List<String> headlines;
+
+    public News() {
+
+    }
+
+    public News(Month month, List<String> headlines) {
+        this.month = month;
+        this.headlines = headlines;
+    }
+
+    public Month getMonth() {
+        return month;
+    }
+
+    public void setMonth(Month month) {
+        this.month = month;
+    }
+
+    public List<String> getHeadlines() {
+        return headlines;
+    }
+
+    public void setHeadlines(List<String> headlines) {
+        this.headlines = headlines;
+    }
+}

--- a/guides/micronaut-cache/java/src/main/java/example/micronaut/NewsController.java
+++ b/guides/micronaut-cache/java/src/main/java/example/micronaut/NewsController.java
@@ -1,0 +1,21 @@
+package example.micronaut;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+import java.time.Month;
+
+@Controller
+public class NewsController {
+
+    private final NewsService newsService;
+
+    public NewsController(NewsService newsService) {
+        this.newsService = newsService;
+    }
+
+    @Get("/{month}")
+    public News index(Month month) {
+        return new News(month, newsService.headlines(month));
+    }
+}

--- a/guides/micronaut-cache/java/src/main/java/example/micronaut/NewsService.java
+++ b/guides/micronaut-cache/java/src/main/java/example/micronaut/NewsService.java
@@ -1,0 +1,58 @@
+package example.micronaut;
+
+import io.micronaut.cache.annotation.CacheConfig;
+import io.micronaut.cache.annotation.CacheInvalidate;
+import io.micronaut.cache.annotation.CachePut;
+import io.micronaut.cache.annotation.Cacheable;
+
+import javax.inject.Singleton;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Singleton // <1>
+@CacheConfig("headlines") // <2>
+public class NewsService {
+
+    Map<Month, List<String>> headlines = new HashMap<Month, List<String>>() {{
+        put(Month.NOVEMBER, Arrays.asList("Micronaut Graduates to Trial Level in Thoughtworks technology radar Vol.1",
+                "Micronaut AOP: Awesome flexibility without the complexity"));
+        put(Month.OCTOBER, Collections.singletonList("Micronaut AOP: Awesome flexibility without the complexity"));
+    }};
+
+    @Cacheable // <3>
+    public List<String> headlines(Month month) {
+        try {
+            TimeUnit.SECONDS.sleep(3); // <4>
+            return headlines.get(month);
+        } catch (InterruptedException e) {
+            return null;
+        }
+    }
+
+    @CachePut(parameters = {"month"}) // <5>
+    public List<String> addHeadline(Month month, String headline) {
+        if (headlines.containsKey(month)) {
+            List<String> l = new ArrayList<>(headlines.get(month));
+            l.add(headline);
+            headlines.put(month, l);
+        } else {
+            headlines.put(month, Arrays.asList(headline));
+        }
+        return headlines.get(month);
+    }
+
+    @CacheInvalidate(parameters = {"month"}) // <6>
+    public void removeHeadline(Month month, String headline) {
+        if (headlines.containsKey(month)) {
+            List<String> l = new ArrayList<>(headlines.get(month));
+            l.remove(headline);
+            headlines.put(month, l);
+        }
+    }
+}

--- a/guides/micronaut-cache/java/src/main/resources/application.yml
+++ b/guides/micronaut-cache/java/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+#tag::config[]
+micronaut:
+  caches:
+    headlines: # <1>
+      charset: 'UTF-8'
+#end::config[]

--- a/guides/micronaut-cache/java/src/test/java/example/micronaut/NewsControllerTest.java
+++ b/guides/micronaut-cache/java/src/test/java/example/micronaut/NewsControllerTest.java
@@ -1,0 +1,39 @@
+package example.micronaut;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.uri.UriBuilder;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import javax.inject.Inject;
+import java.time.Month;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+public class NewsControllerTest {
+
+    @Inject
+    EmbeddedServer server;
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Timeout(4) // <1>
+    @Test
+    void fetchingOctoberHeadlinesUsesCache() {
+        HttpRequest request = HttpRequest.GET(UriBuilder.of("/").path(Month.OCTOBER.toString()).build());
+        News news = client.toBlocking().retrieve(request, News.class);
+        String expected = "Micronaut AOP: Awesome flexibility without the complexity";
+        assertEquals(Arrays.asList(expected), news.getHeadlines());
+
+        news = client.toBlocking().retrieve(request, News.class);
+        assertEquals(Arrays.asList(expected), news.getHeadlines());
+    }
+}

--- a/guides/micronaut-cache/java/src/test/java/example/micronaut/NewsControllerTest.java
+++ b/guides/micronaut-cache/java/src/test/java/example/micronaut/NewsControllerTest.java
@@ -5,7 +5,7 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.uri.UriBuilder;
 import io.micronaut.runtime.server.EmbeddedServer;
-import io.micronaut.test.annotation.MicronautTest;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 

--- a/guides/micronaut-cache/java/src/test/java/example/micronaut/NewsServiceTest.java
+++ b/guides/micronaut-cache/java/src/test/java/example/micronaut/NewsServiceTest.java
@@ -1,0 +1,96 @@
+package example.micronaut;
+
+import io.micronaut.test.annotation.MicronautTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Timeout;
+
+import javax.inject.Inject;
+import java.time.Month;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class) // <1>
+@MicronautTest // <2>
+class NewsServiceTest {
+
+    @Inject // <3>
+    NewsService newsService;
+
+    @Timeout(4) // <4>
+    @Test
+    @Order(1) // <5>
+    public void firstInvocationOfNovemberDoesNotHitCache() {
+        List<String> headlines = newsService.headlines(Month.NOVEMBER);
+        assertEquals(2, headlines.size());
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(2) // <5>
+    public void secondInvocationOfNovemberHitsCache() {
+        List<String> headlines = newsService.headlines(Month.NOVEMBER);
+        assertEquals(2, headlines.size());
+    }
+
+    @Timeout(4) // <4>
+    @Test
+    @Order(3) // <5>
+    public void firstInvocationOfOctoberDoesNotHitCache() {
+        List<String> headlines = newsService.headlines(Month.OCTOBER);
+        assertEquals(1, headlines.size());
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(4) // <5>
+    public void secondInvocationOfOctoberHitsCache() {
+        List<String> headlines = newsService.headlines(Month.OCTOBER);
+        assertEquals(1, headlines.size());
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(5) // <5>
+    public void addingAHeadlineToNovemberUpdatesCache() {
+        List<String> headlines = newsService.addHeadline(Month.NOVEMBER, "Micronaut 1.3 Milestone 1 Released");
+        assertEquals(3, headlines.size());
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(6) // <5>
+    public void novemberCacheWasUpdatedByCachePutAndThusTheValueIsRetrievedFromTheCache() {
+        List<String> headlines = newsService.headlines(Month.NOVEMBER);
+        assertEquals(3, headlines.size());
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(7) // <5>
+    public void invalidateNovemberCacheWithCacheInvalidate() {
+        assertDoesNotThrow(() -> {
+            newsService.removeHeadline(Month.NOVEMBER, "Micronaut 1.3 Milestone 1 Released");
+        });
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(8) // <5>
+    public void octoberCacheIsStillValid() {
+        List<String> headlines = newsService.headlines(Month.OCTOBER);
+        assertEquals(1, headlines.size());
+    }
+
+    @Timeout(4) // <4>
+    @Test
+    @Order(9) // <5>
+    public void novemberCacheWasInvalidated() {
+        List<String> headlines = newsService.headlines(Month.NOVEMBER);
+        assertEquals(2, headlines.size());
+    }
+}

--- a/guides/micronaut-cache/java/src/test/java/example/micronaut/NewsServiceTest.java
+++ b/guides/micronaut-cache/java/src/test/java/example/micronaut/NewsServiceTest.java
@@ -1,6 +1,6 @@
 package example.micronaut;
 
-import io.micronaut.test.annotation.MicronautTest;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;

--- a/guides/micronaut-cache/kotlin/src/main/kotlin/example/micronaut/News.kt
+++ b/guides/micronaut-cache/kotlin/src/main/kotlin/example/micronaut/News.kt
@@ -1,0 +1,7 @@
+package example.micronaut
+
+import io.micronaut.core.annotation.Introspected
+import java.time.Month
+
+@Introspected
+data class News(val month: Month, val headlines: List<String>)

--- a/guides/micronaut-cache/kotlin/src/main/kotlin/example/micronaut/NewsController.kt
+++ b/guides/micronaut-cache/kotlin/src/main/kotlin/example/micronaut/NewsController.kt
@@ -1,0 +1,13 @@
+package example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import java.time.Month
+
+@Controller
+class NewsController(val newsService: NewsService) {
+    @Get("/{month}")
+    fun index(month: Month): News {
+        return News(month, newsService.headlines(month).orEmpty())
+    }
+}

--- a/guides/micronaut-cache/kotlin/src/main/kotlin/example/micronaut/NewsService.kt
+++ b/guides/micronaut-cache/kotlin/src/main/kotlin/example/micronaut/NewsService.kt
@@ -1,0 +1,43 @@
+package example.micronaut
+
+import io.micronaut.cache.annotation.CacheConfig
+import io.micronaut.cache.annotation.CacheInvalidate
+import io.micronaut.cache.annotation.CachePut
+import io.micronaut.cache.annotation.Cacheable
+import java.time.Month
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+@Singleton // <1>
+@CacheConfig("headlines") // <2>
+open class NewsService {
+    val headlines = mutableMapOf(
+            Month.NOVEMBER to listOf("Micronaut Graduates to Trial Level in Thoughtworks technology radar Vol.1",
+            "Micronaut AOP: Awesome flexibility without the complexity"),
+            Month.OCTOBER to listOf("Micronaut AOP: Awesome flexibility without the complexity"))
+
+    @Cacheable // <3>
+    open fun headlines(month: Month): List<String>? {
+        return try {
+            TimeUnit.SECONDS.sleep(3) // <4>
+            headlines[month]
+        } catch (e: InterruptedException) {
+            null
+        }
+    }
+
+    @CachePut(parameters = ["month"]) // <5>
+    open fun addHeadline(month: Month, headline: String): List<String>? {
+        val l = headlines.getOrDefault(month, emptyList()).toMutableList()
+        l.add(headline)
+        headlines[month] = l
+        return headlines[month]
+    }
+
+    @CacheInvalidate(parameters = ["month"]) // <6>
+    open fun removeHeadline(month: Month, headline: String?) {
+        val l = headlines.getOrDefault(month, emptyList()).toMutableList()
+        l.remove(headline)
+        headlines[month] = l
+    }
+}

--- a/guides/micronaut-cache/kotlin/src/main/resources/application.yml
+++ b/guides/micronaut-cache/kotlin/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+#tag::config[]
+micronaut:
+  caches:
+    headlines: # <1>
+      charset: 'UTF-8'
+#end::config[]

--- a/guides/micronaut-cache/kotlin/src/test/kotlin/example/micronaut/NewsControllerTest.kt
+++ b/guides/micronaut-cache/kotlin/src/test/kotlin/example/micronaut/NewsControllerTest.kt
@@ -1,0 +1,33 @@
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.time.Month
+import java.util.*
+import javax.inject.Inject
+
+@MicronautTest
+class NewsControllerTest {
+
+    @Inject
+    @field:Client("/")
+    lateinit var client: HttpClient
+
+    @Timeout(5) // <1>
+    @Test
+    fun fetchingOctoberHeadlinesUsesCache() {
+        val request: HttpRequest<Any> = HttpRequest.GET(UriBuilder.of("/").path(Month.OCTOBER.toString()).build())
+        var news: News = client.toBlocking().retrieve(request, News::class.java)
+        val expected = "Micronaut AOP: Awesome flexibility without the complexity"
+        Assertions.assertEquals(listOf(expected), news.headlines)
+        news = client.toBlocking().retrieve(request, News::class.java)
+        Assertions.assertEquals(listOf(expected), news.headlines)
+    }
+}

--- a/guides/micronaut-cache/kotlin/src/test/kotlin/example/micronaut/NewsControllerTest.kt
+++ b/guides/micronaut-cache/kotlin/src/test/kotlin/example/micronaut/NewsControllerTest.kt
@@ -5,7 +5,7 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.uri.UriBuilder
 import io.micronaut.runtime.server.EmbeddedServer
-import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout

--- a/guides/micronaut-cache/kotlin/src/test/kotlin/example/micronaut/NewsServiceTest.kt
+++ b/guides/micronaut-cache/kotlin/src/test/kotlin/example/micronaut/NewsServiceTest.kt
@@ -1,0 +1,85 @@
+package example.micronaut
+
+import io.micronaut.test.annotation.MicronautTest
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
+import java.time.Month
+import javax.inject.Inject
+
+@TestMethodOrder(OrderAnnotation::class) // <1>
+@MicronautTest // <2>
+internal class NewsServiceTest {
+    @Inject
+    lateinit var newsService : NewsService // <3>
+
+    @Timeout(4) // <4>
+    @Test
+    @Order(1) // <5>
+    fun firstInvocationOfNovemberDoesNotHitCache() {
+        val headlines = newsService.headlines(Month.NOVEMBER)
+        Assertions.assertEquals(2, headlines!!.size)
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(2) // <5>
+    fun secondInvocationOfNovemberHitsCache() {
+        val headlines = newsService.headlines(Month.NOVEMBER)
+        Assertions.assertEquals(2, headlines!!.size)
+    }
+
+    @Timeout(4) // <4>
+    @Test
+    @Order(3) // <5>
+    fun firstInvocationOfOctoberDoesNotHitCache() {
+        val headlines = newsService.headlines(Month.OCTOBER)
+        Assertions.assertEquals(1, headlines!!.size)
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(4) // <5>
+    fun secondInvocationOfOctoberHitsCache() {
+        val headlines = newsService.headlines(Month.OCTOBER)
+        Assertions.assertEquals(1, headlines!!.size)
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(5) // <5>
+    fun addingAHeadlineToNovemberUpdatesCache() {
+        val headlines = newsService.addHeadline(Month.NOVEMBER, "Micronaut 1.3 Milestone 1 Released")
+        Assertions.assertEquals(3, headlines!!.size)
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(6) // <5>
+    fun novemberCacheWasUpdatedByCachePutAndThusTheValueIsRetrievedFromTheCache() {
+        val headlines = newsService.headlines(Month.NOVEMBER)
+        Assertions.assertEquals(3, headlines!!.size)
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(7) // <5>
+    fun invalidateNovemberCacheWithCacheInvalidate() {
+        Assertions.assertDoesNotThrow { newsService.removeHeadline(Month.NOVEMBER, "Micronaut 1.3 Milestone 1 Released") }
+    }
+
+    @Timeout(1) // <4>
+    @Test
+    @Order(8) // <5>
+    fun octoberCacheIsStillValid() {
+        val headlines = newsService.headlines(Month.OCTOBER)
+        Assertions.assertEquals(1, headlines!!.size)
+    }
+
+    @Timeout(4) // <4>
+    @Test
+    @Order(9) // <5>
+    fun novemberCacheWasInvalidated() {
+        val headlines = newsService.headlines(Month.NOVEMBER)
+        Assertions.assertEquals(2, headlines!!.size)
+    }
+}

--- a/guides/micronaut-cache/kotlin/src/test/kotlin/example/micronaut/NewsServiceTest.kt
+++ b/guides/micronaut-cache/kotlin/src/test/kotlin/example/micronaut/NewsServiceTest.kt
@@ -1,6 +1,6 @@
 package example.micronaut
 
-import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
 import java.time.Month

--- a/guides/micronaut-cache/metadata.json
+++ b/guides/micronaut-cache/metadata.json
@@ -1,0 +1,13 @@
+{
+  "asciidoctor": "micronaut-cache.adoc",
+  "slug": "micronaut-cache",
+  "title": "Micronaut Cache",
+  "intro": "Learn how to use Micronaut's caching annotations",
+  "authors": ["Sergio del Amo"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["graalvm","cache-caffeine"]
+    }
+  ]
+}

--- a/guides/micronaut-cache/micronaut-cache.adoc
+++ b/guides/micronaut-cache/micronaut-cache.adoc
@@ -6,7 +6,10 @@ Authors: @authors@
 
 Micronaut Version: @micronaut@
 
-include::{commondir}/common-gettingStarted.adoc[]
+== Getting Started
+
+In this guide, you are going to use Micronaut’s caching annotations to speed up your application.
+
 
 include::{commondir}/common-requirements.adoc[]
 
@@ -16,7 +19,7 @@ include::{commondir}/common-create-app.adoc[]
 
 === Configure the Application
 
-In this sample application, we cache news headlines. Add https://micronaut-projects.github.io/micronaut-cache/latest/guide/index.html[Micronaut Caffeine Cache] dependency which
+In this sample application, we cache news headlines. Add https://micronaut-projects.github.io/micronaut-cache/latest/guide/index.html[Micronaut Caffeine Cache] dependency
 which adds support for cache using https://github.com/ben-manes/caffeine[Caffeine].
 
 dependency:micronaut-cache-caffeine[groupId=io.micronaut.cache]
@@ -55,8 +58,12 @@ test:NewsServiceTest[]
 <2> Annotation used to define a Micronaut test
 <3> Inject `NewsService` bean.
 <4> Timeout annotation fails a test if its execution exceeds a given duration. It helps us verify that we are leaveraging the cache.
+
+:exclude-for-languages:groovy
+
 <5> Used to configure the order in which the test method should executed relative to other tests in the class.
 
+:exclude-for-languages:
 
 === Controller
 
@@ -73,11 +80,6 @@ test:NewsControllerTest[]
 <1> We call the endpoint twice and verify with the `@Timeout` annotation that the cache is being used.
 
 
-----------------------
--------------------
-----------------------
-
-
 include::{commondir}/common-runapp.adoc[]
 
 include::{commondir}/common-graal-with-plugins.adoc[]
@@ -90,6 +92,7 @@ You should be able to execute `curl localhost:8080/NOVEMBER` and see results
 
 == Next steps
 
-Read about Micronaut's https://docs.micronaut.io/1.3.0.M1/guide/index.html#caching[Cache Advise]. Moreover, check the https://micronaut-projects.github.io/micronaut-cache/latest/guide/index.html[Micronaut Cache] project for more information.
+Read about Micronaut's https://docs.micronaut.io/latest/guide/index.html#caching[Cache Advise].
+Moreover, check the https://micronaut-projects.github.io/micronaut-cache/latest/guide/index.html[Micronaut Cache] project for more information.
 
 include::{commondir}/common-helpWithMicronaut.adoc[]

--- a/guides/micronaut-cache/micronaut-cache.adoc
+++ b/guides/micronaut-cache/micronaut-cache.adoc
@@ -1,0 +1,95 @@
+= @guideTitle@
+
+@guideIntro@
+
+Authors: @authors@
+
+Micronaut Version: @micronaut@
+
+include::{commondir}/common-gettingStarted.adoc[]
+
+include::{commondir}/common-requirements.adoc[]
+
+include::{commondir}/common-completesolution.adoc[]
+
+include::{commondir}/common-create-app.adoc[]
+
+=== Configure the Application
+
+In this sample application, we cache news headlines. Add https://micronaut-projects.github.io/micronaut-cache/latest/guide/index.html[Micronaut Caffeine Cache] dependency which
+which adds support for cache using https://github.com/ben-manes/caffeine[Caffeine].
+
+dependency:micronaut-cache-caffeine[groupId=io.micronaut.cache]
+
+Configure your caches in `application.yml`:
+
+resource:application.yml[tag=config]
+
+<1> Configure a cache called `headlines`.
+
+TIP: Check the https://micronaut-projects.github.io/micronaut-cache/snapshot/guide/configurationreference.html#io.micronaut.cache.caffeine.DefaultCacheConfiguration[properties (`maximum-size`, `expire-after-write` and `expire-after-access`)] to configure the size and expiration of your caches. It is important to keep the caches' size under control.
+
+=== Micronaut Cache Api
+
+Imagine a service which retrieves headlines for a given month. This operation may be expensive and you may want to cache it.
+
+source:NewsService[]
+
+
+<1> To register a Singleton in Micronaut’s application context annotate your class with `javax.inject.Singleton`.
+<2> Specifies the cache name `headlines` to store cache operation values in.
+<3> Indicates a method is cacheable. The cache name `headlines` specified in `@CacheConfig` is used. Since the method has only one parameter, you don't need to specify the `month` parameters attribute of the the annation.
+<4> Emulate an expensive operation by sleeping for several seconds.
+<5> The return value is cached with name `headlines` for the supplied `month`. The method invocation is never skipped even if the cache `headlines` for the supplied `month` already existed.
+<6> Method invocation causes the invalidation of the cache `headlines` for the supplied `month`.
+
+TIP: If you don't annotate the class with `@CacheConfig`, specify the cache name in the cache annotations. E.g. `@Cacheable(value = "headlines", parameters = {"month"})`
+
+=== Test the Cache
+
+We can verify that the cache works as expected:
+
+test:NewsServiceTest[]
+
+<1> Used to configure the test method execution order for the annotated test class.
+<2> Annotation used to define a Micronaut test
+<3> Inject `NewsService` bean.
+<4> Timeout annotation fails a test if its execution exceeds a given duration. It helps us verify that we are leaveraging the cache.
+<5> Used to configure the order in which the test method should executed relative to other tests in the class.
+
+
+=== Controller
+
+Create a controller which engages the previous service:
+
+source:News[]
+
+source:NewsController[]
+
+Add a test:
+
+test:NewsControllerTest[]
+
+<1> We call the endpoint twice and verify with the `@Timeout` annotation that the cache is being used.
+
+
+----------------------
+-------------------
+----------------------
+
+
+include::{commondir}/common-runapp.adoc[]
+
+include::{commondir}/common-graal-with-plugins.adoc[]
+
+:exclude-for-languages:groovy
+
+You should be able to execute `curl localhost:8080/NOVEMBER` and see results
+
+:exclude-for-languages:
+
+== Next steps
+
+Read about Micronaut's https://docs.micronaut.io/1.3.0.M1/guide/index.html#caching[Cache Advise]. Moreover, check the https://micronaut-projects.github.io/micronaut-cache/latest/guide/index.html[Micronaut Cache] project for more information.
+
+include::{commondir}/common-helpWithMicronaut.adoc[]


### PR DESCRIPTION
closes https://github.com/micronaut-projects/micronaut-guides-poc/issues/19

Note: I ran into two unexpected things after working through the steps @sdelamo detailed

1. I was unable to successfully follow the steps for `graalvm` on my machine, getting a build error for `./gradlew nativeImage` that `/usr/bin/ld: cannot find -lstdc++`. Tried updating my system deps and `apt install`-ing `libstdc++` but couldn't resolve. 
2. The Kotlin generated project did not pass `test.sh` at first; I had to mark all of `NewsService.kt`'s methods and class as `open`. I didn't see this being required in, for example, the `micronaut-configuration` kotlin guide and fear perhaps I am missing some metadata file. Otherwise perhaps there is an issue to file w/ either `micronaut-cache-caffeine` or the guide builder poc here.

Otherwise I was able to get all the adoc converted, the outputted guides for all the variations look good locally, and test.sh passes. Let me know if you see anything off or ways to improve!