### PR TITLE
New macro for tests without logic to detect language/file extension

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -7,11 +7,6 @@ import io.micronaut.starter.api.TestFramework
 import java.nio.file.Path
 import java.nio.file.Paths
 
-import static io.micronaut.starter.api.TestFramework.JUNIT
-import static io.micronaut.starter.api.TestFramework.KOTEST
-import static io.micronaut.starter.api.TestFramework.KOTLINTEST
-import static io.micronaut.starter.api.TestFramework.SPOCK
-
 @CompileStatic
 class GuideAsciidocGenerator {
 
@@ -99,7 +94,7 @@ class GuideAsciidocGenerator {
             text = text.replace("@testFramework@", guidesOption.testFramework.toString())
             text = text.replace("@authors@", metadata.authors.join(', '))
             text = text.replace("@languageextension@", guidesOption.language.extension)
-            text = text.replace("@testsuffix@", guidesOption.testFramework == SPOCK ? 'Spec' : 'Test')
+            text = text.replace("@testsuffix@", guidesOption.testFramework == TestFramework.SPOCK ? 'Spec' : 'Test')
 
             text = text.replace("@sourceDir@", projectName)
 
@@ -164,7 +159,7 @@ class GuideAsciidocGenerator {
         if (testFramework) {
             if (name.endsWith('Test')) {
                 fileName = name.substring(0, name.indexOf('Test'))
-                fileName += testFramework == SPOCK ? 'Spec' : 'Test'
+                fileName += testFramework == TestFramework.SPOCK ? 'Spec' : 'Test'
             }
         }
         String folder = testFramework ? 'test' : 'main'
@@ -196,20 +191,20 @@ class GuideAsciidocGenerator {
         String module = appName ? "${appName}/" : ""
         List<String> tags = tagNames ? tagNames.collect { "tag=${it}".toString() } : []
 
-        String fileExtension = resolveTestExtension(testFramework)
-        String langFolder = resolveLangFolder(testFramework)
+        String fileExtension = testFramework.toTestFramework().defaultLanguage.getExtension()
+        String langTestFolder = testFramework.toTestFramework().defaultLanguage.getTestSrcDir()
 
         List<String> lines = [
-            "[source,${langFolder}]".toString(),
-            ".${module}src/test/${langFolder}/example/micronaut/${fileName}.${fileExtension}".toString(),
+            "[source,${fileExtension}]".toString(),
+            ".${module}${langTestFolder}/example/micronaut/${fileName}.${fileExtension}".toString(),
             '----',
         ]
         if (tags) {
             for (String tag : tags) {
-                lines.add("include::{sourceDir}/@sourceDir@/${module}src/test/${langFolder}/example/micronaut/${fileName}.${fileExtension}[${tag}]\n".toString())
+                lines.add("include::{sourceDir}/@sourceDir@/${module}${langTestFolder}/example/micronaut/${fileName}.${fileExtension}[${tag}]\n".toString())
             }
         } else {
-            lines.add("include::{sourceDir}/@sourceDir@/${module}src/test/${langFolder}/example/micronaut/${fileName}.${fileExtension}[]".toString())
+            lines.add("include::{sourceDir}/@sourceDir@/${module}${langTestFolder}/example/micronaut/${fileName}.${fileExtension}[]".toString())
         }
 
         lines.add('----')
@@ -219,7 +214,7 @@ class GuideAsciidocGenerator {
     private static List<String> resourceIncludeLines(String line, String resourceDir, String macro) {
         String fileName = extractName(line, macro)
         String appName = extractAppName(line)
-        List<String> tagNames =  extractTags(line)
+        List<String> tagNames = extractTags(line)
 
         String module = appName ? "${appName}/" : ""
         List<String> tags = tagNames ? tagNames.collect { "tag=${it}".toString() } : []
@@ -286,34 +281,6 @@ class GuideAsciidocGenerator {
                 return 'xml'
             default:
                 return ''
-        }
-    }
-
-    private static String resolveTestExtension(TestFramework testFramework) {
-        switch (testFramework) {
-            case JUNIT:
-                return 'java'
-            case SPOCK:
-                return 'groovy'
-            case KOTEST:
-            case KOTLINTEST:
-                return 'kt'
-            default:
-                return '@languageextension@'
-        }
-    }
-
-    private static String resolveLangFolder(TestFramework testFramework) {
-        switch (testFramework) {
-            case JUNIT:
-                return 'java'
-            case SPOCK:
-                return 'groovy'
-            case KOTEST:
-            case KOTLINTEST:
-                return 'kotlin'
-            default:
-                return '@lang@'
         }
     }
 }


### PR DESCRIPTION
For some guides like Security Cookie we use Geb for tests and we also include snippets of those tests in the guide. 
The problem with our current approach is that we include a test file with `test:HomeTest[]` and depending on the language and the test framework we look for the right file in `src/test/{java,groovy,kotlin}` directories, with the right file extension, and even for Spock, we look for `HomeSpec.groovy` instead of `HomeTest.groovy`. This makes really easy to write multi-language guides.

But now, we use Geb for testing the three languages (so all the test code is Groovy), so our previous macro doesn't work anymore. There isn't an easy way to know that when doing `test:HomePage[]` we really want to include the file `src/test/groovy/.../HomePage.groovy` independently of the language of the guide.

I've created a new macro `rawTest:` that just includes the file without guessing anything and only based on the test framework. Even though the code seems similar to what we already have I've decided to create a new method to avoid adding more `if` in the other one (and to break things). 
If we want we can refactor in the future.
 