### PR TITLE
Fix annotationProcessor scopes for Kotlin/Groovy

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -45,7 +45,7 @@ class GuideAsciidocGenerator {
                     groupDependencies = !groupDependencies
                     if (!groupDependencies) {
                         // closing tag. Group and output them all together
-                        lines.addAll(DependencyLines.asciidoc(groupedDependencies, guidesOption.buildTool))
+                        lines.addAll(DependencyLines.asciidoc(groupedDependencies, guidesOption.buildTool, guidesOption.language))
                         groupedDependencies = []
                     }
 
@@ -53,7 +53,7 @@ class GuideAsciidocGenerator {
                     if (groupDependencies) {
                         groupedDependencies.add(line)
                     } else {
-                        lines.addAll(DependencyLines.asciidoc(line, guidesOption.buildTool))
+                        lines.addAll(DependencyLines.asciidoc(line, guidesOption.buildTool, guidesOption.language))
                     }
 
                 } else if (line == ':exclude-for-build:') {


### PR DESCRIPTION
This PR generates the right dependencies for Kotlin and Groovy when defining an `annotationProcessor` dependency. For example, for Kotlin-Gradle it needs to be `kapt` instead of `annotationProcessor`.