### PR TITLE
Add Geb feature and use it in error-handling guide

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/GebFeature.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/GebFeature.java
@@ -1,0 +1,35 @@
+package io.micronaut.guides.feature;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.options.TestFramework;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class GebFeature implements Feature {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "geb";
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        if (generatorContext.getTestFramework().equals(TestFramework.JUNIT)) {
+            generatorContext.addDependency(Dependency.builder().groupId("org.gebish").lookupArtifactId("geb-junit").test());
+        } else if (generatorContext.getTestFramework().equals(TestFramework.SPOCK)) {
+            generatorContext.addDependency(Dependency.builder().groupId("org.gebish").lookupArtifactId("geb-spock").test());
+        }
+        generatorContext.addDependency(Dependency.builder().groupId("org.seleniumhq.selenium").lookupArtifactId("htmlunit-driver").test());
+    }
+}

--- a/buildSrc/src/main/resources/pom.xml
+++ b/buildSrc/src/main/resources/pom.xml
@@ -12,11 +12,14 @@
         </repository>
     </repositories>
     <dependencies>
+        <!-- MyBatis -->
         <dependency>
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis</artifactId>
             <version>3.5.6</version>
         </dependency>
+
+        <!-- Geb -->
         <dependency>
             <groupId>org.gebish</groupId>
             <artifactId>geb-junit5</artifactId>
@@ -34,8 +37,8 @@
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-support</artifactId>
-            <version>3.141.59</version>
+            <artifactId>htmlunit-driver</artifactId>
+            <version>2.47.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/guides/micronaut-error-handling/metadata.json
+++ b/guides/micronaut-error-handling/metadata.json
@@ -4,14 +4,12 @@
   "title": "Error Handling",
   "intro": "Learn about Error handling in Micronaut.",
   "authors": ["Sergio del Amo"],
-  "skipGradleTests": true,
-  "skipMavenTests": true,
   "languages": ["java"],
   "testFramework": "spock",
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "views-velocity"]
+      "features": ["graalvm", "views-velocity", "geb"]
     }
   ]
 }


### PR DESCRIPTION
This PR:
- Adds the `Geb` feature needed for testing some guides
- Enable the tests in "Error Handling" guide

Leaving it as draft now because it uses `2.4.0-SNAPSHOT` version of Micronaut. Once we release the version I'll update the PR.