### PR TITLE
Add Email guide (Java and Groovy)

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/Sendgrid.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/Sendgrid.java
@@ -1,0 +1,29 @@
+package io.micronaut.guides.feature;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.Feature;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class Sendgrid implements Feature {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "sendgrid";
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.addDependency(Dependency.builder().groupId("com.sendgrid").lookupArtifactId("sendgrid-java").compile().build());
+    }
+}

--- a/buildSrc/src/main/java/io/micronaut/guides/feature/Ses.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/Ses.java
@@ -1,0 +1,29 @@
+package io.micronaut.guides.feature;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.Feature;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class Ses implements Feature {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "ses";
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.addDependency(Dependency.builder().groupId("software.amazon.awssdk").lookupArtifactId("ses").compile().build());
+    }
+}

--- a/buildSrc/src/main/resources/pom.xml
+++ b/buildSrc/src/main/resources/pom.xml
@@ -40,5 +40,19 @@
             <artifactId>htmlunit-driver</artifactId>
             <version>2.47.1</version>
         </dependency>
+
+        <!-- Ses -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ses</artifactId>
+            <version>2.16.18</version>
+        </dependency>
+
+        <!-- Sendgrid -->
+        <dependency>
+            <groupId>com.sendgrid</groupId>
+            <artifactId>sendgrid-java</artifactId>
+            <version>4.7.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/Application.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/Application.groovy
@@ -1,0 +1,12 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic;
+import io.micronaut.runtime.Micronaut;
+
+@CompileStatic
+class Application {
+
+    static void main(String[] args) {
+        Micronaut.run(Application.class);
+    }
+}

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/AwsResourceAccessCondition.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/AwsResourceAccessCondition.groovy
@@ -1,0 +1,32 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.condition.Condition
+import io.micronaut.context.condition.ConditionContext
+import io.micronaut.context.env.Environment
+import io.micronaut.core.util.StringUtils
+
+/**
+ * @see <a href="https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-roles.html">Configure IAM Roles for Amazon EC2</a>
+ */
+@CompileStatic
+class AwsResourceAccessCondition implements Condition {
+
+    @Override
+    boolean matches(ConditionContext context) {
+
+        if (StringUtils.isNotEmpty(System.getProperty("aws.accessKeyId")) &&  StringUtils.isNotEmpty(System.getProperty("aws.secretAccessKey"))) { // <1>
+            return true
+        }
+
+        if (StringUtils.isNotEmpty(System.getenv("AWS_ACCESS_KEY_ID")) &&  StringUtils.isNotEmpty(System.getenv("AWS_SECRET_ACCESS_KEY"))) { // <2>
+            return true
+        }
+
+        if (StringUtils.isNotEmpty(System.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"))) { // <3>
+            return true
+        }
+
+        context != null && context.getBean(Environment.class).getActiveNames().contains(Environment.AMAZON_EC2) // <4>
+    }
+}

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/AwsSesMailService.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/AwsSesMailService.groovy
@@ -1,0 +1,55 @@
+package example.micronaut
+
+import edu.umd.cs.findbugs.annotations.NonNull
+import edu.umd.cs.findbugs.annotations.Nullable
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Secondary
+import io.micronaut.context.annotation.Value
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ses.SesClient
+import software.amazon.awssdk.services.ses.model.Body
+import software.amazon.awssdk.services.ses.model.Content
+import software.amazon.awssdk.services.ses.model.Destination
+import software.amazon.awssdk.services.ses.model.Message
+import software.amazon.awssdk.services.ses.model.SendEmailRequest
+import software.amazon.awssdk.services.ses.model.SendEmailResponse
+
+import javax.inject.Singleton
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+@CompileStatic
+@Singleton // <1>
+@Requires(condition = AwsResourceAccessCondition.class)  // <2>
+@Secondary // <3>
+public class AwsSesMailService implements EmailService {
+    private static final Logger LOG = LoggerFactory.getLogger(AwsSesMailService.class)
+    protected final String sourceEmail
+    protected final SesClient ses
+
+    public AwsSesMailService(@Nullable @Value('${AWS_REGION}') String awsRegionEnv, // <4>
+                             @Nullable @Value('${AWS_SOURCE_EMAIL}') String sourceEmailEnv,
+                             @Nullable @Value('${aws.region}') String awsRegionProp,
+                             @Nullable @Value('${aws.sourceemail}') String sourceEmailProp) {
+
+        this.sourceEmail = sourceEmailEnv != null ? sourceEmailEnv : sourceEmailProp
+        String awsRegion = awsRegionEnv != null ? awsRegionEnv : awsRegionProp
+        this.ses = SesClient.builder().region(Region.of(awsRegion)).build()
+    }
+
+    @Override
+    void send(@NonNull @NotNull @Valid Email email) {
+        SendEmailRequest sendEmailRequest = SendEmailRequest.builder()
+                .destination(Destination.builder().toAddresses(email.recipient).build())
+                .source(sourceEmail)
+                .message(Message.builder().subject(Content.builder().data(email.subject).build())
+                        .body(Body.builder().text(Content.builder().data(email.textBody).build()).build()).build()).build() as SendEmailRequest
+        SendEmailResponse response =ses.sendEmail(sendEmailRequest)
+        if (LOG.isInfoEnabled()) {
+            LOG.info("Sent email with id: {}", response.messageId())
+        }
+    }
+}

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/Email.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/Email.groovy
@@ -1,0 +1,11 @@
+package example.micronaut;
+
+interface Email {
+    String getRecipient()
+    List<String> getCc()
+    List<String> getBcc()
+    String getSubject()
+    String getHtmlBody()
+    String getTextBody()
+    String getReplyTo()
+}

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/EmailCmd.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/EmailCmd.groovy
@@ -1,0 +1,39 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic;
+import io.micronaut.core.annotation.Introspected;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull
+
+//tag::clazzwithannotations[]
+@EmailConstraints
+//end::clazzwithannotations[]
+//tag::clazz[]
+@Introspected
+@CompileStatic
+class EmailCmd implements Email {
+//end::clazz[]
+
+    //tag::properties[]
+    @NotNull
+    @NotBlank
+    String recipient
+
+    @NotNull
+    @NotBlank
+    String subject
+
+    List<String> cc = []
+    List<String> bcc = []
+
+    String htmlBody
+    String textBody
+    String replyTo
+    //end::properties[]
+}
+
+//tag::settersandgetters[]
+//end::settersandgetters[]
+//tag::close[]
+//end::close[]

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/EmailConstraints.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/EmailConstraints.groovy
@@ -1,0 +1,21 @@
+package example.micronaut
+
+import javax.validation.Constraint
+import javax.validation.Payload
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Constraint(validatedBy = [])
+@Target(value = [ElementType.TYPE])
+@Retention(RetentionPolicy.RUNTIME)
+@interface EmailConstraints {
+
+    String message() default "{email.invalid}"
+
+    Class<?>[] groups() default []
+
+    Class<? extends Payload>[] payload() default []
+
+}

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/EmailConstraintsFactory.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/EmailConstraintsFactory.groovy
@@ -1,0 +1,29 @@
+package example.micronaut
+
+import edu.umd.cs.findbugs.annotations.NonNull
+import edu.umd.cs.findbugs.annotations.Nullable
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.Factory
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.util.StringUtils
+import io.micronaut.validation.validator.constraints.ConstraintValidator
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext
+
+import javax.inject.Singleton
+
+@Factory
+@CompileStatic
+class EmailConstraintsFactory {
+
+    @Singleton
+    ConstraintValidator<EmailConstraints, EmailCmd> emailBodyValidator() {
+        return new ConstraintValidator<EmailConstraints, EmailCmd>() {
+            @Override
+            boolean isValid(@Nullable EmailCmd value,
+                            @NonNull AnnotationValue<EmailConstraints> annotationMetadata,
+                            @NonNull ConstraintValidatorContext context) {
+                StringUtils.isNotEmpty(value?.textBody) || StringUtils.isNotEmpty(value?.htmlBody)
+            }
+        }
+    }
+}

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/EmailService.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/EmailService.groovy
@@ -1,0 +1,10 @@
+package example.micronaut
+
+import edu.umd.cs.findbugs.annotations.NonNull
+
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+interface EmailService {
+    void send(@NonNull @NotNull @Valid Email email)
+}

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/MailController.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/MailController.groovy
@@ -1,0 +1,26 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+
+import javax.validation.Valid
+
+@CompileStatic
+@Controller("/mail") // <1>
+class MailController {
+
+    private final EmailService emailService
+
+    MailController(EmailService emailService) { // <2>
+        this.emailService = emailService
+    }
+
+    @Post("/send") // <3>
+    HttpResponse<?> send(@Body @Valid EmailCmd cmd) { // <4>
+        emailService.send(cmd)
+        HttpResponse.ok()  // <5>
+    }
+}

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/SendGridEmailCondition.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/SendGridEmailCondition.groovy
@@ -1,0 +1,19 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.core.util.StringUtils;
+
+@CompileStatic
+class SendGridEmailCondition implements Condition {
+    @Override
+    boolean matches(ConditionContext context) {
+        return envOrSystemProperty("SENDGRID_APIKEY", "sendgrid.apikey") &&
+                envOrSystemProperty("SENDGRID_FROM_EMAIL", "sendgrid.fromemail");
+    }
+
+    private static boolean envOrSystemProperty(String env, String prop) {
+        return StringUtils.isNotEmpty(System.getProperty(prop)) || StringUtils.isNotEmpty(System.getenv(env));
+    }
+}

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/SendGridEmailService.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/SendGridEmailService.groovy
@@ -1,0 +1,107 @@
+package example.micronaut
+
+import com.sendgrid.SendGrid
+import com.sendgrid.Request
+import com.sendgrid.Response
+import com.sendgrid.Method
+import com.sendgrid.helpers.mail.Mail
+import com.sendgrid.helpers.mail.objects.Content
+import com.sendgrid.helpers.mail.objects.Personalization
+import edu.umd.cs.findbugs.annotations.NonNull
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import javax.inject.Singleton
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+@CompileStatic
+@Singleton // <1>
+@Requires(condition = SendGridEmailCondition.class) // <2>
+class SendGridEmailService implements EmailService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SendGridEmailService.class)
+
+    protected final String apiKey
+
+    protected final String fromEmail
+
+    SendGridEmailService(@Value('${SENDGRID_APIKEY:none}') String apiKeyEnv, // <3>
+                         @Value('${SENDGRID_FROM_EMAIL:none}') String fromEmailEnv,
+                         @Value('${sendgrid.apikey:none}') String apiKeyProp,
+                         @Value('${sendgrid.fromemail:none}') String fromEmailProp) {
+        this.apiKey = apiKeyEnv != null && !apiKeyEnv.equals("none") ? apiKeyEnv : apiKeyProp
+        this.fromEmail = fromEmailEnv != null && !fromEmailEnv.equals("none")  ? fromEmailEnv: fromEmailProp
+    }
+
+    protected static Content contentOfEmail(Email email) {
+        if ( email.textBody !=null ) {
+            return new Content("text/plain", email.textBody)
+        }
+        if ( email.htmlBody !=null ) {
+            return new Content("text/html", email.htmlBody)
+        }
+        return null
+    }
+
+    @Override
+    public void send(@NonNull @NotNull @Valid Email email) {
+
+        Personalization personalization = new Personalization()
+        personalization.setSubject(email.subject)
+
+        com.sendgrid.helpers.mail.objects.Email to = new com.sendgrid.helpers.mail.objects.Email(email.recipient)
+        personalization.addTo(to)
+
+        if ( email.cc != null ) {
+            for ( String cc : email.cc ) {
+                com.sendgrid.helpers.mail.objects.Email ccEmail = new com.sendgrid.helpers.mail.objects.Email()
+                ccEmail.setEmail(cc)
+                personalization.addCc(ccEmail)
+            }
+        }
+
+        if ( email.bcc  != null ) {
+            for ( String bcc : email.bcc ) {
+                com.sendgrid.helpers.mail.objects.Email bccEmail = new com.sendgrid.helpers.mail.objects.Email()
+                bccEmail.setEmail(bcc)
+                personalization.addBcc(bccEmail)
+            }
+        }
+
+        Mail mail = new Mail()
+        com.sendgrid.helpers.mail.objects.Email from = new com.sendgrid.helpers.mail.objects.Email()
+        from.setEmail(fromEmail)
+        mail.from = from
+        mail.addPersonalization(personalization)
+        Content content = contentOfEmail(email)
+        mail.addContent(content)
+
+        SendGrid sg = new SendGrid(apiKey)
+        Request request = new Request()
+        try {
+            request.setMethod(Method.POST)
+            request.setEndpoint("mail/send")
+            request.setBody(mail.build())
+
+            Response response = sg.api(request)
+            if (LOG.isInfoEnabled()) {
+                LOG.info("Status Code: {}", String.valueOf(response.getStatusCode()))
+                LOG.info("Body: {}", response.getBody())
+                for ( String k : response.getHeaders().keySet()) {
+                    String v = response.getHeaders().get(k)
+                    LOG.info("Response Header {} => {}", k, v)
+                }
+            }
+
+
+        } catch (IOException ex) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error(ex.getMessage())
+            }
+        }
+    }
+}

--- a/guides/micronaut-email/groovy/src/main/resources/logback.xml
+++ b/guides/micronaut-email/groovy/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <!-- tag::logger[] -->
+<logger name="example.micronaut" level="TRACE"/>
+    <!-- end::logger[] -->
+</configuration>

--- a/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/AwsResourceAccessConditionSpec.groovy
+++ b/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/AwsResourceAccessConditionSpec.groovy
@@ -1,0 +1,26 @@
+package example.micronaut;
+
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class AwsResourceAccessConditionSpec extends Specification {
+
+    @RestoreSystemProperties
+    void "condition is true if system properties are present"() {
+        when:
+        System.setProperty("aws.accessKeyId", "XXXX")
+        System.setProperty("aws.secretAccessKey", "YYYY")
+        AwsResourceAccessCondition condition = new AwsResourceAccessCondition()
+
+        then:
+        condition.matches(null)
+    }
+
+    void "condition is false if System Properties are not present"() {
+        given:
+        AwsResourceAccessCondition condition = new AwsResourceAccessCondition();
+
+        expect:
+        !condition.matches(null)
+    }
+}

--- a/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/AwsSesMailServiceSpec.groovy
+++ b/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/AwsSesMailServiceSpec.groovy
@@ -1,0 +1,38 @@
+package example.micronaut;
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class AwsSesMailServiceSpec extends Specification {
+
+    void "aws ses mail service is not loaded if system property is not present"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+
+        expect:
+        !ctx.containsBean(AwsSesMailService.class)
+
+        cleanup:
+        ctx.close();
+    }
+
+    @RestoreSystemProperties
+    void "aws ses mail service is loaded if system properties are present"() {
+        given:
+        System.setProperty("aws.accessKeyId", "XXXX")
+        System.setProperty("aws.secretAccessKey", "YKYY")
+        System.setProperty("aws.region", "XXXX")
+        System.setProperty("aws.sourceemail", "me@micronaut.example")
+        ApplicationContext ctx = ApplicationContext.run()
+
+        when:
+        AwsSesMailService bean = ctx.getBean(AwsSesMailService.class)
+
+        then:
+        "me@micronaut.example" == bean.sourceEmail
+
+        cleanup:
+        ctx.close()
+    }
+}

--- a/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/MailControllerSpec.groovy
+++ b/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/MailControllerSpec.groovy
@@ -1,0 +1,49 @@
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+@MicronautTest // <1>
+@Property(name = "spec.name", value = "mailcontroller") // <2>
+class MailControllerSpec extends Specification {
+
+    @Inject
+    ApplicationContext applicationContext // <3>
+
+    @Inject
+    @Client("/")
+    RxHttpClient client // <4>
+
+    void "mail send interacts once email service"() {
+        given:
+        EmailCmd cmd = new EmailCmd(subject: "Test", recipient: "delamos@grails.example", textBody: "Hola hola")
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd) // <5>
+
+        when:
+        Collection<EmailService> emailServices = applicationContext.getBeansOfType(EmailService.class)
+
+        then:
+        1 == emailServices.size()
+
+        when:
+        EmailService emailService = applicationContext.getBean(EmailService.class)
+
+        then:
+        emailService instanceof MockEmailService
+
+        when:
+        HttpResponse<?> rsp = client.toBlocking().exchange(request)
+        then:
+        HttpStatus.OK == rsp.getStatus()
+        old(((MockEmailService) emailService).emails.size()) + 1 == ((MockEmailService) emailService).emails.size() // <6>
+    }
+}

--- a/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/MailControllerValidationSpec.groovy
+++ b/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/MailControllerValidationSpec.groovy
@@ -1,0 +1,87 @@
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Specification
+import javax.inject.Inject
+
+@MicronautTest // <1>
+@Property(name = "spec.name", value = "mailcontroller") // <2>
+class MailControllerValidationSpec extends Specification {
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Inject
+    @Client("/")
+    RxHttpClient client;
+
+    void "mail send cannot be invoked without subject"() {
+        given:
+        EmailCmd cmd = new EmailCmd(recipient: "delamos@micronaut.example", textBody: "Hola hola")
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd) // <3>
+
+        when:
+        client.toBlocking().exchange(request)
+
+        then:
+        HttpClientResponseException e = thrown()
+        HttpStatus.BAD_REQUEST == e.status
+    }
+
+    void "mail send cannot be invoked without recipient"() {
+        given:
+        EmailCmd cmd = new EmailCmd(subject: "Hola", textBody: "Hola hola")
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd) // <3>
+
+        when:
+        client.toBlocking().exchange(request)
+
+        then:
+        HttpClientResponseException e = thrown()
+        HttpStatus.BAD_REQUEST == e.status
+    }
+
+    void "mail send cannot be invoked without either text body or html body"() {
+        EmailCmd cmd = new EmailCmd(subject: "Hola", recipient: "delamos@micronaut.example")
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd) // <3>
+
+        when:
+        client.toBlocking().exchange(request)
+
+        then:
+        HttpClientResponseException e = thrown()
+        HttpStatus.BAD_REQUEST == e.status
+    }
+
+    void "mail send can be invoked without text body and not html body"() {
+        given:
+        EmailCmd cmd = new EmailCmd(subject: "Hola", recipient: "delamos@micronaut.example", textBody: "Hello")
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd) // <3>
+
+        when:
+        HttpResponse<?> rsp = client.toBlocking().exchange(request)
+
+        then:
+        HttpStatus.OK == rsp.getStatus()
+    }
+
+    void "mail send can be invoked with html body and not text body"() {
+        given:
+        EmailCmd cmd = new EmailCmd(subject: "Hola", recipient: "delamos@micronaut.example", htmlBody: "<h1>Hello</h1>")
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd) // <3>
+
+        when:
+        HttpResponse<?> rsp = client.toBlocking().exchange(request)
+
+        then:
+        HttpStatus.OK == rsp.getStatus()
+    }
+}

--- a/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/MockEmailService.groovy
+++ b/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/MockEmailService.groovy
@@ -1,0 +1,22 @@
+package example.micronaut
+
+import edu.umd.cs.findbugs.annotations.NonNull
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+
+import javax.inject.Singleton
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+@Primary
+@Requires(property = "spec.name", value = "mailcontroller")
+@Singleton
+class MockEmailService implements EmailService {
+
+    public List<Email> emails = new ArrayList<>()
+
+    @Override
+    void send(@NonNull @NotNull @Valid Email email) {
+        emails << email
+    }
+}

--- a/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/SendGridEmailConditionSpec.groovy
+++ b/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/SendGridEmailConditionSpec.groovy
@@ -1,0 +1,26 @@
+package example.micronaut
+
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class SendGridEmailConditionSpec extends Specification {
+
+    @RestoreSystemProperties
+    void "condition is true if system properites are present"() {
+        given:
+        System.setProperty("sendgrid.apikey", "XXXX")
+        System.setProperty("sendgrid.fromemail", "me@micronaut.example")
+        SendGridEmailCondition condition = new SendGridEmailCondition()
+
+        expect:
+        condition.matches(null)
+    }
+
+    void "condition is false if system properties are not present"() {
+        given:
+        SendGridEmailCondition condition = new SendGridEmailCondition()
+
+        expect:
+        !condition.matches(null)
+    }
+}

--- a/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/SendGridEmailServiceSpec.groovy
+++ b/guides/micronaut-email/groovy/src/test/groovy/example/micronaut/SendGridEmailServiceSpec.groovy
@@ -1,0 +1,36 @@
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class SendGridEmailServiceSpec extends Specification {
+
+    void "send grid email service is not loaded if system property is not present"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+
+        expect:
+        !ctx.containsBean(SendGridEmailService.class)
+
+        cleanup:
+        ctx.close()
+    }
+
+    @RestoreSystemProperties
+    void "send grid email service is loaded if system properties are present"() {
+        given:
+        System.setProperty("sendgrid.apikey", "XXXX")
+        System.setProperty("sendgrid.fromemail", "me@micronaut.example")
+        ApplicationContext ctx = ApplicationContext.run()
+        SendGridEmailService bean = ctx.getBean(SendGridEmailService.class)
+
+        expect:
+        "XXXX" == bean.apiKey
+        "me@micronaut.example" == bean.fromEmail
+
+        cleanup:
+        ctx.close()
+
+    }
+}

--- a/guides/micronaut-email/java/src/main/java/example/micronaut/AwsResourceAccessCondition.java
+++ b/guides/micronaut-email/java/src/main/java/example/micronaut/AwsResourceAccessCondition.java
@@ -1,0 +1,30 @@
+package example.micronaut;
+
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.util.StringUtils;
+
+/**
+ * @see <a href="https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-roles.html">Configure IAM Roles for Amazon EC2</a>
+ */
+public class AwsResourceAccessCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context) {
+
+        if (StringUtils.isNotEmpty(System.getProperty("aws.accessKeyId")) &&  StringUtils.isNotEmpty(System.getProperty("aws.secretAccessKey"))) { // <1>
+            return true;
+        }
+
+        if (StringUtils.isNotEmpty(System.getenv("AWS_ACCESS_KEY_ID")) &&  StringUtils.isNotEmpty(System.getenv("AWS_SECRET_ACCESS_KEY"))) { // <2>
+            return true;
+        }
+
+        if (StringUtils.isNotEmpty(System.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"))) { // <3>
+            return true;
+        }
+
+        return context != null && context.getBean(Environment.class).getActiveNames().contains(Environment.AMAZON_EC2); // <4>
+    }
+}

--- a/guides/micronaut-email/java/src/main/java/example/micronaut/AwsSesMailService.java
+++ b/guides/micronaut-email/java/src/main/java/example/micronaut/AwsSesMailService.java
@@ -1,0 +1,55 @@
+package example.micronaut;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Secondary;
+import io.micronaut.context.annotation.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.Body;
+import software.amazon.awssdk.services.ses.model.Content;
+import software.amazon.awssdk.services.ses.model.Destination;
+import software.amazon.awssdk.services.ses.model.Message;
+import software.amazon.awssdk.services.ses.model.SendEmailRequest;
+import software.amazon.awssdk.services.ses.model.SendEmailResponse;
+
+import javax.inject.Singleton;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+
+@Singleton // <1>
+@Requires(condition = AwsResourceAccessCondition.class)  // <2>
+@Secondary // <3>
+public class AwsSesMailService implements EmailService {
+    private static final Logger LOG = LoggerFactory.getLogger(AwsSesMailService.class);
+    protected final String sourceEmail;
+    protected final SesClient ses;
+
+    public AwsSesMailService(@Nullable @Value("${AWS_REGION}") String awsRegionEnv, // <4>
+                             @Nullable @Value("${AWS_SOURCE_EMAIL}") String sourceEmailEnv,
+                             @Nullable @Value("${aws.region}") String awsRegionProp,
+                             @Nullable @Value("${aws.sourceemail}") String sourceEmailProp) {
+
+        this.sourceEmail = sourceEmailEnv != null ? sourceEmailEnv : sourceEmailProp;
+        String awsRegion = awsRegionEnv != null ? awsRegionEnv : awsRegionProp;
+        this.ses = SesClient.builder().region(Region.of(awsRegion)).build();
+    }
+
+    @Override
+    public void send(@NonNull @NotNull @Valid Email email) {
+        SendEmailRequest sendEmailRequest = SendEmailRequest.builder()
+                .destination(Destination.builder().toAddresses(email.getRecipient()).build())
+                .source(sourceEmail)
+                .message(Message.builder().subject(Content.builder().data(email.getSubject()).build())
+                        .body(Body.builder().text(Content.builder().data(email.getTextBody()).build()).build()).build())
+                .build();
+        SendEmailResponse response =ses.sendEmail(sendEmailRequest);
+        if (LOG.isInfoEnabled()) {
+            LOG.info("Sent email with id: {}", response.messageId());
+        }
+    }
+}

--- a/guides/micronaut-email/java/src/main/java/example/micronaut/Email.java
+++ b/guides/micronaut-email/java/src/main/java/example/micronaut/Email.java
@@ -1,0 +1,13 @@
+package example.micronaut;
+
+import java.util.List;
+
+public interface Email {
+    String getRecipient();
+    List<String> getCc();
+    List<String> getBcc();
+    String getSubject();
+    String getHtmlBody();
+    String getTextBody();
+    String getReplyTo();
+}

--- a/guides/micronaut-email/java/src/main/java/example/micronaut/EmailCmd.java
+++ b/guides/micronaut-email/java/src/main/java/example/micronaut/EmailCmd.java
@@ -1,0 +1,105 @@
+package example.micronaut;
+
+import io.micronaut.core.annotation.Introspected;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+//tag::clazzwithannotations[]
+@EmailConstraints
+//end::clazzwithannotations[]
+//tag::clazz[]
+@Introspected
+public class EmailCmd implements Email {
+//end::clazz[]
+
+    //tag::properties[]
+    @NotNull
+    @NotBlank
+    private String recipient;
+
+    @NotNull
+    @NotBlank
+    private String subject;
+
+    private List<String> cc = new ArrayList<>();
+    private List<String> bcc = new ArrayList<>();
+
+    private String htmlBody;
+    private String textBody;
+    private String replyTo;
+    //end::properties[]
+
+    //tag::settersandgetters[]
+    @Override
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
+    }
+
+    @Override
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    @Override
+    public List<String> getCc() {
+        return cc;
+    }
+
+    public void setCc(List<String> cc) {
+        this.cc = cc;
+    }
+
+    @Override
+    public List<String> getBcc() {
+        return bcc;
+    }
+
+    public void setBcc(List<String> bcc) {
+        this.bcc = bcc;
+    }
+
+    @Override
+    public String getHtmlBody() {
+        return htmlBody;
+    }
+
+    public void setHtmlBody(String htmlBody) {
+        this.htmlBody = htmlBody;
+    }
+
+    @Override
+    public String getTextBody() {
+        return textBody;
+    }
+
+    public void setTextBody(String textBody) {
+        this.textBody = textBody;
+    }
+
+    @Override
+    public String getReplyTo() {
+        return replyTo;
+    }
+
+    public void setReplyTo(String replyTo) {
+        this.replyTo = replyTo;
+    }
+}
+//end::settersandgetters[]
+/*
+//tag::close[]
+    // getters & setters
+}
+//end::close[]
+ */

--- a/guides/micronaut-email/java/src/main/java/example/micronaut/EmailConstraints.java
+++ b/guides/micronaut-email/java/src/main/java/example/micronaut/EmailConstraints.java
@@ -1,0 +1,21 @@
+package example.micronaut;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = {})
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EmailConstraints {
+
+    String message() default "{email.invalid}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/guides/micronaut-email/java/src/main/java/example/micronaut/EmailConstraintsFactory.java
+++ b/guides/micronaut-email/java/src/main/java/example/micronaut/EmailConstraintsFactory.java
@@ -1,0 +1,18 @@
+package example.micronaut;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+
+import javax.inject.Singleton;
+
+@Factory
+public class EmailConstraintsFactory {
+
+    @Singleton
+    ConstraintValidator<EmailConstraints, EmailCmd> emailBodyValidator() {
+        return (value, annotationMetadata, context) ->
+                value != null &&
+                        (StringUtils.isNotEmpty(value.getTextBody()) || StringUtils.isNotEmpty(value.getHtmlBody()));
+    }
+}

--- a/guides/micronaut-email/java/src/main/java/example/micronaut/EmailService.java
+++ b/guides/micronaut-email/java/src/main/java/example/micronaut/EmailService.java
@@ -1,0 +1,10 @@
+package example.micronaut;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public interface EmailService {
+    void send(@NonNull @NotNull @Valid Email email);
+}

--- a/guides/micronaut-email/java/src/main/java/example/micronaut/MailController.java
+++ b/guides/micronaut-email/java/src/main/java/example/micronaut/MailController.java
@@ -1,0 +1,26 @@
+package example.micronaut;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.Valid;
+
+@Controller("/mail") // <1>
+public class MailController {
+
+    private final EmailService emailService;
+
+    public MailController(EmailService emailService) { // <2>
+        this.emailService = emailService;
+    }
+
+    @Post("/send") // <3>
+    public HttpResponse<?> send(@Body @Valid EmailCmd cmd) { // <4>
+        emailService.send(cmd);
+        return HttpResponse.ok();  // <5>
+    }
+}

--- a/guides/micronaut-email/java/src/main/java/example/micronaut/SendGridEmailCondition.java
+++ b/guides/micronaut-email/java/src/main/java/example/micronaut/SendGridEmailCondition.java
@@ -1,0 +1,17 @@
+package example.micronaut;
+
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.core.util.StringUtils;
+
+public class SendGridEmailCondition implements Condition {
+    @Override
+    public boolean matches(ConditionContext context) {
+        return envOrSystemProperty("SENDGRID_APIKEY", "sendgrid.apikey") &&
+                envOrSystemProperty("SENDGRID_FROM_EMAIL", "sendgrid.fromemail");
+    }
+
+    private boolean envOrSystemProperty(String env, String prop) {
+        return StringUtils.isNotEmpty(System.getProperty(prop)) || StringUtils.isNotEmpty(System.getenv(env));
+    }
+}

--- a/guides/micronaut-email/java/src/main/java/example/micronaut/SendGridEmailService.java
+++ b/guides/micronaut-email/java/src/main/java/example/micronaut/SendGridEmailService.java
@@ -1,0 +1,106 @@
+package example.micronaut;
+
+import com.sendgrid.SendGrid;
+import com.sendgrid.Request;
+import com.sendgrid.Response;
+import com.sendgrid.Method;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Personalization;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.io.IOException;
+
+@Singleton // <1>
+@Requires(condition = SendGridEmailCondition.class) // <2>
+class SendGridEmailService implements EmailService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SendGridEmailService.class);
+
+    protected final String apiKey;
+
+    protected final String fromEmail;
+
+    SendGridEmailService(@Value("${SENDGRID_APIKEY:none}") String apiKeyEnv, // <3>
+                         @Value("${SENDGRID_FROM_EMAIL:none}") String fromEmailEnv,
+                         @Value("${sendgrid.apikey:none}") String apiKeyProp,
+                         @Value("${sendgrid.fromemail:none}") String fromEmailProp) {
+        this.apiKey = apiKeyEnv != null && !apiKeyEnv.equals("none") ? apiKeyEnv : apiKeyProp;
+        this.fromEmail = fromEmailEnv != null && !fromEmailEnv.equals("none")  ? fromEmailEnv: fromEmailProp;
+    }
+
+    protected Content contentOfEmail(Email email) {
+        if ( email.getTextBody() !=null ) {
+            return new Content("text/plain", email.getTextBody());
+        }
+        if ( email.getHtmlBody() !=null ) {
+            return new Content("text/html", email.getHtmlBody());
+        }
+        return null;
+    }
+
+    @Override
+    public void send(@NonNull @NotNull @Valid Email email) {
+
+        Personalization personalization = new Personalization();
+        personalization.setSubject(email.getSubject());
+
+        com.sendgrid.helpers.mail.objects.Email to = new com.sendgrid.helpers.mail.objects.Email(email.getRecipient());
+        personalization.addTo(to);
+
+        if ( email.getCc() != null ) {
+            for ( String cc : email.getCc() ) {
+                com.sendgrid.helpers.mail.objects.Email ccEmail = new com.sendgrid.helpers.mail.objects.Email();
+                ccEmail.setEmail(cc);
+                personalization.addCc(ccEmail);
+            }
+        }
+
+        if ( email.getBcc()  != null ) {
+            for ( String bcc : email.getBcc() ) {
+                com.sendgrid.helpers.mail.objects.Email bccEmail = new com.sendgrid.helpers.mail.objects.Email();
+                bccEmail.setEmail(bcc);
+                personalization.addBcc(bccEmail);
+            }
+        }
+
+        Mail mail = new Mail();
+        com.sendgrid.helpers.mail.objects.Email from = new com.sendgrid.helpers.mail.objects.Email();
+        from.setEmail(fromEmail);
+        mail.from = from;
+        mail.addPersonalization(personalization);
+        Content content = contentOfEmail(email);
+        mail.addContent(content);
+
+        SendGrid sg = new SendGrid(apiKey);
+        Request request = new Request();
+        try {
+            request.setMethod(Method.POST);
+            request.setEndpoint("mail/send");
+            request.setBody(mail.build());
+
+            Response response = sg.api(request);
+            if (LOG.isInfoEnabled()) {
+                LOG.info("Status Code: {}", String.valueOf(response.getStatusCode()));
+                LOG.info("Body: {}", response.getBody());
+                for ( String k : response.getHeaders().keySet()) {
+                    String v = response.getHeaders().get(k);
+                    LOG.info("Response Header {} => {}", k, v);
+                }
+            }
+
+
+        } catch (IOException ex) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error(ex.getMessage());
+            }
+        }
+    }
+}

--- a/guides/micronaut-email/java/src/main/resources/logback.xml
+++ b/guides/micronaut-email/java/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <!-- tag::logger[] -->
+<logger name="example.micronaut" level="TRACE"/>
+    <!-- end::logger[] -->
+</configuration>

--- a/guides/micronaut-email/java/src/test/java/example/micronaut/AwsResourceAccessConditionTest.java
+++ b/guides/micronaut-email/java/src/test/java/example/micronaut/AwsResourceAccessConditionTest.java
@@ -1,0 +1,38 @@
+package example.micronaut;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AwsResourceAccessConditionTest {
+
+    @Test
+    public void conditionIsTrueIfSystemPropertiesArePresent() {
+
+        String accesskeyid = System.getProperty("aws.accessKeyId");
+        String awssecretkey = System.getProperty("aws.secretAccessKey");
+        System.setProperty("aws.accessKeyId", "XXXX");
+        System.setProperty("aws.secretAccessKey", "YYYY");
+
+        AwsResourceAccessCondition condition = new AwsResourceAccessCondition();
+        assertTrue(condition.matches(null));
+
+        if (accesskeyid == null) {
+            System.clearProperty("aws.accessKeyId");
+        } else {
+            System.setProperty("aws.accessKeyId", accesskeyid);
+        }
+        if (awssecretkey == null) {
+            System.clearProperty("aws.secretAccessKey");
+        } else {
+            System.setProperty("aws.secretAccessKey", awssecretkey);
+        }
+    }
+
+    @Test
+    public void conditionIsFalseIfSystemPropertiesAreNotPresent() {
+        AwsResourceAccessCondition condition = new AwsResourceAccessCondition();
+        assertFalse(condition.matches(null));
+    }
+}

--- a/guides/micronaut-email/java/src/test/java/example/micronaut/AwsSesMailServiceTest.java
+++ b/guides/micronaut-email/java/src/test/java/example/micronaut/AwsSesMailServiceTest.java
@@ -1,0 +1,55 @@
+package example.micronaut;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class AwsSesMailServiceTest {
+
+    @Test
+    public void awsSesMailServiceIsNotLoadedIfSystemPropertyIsNotPresent() {
+        ApplicationContext ctx = ApplicationContext.run();
+        assertFalse(ctx.containsBean(AwsSesMailService.class));
+        ctx.close();
+    }
+
+    @Test
+    public void awsSesMailServiceIsLoadedIfSystemPropertiesArePresent() {
+        String accesskeyid = System.getProperty("aws.accessKeyId");
+        String awssecretkey = System.getProperty("aws.secretAccessKey");
+        String awsregion = System.getProperty("aws.region");
+        String sourceemail = System.getProperty("aws.sourceemail");
+
+        System.setProperty("aws.accessKeyId", "XXXX");
+        System.setProperty("aws.secretAccessKey", "YKYY");
+        System.setProperty("aws.region", "XXXX");
+        System.setProperty("aws.sourceemail", "me@micronaut.example");
+
+        ApplicationContext ctx = ApplicationContext.run();
+        AwsSesMailService bean = ctx.getBean(AwsSesMailService.class);
+        assertEquals("me@micronaut.example", bean.sourceEmail);
+        ctx.close();
+
+        if (awsregion == null) {
+            System.clearProperty("aws.region");
+        } else {
+            System.setProperty("aws.region", awsregion);
+        }
+        if (sourceemail == null) {
+            System.clearProperty("aws.sourceemail");
+        } else {
+            System.setProperty("aws.sourceemail", sourceemail);
+        }
+        if (accesskeyid == null) {
+            System.clearProperty("aws.accessKeyId");
+        } else {
+            System.setProperty("aws.accessKeyId", accesskeyid);
+        }
+        if (awssecretkey == null) {
+            System.clearProperty("aws.secretAccessKey");
+        } else {
+            System.setProperty("aws.secretAccessKey", awssecretkey);
+        }
+    }
+}

--- a/guides/micronaut-email/java/src/test/java/example/micronaut/MailControllerTest.java
+++ b/guides/micronaut-email/java/src/test/java/example/micronaut/MailControllerTest.java
@@ -1,0 +1,50 @@
+package example.micronaut;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest // <1>
+@Property(name = "spec.name", value = "mailcontroller") // <2>
+class MailControllerTest {
+
+    @Inject
+    ApplicationContext applicationContext; // <3>
+
+    @Inject
+    @Client("/")
+    RxHttpClient client; // <4>
+
+    @Test
+    public void mailsendInteractsOnceEmailService() {
+        EmailCmd cmd = new EmailCmd();
+        cmd.setSubject("Test");
+        cmd.setRecipient("delamos@grails.example");
+        cmd.setTextBody("Hola hola");
+
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd); // <5>
+        Collection<EmailService> emailServices = applicationContext.getBeansOfType(EmailService.class);
+        assertEquals(1, emailServices.size());
+
+        EmailService emailService = applicationContext.getBean(EmailService.class);
+        assertTrue(emailService instanceof MockEmailService);
+
+        int oldEmailsSize = ((MockEmailService) emailService).emails.size();
+        HttpResponse<?> rsp = client.toBlocking().exchange(request);
+
+        assertEquals(HttpStatus.OK, rsp.getStatus());
+        assertEquals(oldEmailsSize + 1 , ((MockEmailService) emailService).emails.size()); // <6>
+    }
+}

--- a/guides/micronaut-email/java/src/test/java/example/micronaut/MailControllerValidationTest.java
+++ b/guides/micronaut-email/java/src/test/java/example/micronaut/MailControllerValidationTest.java
@@ -1,0 +1,90 @@
+package example.micronaut;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import javax.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@MicronautTest // <1>
+@Property(name = "spec.name", value = "mailcontroller") // <2>
+class MailControllerValidationTest {
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Inject
+    @Client("/")
+    RxHttpClient client;
+
+    @Test
+    public void mailSendCannotBeInvokedWithoubSubject() {
+        EmailCmd cmd = new EmailCmd();
+        cmd.setRecipient("delamos@micronaut.example");
+        cmd.setTextBody("Hola hola");
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd); // <3>
+
+        Executable e = () -> client.toBlocking().exchange(request);
+        HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, e);
+        assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
+    }
+
+    @Test
+    public void mailSendCannotBeInvokedWithoutRecipient() {
+        EmailCmd cmd = new EmailCmd();
+        cmd.setSubject("Hola");
+        cmd.setTextBody("Hola hola");
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd); // <3>
+
+        Executable e = () -> client.toBlocking().exchange(request);
+        HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, e);
+        assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
+    }
+
+    @Test
+    public void mailSendCannotBeInvokedWithoutEitherTextBodyOrHtmlBody() {
+        EmailCmd cmd = new EmailCmd();
+        cmd.setSubject("Hola");
+        cmd.setRecipient("delamos@micronaut.example");
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd); // <3>
+
+        Executable e = () -> client.toBlocking().exchange(request);
+        HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, e);
+        assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
+    }
+
+    @Test
+    public void mailSendCanBeInvokedWithoutTextBodyAndNotHtmlBody() {
+        EmailCmd cmd = new EmailCmd();
+        cmd.setSubject("Hola");
+        cmd.setRecipient("delamos@micronaut.example");
+        cmd.setTextBody("Hello");
+
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd); // <3>
+        HttpResponse<?> rsp = client.toBlocking().exchange(request);
+        assertEquals(HttpStatus.OK, rsp.getStatus());
+    }
+
+    @Test
+    public void mailSendCanBeInvokedWithoutHtmlBodyAndNotTextBody() {
+        EmailCmd cmd = new EmailCmd();
+        cmd.setSubject("Hola");
+        cmd.setRecipient("delamos@micronaut.example");
+        cmd.setHtmlBody("<h1>Hello</h1>");
+
+        HttpRequest<EmailCmd> request = HttpRequest.POST("/mail/send", cmd); // <3>
+        HttpResponse<?> rsp = client.toBlocking().exchange(request);
+        assertEquals(HttpStatus.OK, rsp.getStatus());
+    }
+}

--- a/guides/micronaut-email/java/src/test/java/example/micronaut/MockEmailService.java
+++ b/guides/micronaut-email/java/src/test/java/example/micronaut/MockEmailService.java
@@ -1,0 +1,24 @@
+package example.micronaut;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+
+import javax.inject.Singleton;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+@Primary
+@Requires(property = "spec.name", value = "mailcontroller")
+@Singleton
+public class MockEmailService implements EmailService {
+
+    public List<Email> emails = new ArrayList<>();
+
+    @Override
+    public void send(@NonNull @NotNull @Valid Email email) {
+        emails.add(email);
+    }
+}

--- a/guides/micronaut-email/java/src/test/java/example/micronaut/SendGridEmailConditionTest.java
+++ b/guides/micronaut-email/java/src/test/java/example/micronaut/SendGridEmailConditionTest.java
@@ -1,0 +1,38 @@
+package example.micronaut;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SendGridEmailConditionTest {
+
+    @Test
+    public void conditionIsTrueIfSystemPropertiesArePresent() {
+
+        String sendGridApiKey = System.getProperty("sendgrid.apikey");
+        String sendGrindFromEmail = System.getProperty("sendgrid.fromemail");
+        System.setProperty("sendgrid.apikey", "XXXX");
+        System.setProperty("sendgrid.fromemail", "me@micronaut.example");
+
+        SendGridEmailCondition condition = new SendGridEmailCondition();
+        assertTrue(condition.matches(null));
+
+        if (sendGridApiKey == null) {
+            System.clearProperty("sendgrid.apikey");
+        } else {
+            System.setProperty("sendgrid.apikey", sendGridApiKey);
+        }
+        if (sendGrindFromEmail == null) {
+            System.clearProperty("sendgrid.fromemail");
+        } else {
+            System.setProperty("sendgrid.fromemail", sendGrindFromEmail);
+        }
+    }
+
+    @Test
+    public void conditionIsFalseIfSystemPropertiesAreNotPresent() {
+        SendGridEmailCondition condition = new SendGridEmailCondition();
+        assertFalse(condition.matches(null));
+    }
+}

--- a/guides/micronaut-email/java/src/test/java/example/micronaut/SendGridEmailServiceTest.java
+++ b/guides/micronaut-email/java/src/test/java/example/micronaut/SendGridEmailServiceTest.java
@@ -1,0 +1,41 @@
+package example.micronaut;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class SendGridEmailServiceTest {
+
+    @Test
+    public void sendGridEmailServiceIsNotLoadedIfSystemPropertyIsNotPresent() {
+        ApplicationContext ctx = ApplicationContext.run();
+        assertFalse(ctx.containsBean(SendGridEmailService.class));
+        ctx.close();
+    }
+
+    @Test
+    public void sendGridEmailServiceIsLoadedIfSystemPropertiesArePresent() {
+        String sendGridApiKey = System.getProperty("sendgrid.apikey");
+        String sendGrindFromEmail = System.getProperty("sendgrid.fromemail");
+        System.setProperty("sendgrid.apikey", "XXXX");
+        System.setProperty("sendgrid.fromemail", "me@micronaut.example");
+        ApplicationContext ctx = ApplicationContext.run();
+        SendGridEmailService bean = ctx.getBean(SendGridEmailService.class);
+        assertEquals("XXXX", bean.apiKey);
+        assertEquals("me@micronaut.example", bean.fromEmail);
+        ctx.close();
+        if (sendGridApiKey == null) {
+            System.clearProperty("sendgrid.apikey");
+        } else {
+            System.setProperty("sendgrid.apikey", sendGridApiKey);
+        }
+        if (sendGrindFromEmail == null) {
+            System.clearProperty("sendgrid.fromemail");
+        } else {
+            System.setProperty("sendgrid.fromemail", sendGrindFromEmail);
+        }
+
+    }
+}

--- a/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/AwsResourceAccessCondition.kt
+++ b/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/AwsResourceAccessCondition.kt
@@ -1,0 +1,23 @@
+package example.micronaut
+
+import io.micronaut.context.condition.Condition
+import io.micronaut.context.condition.ConditionContext
+import io.micronaut.context.env.Environment
+import io.micronaut.core.util.StringUtils
+
+class AwsResourceAccessCondition : Condition {
+
+    override fun matches(context: ConditionContext<*>?): Boolean {
+        if (StringUtils.isNotEmpty(System.getProperty("aws.accessKeyId")) && StringUtils.isNotEmpty(System.getProperty("aws.secretAccessKey"))) { // <1>
+            return true
+        }
+        if (StringUtils.isNotEmpty(System.getenv("AWS_ACCESS_KEY_ID")) && StringUtils.isNotEmpty(System.getenv("AWS_SECRET_ACCESS_KEY"))) { // <2>
+            return true
+        }
+        if (StringUtils.isNotEmpty(System.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"))) { // <3>
+            true
+        }
+        return context != null && context.getBean(Environment::class.java).activeNames.contains(Environment.AMAZON_EC2) // <4>
+    }
+
+}

--- a/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/AwsSesMailService.kt
+++ b/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/AwsSesMailService.kt
@@ -1,0 +1,50 @@
+package example.micronaut
+
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.ses.SesClient
+import software.amazon.awssdk.services.ses.model.Body
+import software.amazon.awssdk.services.ses.model.Content
+import software.amazon.awssdk.services.ses.model.Destination
+import software.amazon.awssdk.services.ses.model.Message
+import software.amazon.awssdk.services.ses.model.SendEmailRequest
+import software.amazon.awssdk.services.ses.model.SendEmailResponse
+import javax.inject.Singleton
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+@Singleton // <1>
+@Requires(condition = AwsResourceAccessCondition::class) // <2>
+@Primary // <3>
+class AwsSesMailService(
+    @Value("\${AWS_REGION}") awsRegionEnv: String?,  // <4>
+    @Value("\${AWS_SOURCE_EMAIL}") sourceEmailEnv: String?,
+    @Value("\${aws.region}") awsRegionProp: String?,
+    @Value("\${aws.sourceemail}") sourceEmailProp: String?,
+) : EmailService {
+
+    val sourceEmail = sourceEmailEnv ?: sourceEmailProp
+    val awsRegion = awsRegionEnv ?: awsRegionProp
+    val ses = SesClient.builder().region(software.amazon.awssdk.regions.Region.of(awsRegion)).build()
+
+    override fun send(email: @NotNull @Valid Email) {
+        val sendEmailRequest: SendEmailRequest = SendEmailRequest.builder()
+            .destination(Destination.builder().toAddresses(email.replyTo()).build())
+            .source(sourceEmail)
+            .message(
+                Message.builder().subject(Content.builder().data(email.subject()).build())
+                    .body(Body.builder().text(Content.builder().data(email.textBody()).build()).build()).build()
+            )
+            .build()
+        val response: SendEmailResponse = ses.sendEmail(sendEmailRequest)
+        if (LOG.isInfoEnabled) {
+            LOG.info("Sent email with id: {}", response.messageId())
+        }
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(AwsSesMailService::class.java)
+    }
+}

--- a/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/Email.kt
+++ b/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/Email.kt
@@ -1,0 +1,11 @@
+package example.micronaut
+
+interface Email {
+    fun recipient(): String?
+    fun cc(): List<String>?
+    fun bcc(): List<String>?
+    fun subject(): String?
+    fun htmlBody(): String?
+    fun textBody(): String?
+    fun replyTo(): String?
+}

--- a/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/EmailCmd.kt
+++ b/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/EmailCmd.kt
@@ -1,0 +1,71 @@
+package example.micronaut
+
+import io.micronaut.core.annotation.Introspected
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+
+//tag::clazzwithannotations[]
+@EmailConstraints
+//end::clazzwithannotations[]
+//tag::clazz[]
+@Introspected
+class EmailCmd : Email {
+//end::clazz[]
+
+    //tag::properties[]
+    @NotBlank
+    @NotNull
+    var recipient: String? = null
+
+    @NotBlank
+    @NotNull
+    var subject: String? = null
+
+    var cc: List<String>? = null
+
+    var bcc: List<String>? = null
+
+    var htmlBody: String? = null
+
+    var textBody: String? = null
+
+    var replyTo: String? = null
+    //end::properties[]
+
+    //tag::settersandgetters[]
+    override fun recipient(): String? {
+        return this.recipient
+    }
+
+    override fun cc(): List<String>? {
+        return this.cc
+    }
+
+    override fun bcc(): List<String>? {
+        return this.bcc
+    }
+
+    override fun subject(): String? {
+        return this.subject
+    }
+
+    override fun htmlBody(): String? {
+        return this.htmlBody
+    }
+
+    override fun textBody(): String? {
+        return this.textBody
+    }
+
+    override fun replyTo(): String? {
+        return this.replyTo
+    }
+}
+//end::settersandgetters[]
+/*
+//tag::close[]
+    // getters & setters
+}
+//end::close[]
+ */
+

--- a/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/EmailConstraints.kt
+++ b/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/EmailConstraints.kt
@@ -1,0 +1,14 @@
+package example.micronaut
+
+import javax.validation.Constraint
+import javax.validation.Payload
+import kotlin.reflect.KClass
+
+@Constraint(validatedBy = [])
+@Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class EmailConstraints(
+    val message: String = "{email.invalid}",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)

--- a/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/EmailConstraintsFactory.kt
+++ b/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/EmailConstraintsFactory.kt
@@ -1,0 +1,19 @@
+package example.micronaut
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.util.StringUtils
+import io.micronaut.validation.validator.constraints.ConstraintValidator
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext
+import javax.inject.Singleton
+
+@Factory
+class EmailConstraintsFactory {
+
+    @Singleton
+    fun emailBodyValidator(): ConstraintValidator<EmailConstraints, EmailCmd> {
+        return ConstraintValidator<EmailConstraints, EmailCmd> { value: EmailCmd?, annotationMetadata: AnnotationValue<EmailConstraints?>?, context: ConstraintValidatorContext? ->
+            value != null && (StringUtils.isNotEmpty(value.textBody) || StringUtils.isNotEmpty(value.htmlBody))
+        }
+    }
+}

--- a/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/EmailService.kt
+++ b/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/EmailService.kt
@@ -1,0 +1,5 @@
+package example.micronaut
+
+interface EmailService {
+    fun send(email: Email)
+}

--- a/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/MailController.kt
+++ b/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/MailController.kt
@@ -1,0 +1,17 @@
+package example.micronaut
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import javax.validation.Valid
+
+@Controller("/mail") // <1>
+open class MailController(private val emailService: EmailService) {  // <2>
+
+    @Post("/send") // <3>
+    open fun send(@Body @Valid cmd: EmailCmd): HttpResponse<*> {  // <4>
+        emailService.send(cmd)
+        return HttpResponse.ok<Any>() // <5>
+    }
+}

--- a/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/SendGridEmailCondition.kt
+++ b/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/SendGridEmailCondition.kt
@@ -1,0 +1,17 @@
+package example.micronaut
+
+import io.micronaut.context.condition.Condition
+import io.micronaut.context.condition.ConditionContext
+import io.micronaut.core.util.StringUtils
+
+class SendGridEmailCondition : Condition {
+
+    override fun matches(context: ConditionContext<*>?): Boolean {
+        return envOrSystemProperty("SENDGRID_APIKEY", "sendgrid.apikey") &&
+                envOrSystemProperty("SENDGRID_FROM_EMAIL", "sendgrid.fromemail")
+    }
+
+    private fun envOrSystemProperty(env: String, prop: String): Boolean {
+        return StringUtils.isNotEmpty(System.getProperty(prop)) || StringUtils.isNotEmpty(System.getenv(env))
+    }
+}

--- a/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/SendGridEmailService.kt
+++ b/guides/micronaut-email/kotlin/src/main/kotlin/example/micronaut/SendGridEmailService.kt
@@ -1,0 +1,90 @@
+package example.micronaut
+
+import com.sendgrid.Method
+import com.sendgrid.Request
+import com.sendgrid.SendGrid
+import com.sendgrid.helpers.mail.Mail
+import com.sendgrid.helpers.mail.objects.Content
+import com.sendgrid.helpers.mail.objects.Personalization
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import org.slf4j.LoggerFactory
+import javax.inject.Singleton
+import java.io.IOException
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+@Singleton // <1>
+@Requires(condition = SendGridEmailCondition::class) // <2>
+class SendGridEmailService(@Value("\${SENDGRID_APIKEY:none}") apiKeyEnv: String,  // <3>
+                                    @Value("\${SENDGRID_FROM_EMAIL:none}") fromEmailEnv: String,
+                                    @Value("\${sendgrid.apikey:none}") apiKeyProp: String,
+                                    @Value("\${sendgrid.fromemail:none}") fromEmailProp: String) : EmailService {
+    val apiKey: String
+    val fromEmail: String
+
+    init {
+        this.apiKey = if (apiKeyEnv != "none") apiKeyEnv else apiKeyProp
+        this.fromEmail = if (fromEmailEnv != "none") fromEmailEnv else fromEmailProp
+    }
+    protected fun contentOfEmail(email: Email): Content? {
+        if (email.textBody() != null) {
+            return Content("text/plain", email.textBody())
+        }
+        return if (email.htmlBody() != null) {
+            Content("text/html", email.htmlBody())
+        } else null
+    }
+
+    override fun send(email: @NotNull @Valid Email) {
+        val personalization = Personalization()
+        personalization.subject = email.subject()
+        val to = com.sendgrid.helpers.mail.objects.Email(email.recipient())
+        personalization.addTo(to)
+        if (email.cc() != null) {
+            for (cc in email.cc()!!) {
+                val ccEmail = com.sendgrid.helpers.mail.objects.Email()
+                ccEmail.email = cc
+                personalization.addCc(ccEmail)
+            }
+        }
+        if (email.bcc() != null) {
+            for (bcc in email.bcc()!!) {
+                val bccEmail = com.sendgrid.helpers.mail.objects.Email()
+                bccEmail.email = bcc
+                personalization.addBcc(bccEmail)
+            }
+        }
+        val mail = Mail()
+        val from = com.sendgrid.helpers.mail.objects.Email()
+        from.email = fromEmail
+        mail.from = from
+        mail.addPersonalization(personalization)
+        val content: Content? = contentOfEmail(email)
+        mail.addContent(content)
+        val sg = SendGrid(apiKey)
+        val request = Request()
+        try {
+            request.method = Method.POST
+            request.endpoint = "mail/send"
+            request.body = mail.build()
+            val response = sg.api(request)
+            if (LOG.isInfoEnabled) {
+                LOG.info("Status Code: {}", response.statusCode.toString())
+                LOG.info("Body: {}", response.body)
+                for (k in response.headers.keys) {
+                    val v = response.headers[k]
+                    LOG.info("Response Header {} => {}", k, v)
+                }
+            }
+        } catch (ex: IOException) {
+            if (LOG.isErrorEnabled) {
+                LOG.error(ex.message)
+            }
+        }
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(SendGridEmailService::class.java)
+    }
+}

--- a/guides/micronaut-email/kotlin/src/main/resources/logback.xml
+++ b/guides/micronaut-email/kotlin/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <!-- tag::logger[] -->
+<logger name="example.micronaut" level="TRACE"/>
+    <!-- end::logger[] -->
+</configuration>

--- a/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/AwsResourceAccessConditionTest.kt
+++ b/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/AwsResourceAccessConditionTest.kt
@@ -1,0 +1,35 @@
+package example.micronaut
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class AwsResourceAccessConditionTest {
+
+    @Test
+    fun conditionIsTrueIfSystemPropertiesArePresent() {
+        val accesskeyid = System.getProperty("aws.accessKeyId")
+        val awssecretkey = System.getProperty("aws.secretAccessKey")
+
+        System.setProperty("aws.accessKeyId", "XXXX")
+        System.setProperty("aws.secretAccessKey", "YYYY")
+        val condition = AwsResourceAccessCondition()
+        Assertions.assertTrue(condition.matches(null))
+
+        if (accesskeyid == null) {
+            System.clearProperty("aws.accessKeyId")
+        } else {
+            System.setProperty("aws.accessKeyId", accesskeyid)
+        }
+        if (awssecretkey == null) {
+            System.clearProperty("aws.secretAccessKey")
+        } else {
+            System.setProperty("aws.secretAccessKey", awssecretkey)
+        }
+    }
+
+    @Test
+    fun conditionIsFalseIfSystemPropertiesAreNotPresent() {
+        val condition = AwsResourceAccessCondition()
+        Assertions.assertFalse(condition.matches(null))
+    }
+}

--- a/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/AwsSesMailServiceTest.kt
+++ b/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/AwsSesMailServiceTest.kt
@@ -1,0 +1,55 @@
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class AwsSesMailServiceTest {
+
+    @Test
+    fun awsSesMailServiceIsNotLoadedIfSystemPropertyIsNotPresent() {
+        val ctx = ApplicationContext.run()
+        Assertions.assertFalse(ctx.containsBean(AwsSesMailService::class.java))
+        ctx.close()
+    }
+
+    @Test
+    fun awsSesMailServiceIsLoadedIfSystemPropertiesArePresent() {
+        val accesskeyid = System.getProperty("aws.accessKeyId")
+        val awssecretkey = System.getProperty("aws.secretAccessKey")
+        val awsregion = System.getProperty("aws.region")
+        val sourceemail = System.getProperty("aws.sourceemail")
+
+        System.setProperty("aws.accessKeyId", "XXXX")
+        System.setProperty("aws.secretAccessKey", "YKYY")
+        System.setProperty("aws.region", "XXXX")
+        System.setProperty("aws.sourceemail", "me@micronaut.example")
+
+        val ctx = ApplicationContext.run()
+        val bean = ctx.getBean(AwsSesMailService::class.java)
+        Assertions.assertEquals("me@micronaut.example", bean.sourceEmail)
+
+        ctx.close()
+
+        if (awsregion == null) {
+            System.clearProperty("aws.region")
+        } else {
+            System.setProperty("aws.region", awsregion)
+        }
+        if (sourceemail == null) {
+            System.clearProperty("aws.sourceemail")
+        } else {
+            System.setProperty("aws.sourceemail", sourceemail)
+        }
+        if (accesskeyid == null) {
+            System.clearProperty("aws.accessKeyId")
+        } else {
+            System.setProperty("aws.accessKeyId", accesskeyid)
+        }
+        if (awssecretkey == null) {
+            System.clearProperty("aws.secretAccessKey")
+        } else {
+            System.setProperty("aws.secretAccessKey", awssecretkey)
+        }
+    }
+}

--- a/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/MailControllerTest.kt
+++ b/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/MailControllerTest.kt
@@ -1,0 +1,45 @@
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+@MicronautTest // <1>
+@Property(name = "spec.name", value = "mailcontroller") // <2>
+internal class MailControllerTest {
+
+    @Inject
+    lateinit var applicationContext: ApplicationContext // <3>
+
+    @Inject
+    @field:Client("/")
+    lateinit var client: RxHttpClient // <4>
+
+    @Test
+    fun mailsendInteractsOnceEmailService() {
+        val cmd = EmailCmd()
+        cmd.subject = "Test"
+        cmd.recipient = "delamos@grails.example"
+        cmd.textBody = "Hola hola"
+
+        val request: HttpRequest<EmailCmd> = HttpRequest.POST("/mail/send", cmd) // <5>
+        val emailServices = applicationContext.getBeansOfType(EmailService::class.java)
+        Assertions.assertEquals(1, emailServices.size)
+
+        val emailService = applicationContext.getBean(EmailService::class.java)
+        Assertions.assertTrue(emailService is MockEmailService)
+
+        val oldEmailsSize = (emailService as MockEmailService).emails.size
+        val rsp: HttpResponse<*> = client.toBlocking().exchange<EmailCmd, Any>(request)
+        Assertions.assertEquals(HttpStatus.OK, rsp.status)
+        Assertions.assertEquals(oldEmailsSize + 1, emailService.emails.size) // <6>
+    }
+}

--- a/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/MailControllerValidationTest.kt
+++ b/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/MailControllerValidationTest.kt
@@ -1,0 +1,92 @@
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+import javax.inject.Inject
+
+@MicronautTest // <1>
+@Property(name = "spec.name", value = "mailcontroller") // <2>
+class MailControllerValidationTest {
+
+    @Inject
+    lateinit var applicationContext: ApplicationContext
+
+    @Inject
+    @field:Client("/")
+    lateinit var client: RxHttpClient
+
+    @Test
+    fun mailSendCannotBeInvokedWithoubSubject() {
+        val cmd = EmailCmd()
+        cmd.recipient = "delamos@micronaut.example"
+        cmd.textBody = "Hola hola"
+
+        val request: HttpRequest<EmailCmd> = HttpRequest.POST("/mail/send", cmd) // <3>
+        val e = Executable { client.toBlocking().exchange<EmailCmd, Any>(request) }
+        val thrown = Assertions.assertThrows(HttpClientResponseException::class.java, e)
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, thrown.status)
+    }
+
+    @Test
+    fun mailSendCannotBeInvokedWithoutRecipient() {
+        val cmd = EmailCmd()
+        cmd.subject = "Hola"
+        cmd.textBody = "Hola hola"
+
+        val request: HttpRequest<EmailCmd> = HttpRequest.POST("/mail/send", cmd) // <3>
+        val e = Executable { client.toBlocking().exchange<EmailCmd, Any>(request) }
+        val thrown = Assertions.assertThrows(HttpClientResponseException::class.java, e)
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, thrown.status)
+    }
+
+    @Test
+    fun mailSendCannotBeInvokedWithoutEitherTextBodyOrHtmlBody() {
+        val cmd = EmailCmd()
+        cmd.subject = "Hola"
+        cmd.recipient = "delamos@micronaut.example"
+
+        val request: HttpRequest<EmailCmd> = HttpRequest.POST("/mail/send", cmd) // <3>
+        val e = Executable { client.toBlocking().exchange<EmailCmd, Any>(request) }
+        val thrown = Assertions.assertThrows(HttpClientResponseException::class.java, e)
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, thrown.status)
+    }
+
+    @Test
+    fun mailSendCanBeInvokedWithoutTextBodyAndNotHtmlBody() {
+        val cmd = EmailCmd()
+        cmd.subject = "Hola"
+        cmd.recipient = "delamos@micronaut.example"
+        cmd.textBody = "Hello"
+
+        val request: HttpRequest<EmailCmd> = HttpRequest.POST("/mail/send", cmd) // <3>
+        val rsp: HttpResponse<*> = client.toBlocking().exchange<EmailCmd, Any>(request)
+
+        Assertions.assertEquals(HttpStatus.OK, rsp.status)
+    }
+
+    @Test
+    fun mailSendCanBeInvokedWithoutHtmlBodyAndNotTextBody() {
+        val cmd = EmailCmd()
+        cmd.subject = "Hola"
+        cmd.recipient = "delamos@micronaut.example"
+        cmd.htmlBody = "<h1>Hello</h1>"
+
+        val request: HttpRequest<EmailCmd> = HttpRequest.POST("/mail/send", cmd) // <3>
+        val rsp: HttpResponse<*> = client.toBlocking().exchange<EmailCmd, Any>(request)
+
+        Assertions.assertEquals(HttpStatus.OK, rsp.status)
+    }
+}

--- a/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/MockEmailService.kt
+++ b/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/MockEmailService.kt
@@ -1,0 +1,20 @@
+package example.micronaut
+
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import java.util.ArrayList
+import javax.inject.Singleton
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+@Singleton
+@Primary
+@Requires(property = "spec.name", value = "mailcontroller")
+open class MockEmailService : EmailService {
+
+    var emails: MutableList<Email> = ArrayList()
+
+    override fun send(email: @NotNull @Valid Email) {
+        emails.add(email)
+    }
+}

--- a/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/SendGridEmailConditionTest.kt
+++ b/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/SendGridEmailConditionTest.kt
@@ -1,0 +1,38 @@
+package example.micronaut
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class SendGridEmailConditionTest {
+
+    @Test
+    fun conditionIsTrueIfSystemPropertiesArePresent() {
+        val sendGridApiKey = System.getProperty("sendgrid.apikey")
+        val sendGrindFromEmail = System.getProperty("sendgrid.fromemail")
+        System.setProperty("sendgrid.apikey", "XXXX")
+        System.setProperty("sendgrid.fromemail", "me@micronaut.example")
+
+        val condition = SendGridEmailCondition()
+        Assertions.assertTrue(condition.matches(null))
+
+        if (sendGridApiKey == null) {
+            System.clearProperty("sendgrid.apikey")
+        } else {
+            System.setProperty("sendgrid.apikey", sendGridApiKey)
+        }
+        if (sendGrindFromEmail == null) {
+            System.clearProperty("sendgrid.fromemail")
+        } else {
+            System.setProperty("sendgrid.fromemail", sendGrindFromEmail)
+        }
+    }
+
+    @Test
+    fun conditionIsFalseIfSystemPropertiesAreNotPresent() {
+        val sendGridApiKey = System.getProperty("sendgrid.apikey")
+        val sendGrindFromEmail = System.getProperty("sendgrid.fromemail")
+
+        val condition = SendGridEmailCondition()
+        Assertions.assertFalse(condition.matches(null))
+    }
+}

--- a/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/SendGridEmailServiceTest.kt
+++ b/guides/micronaut-email/kotlin/src/test/kotlin/example/micronaut/SendGridEmailServiceTest.kt
@@ -1,0 +1,42 @@
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class SendGridEmailServiceTest {
+
+    @Test
+    fun sendGridEmailServiceIsNotLoadedIfSystemPropertyIsNotPresent() {
+        val ctx = ApplicationContext.run()
+        Assertions.assertFalse(ctx.containsBean(SendGridEmailService::class.java))
+        ctx.close()
+    }
+
+    @Test
+    fun sendGridEmailServiceIsLoadedIfSystemPropertiesArePresent() {
+        val sendGridApiKey = System.getProperty("sendgrid.apikey")
+        val sendGrindFromEmail = System.getProperty("sendgrid.fromemail")
+        System.setProperty("sendgrid.apikey", "XXXX")
+        System.setProperty("sendgrid.fromemail", "me@micronaut.example")
+
+        val ctx = ApplicationContext.run()
+        val bean = ctx.getBean(SendGridEmailService::class.java)
+
+        Assertions.assertEquals("XXXX", bean.apiKey)
+        Assertions.assertEquals("me@micronaut.example", bean.fromEmail)
+
+        ctx.close()
+
+        if (sendGridApiKey == null) {
+            System.clearProperty("sendgrid.apikey")
+        } else {
+            System.setProperty("sendgrid.apikey", sendGridApiKey)
+        }
+        if (sendGrindFromEmail == null) {
+            System.clearProperty("sendgrid.fromemail")
+        } else {
+            System.setProperty("sendgrid.fromemail", sendGrindFromEmail)
+        }
+    }
+}

--- a/guides/micronaut-email/metadata.json
+++ b/guides/micronaut-email/metadata.json
@@ -1,0 +1,13 @@
+{
+  "asciidoctor": "micronaut-email.adoc",
+  "slug": "micronaut-email",
+  "title": "Send Emails from Micronaut",
+  "intro": "Learn how to send emails with AWS SES and SendGrid from a Micronaut app and leverage @Requires annotation to load beans conditionally.",
+  "authors": ["Sergio del Amo"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["graalvm", "ses", "sendgrid"]
+    }
+  ]
+}

--- a/guides/micronaut-email/metadata.json
+++ b/guides/micronaut-email/metadata.json
@@ -4,6 +4,7 @@
   "title": "Send Emails from Micronaut",
   "intro": "Learn how to send emails with AWS SES and SendGrid from a Micronaut app and leverage @Requires annotation to load beans conditionally.",
   "authors": ["Sergio del Amo"],
+  "languages": ["java", "groovy"],
   "apps": [
     {
       "name": "default",

--- a/guides/micronaut-email/micronaut-email.adoc
+++ b/guides/micronaut-email/micronaut-email.adoc
@@ -1,0 +1,223 @@
+= @guideTitle@
+
+@guideIntro@
+
+Authors: @authors@
+
+Micronaut Version: @micronaut@
+
+include::{commondir}/common-gettingStarted.adoc[]
+
+include::{commondir}/common-requirements.adoc[]
+
+include::{commondir}/common-completesolution.adoc[]
+
+include::{commondir}/common-create-app.adoc[]
+
+
+=== Controller
+
+Create `MailController` which use a collaborator, `emailService` to send and email.
+
+source:MailController[]
+
+<1> The class is defined as a controller with the http://docs.micronaut.io/latest/api/io/micronaut/http/annotation/Controller.html[@Controller] annotation mapped to the path `/mail/send`
+<2> Constructor injection
+<3> The http://docs.micronaut.io/latest/api/io/micronaut/http/annotation/Post.html[@Post] annotation is used to map the index method to all requests that use an HTTP POST
+<4> Add `@Valid` to any method parameter which requires validation. Use a POGO supplied as a JSON payload in the request to populate the email.
+<5> Return 200 OK as the result
+
+
+The previous controller uses a POJO supplied in the request body as a JSON Payload
+
+source:EmailCmd[tags=clazz|properties|settersandgetters]
+
+=== Email Service
+
+Create an interface - `EmailService`. Any email provider present in the application should implement it.
+
+source:EmailService[]
+
+source:Email[]
+
+==== AWS SES
+
+____
+Amazon Simple Email Service (Amazon SES) is a cloud-based email sending service designed to help digital marketers and
+application developers send marketing, notification, and transactional emails. It is a reliable, cost-effective service
+for businesses of all sizes that use email to keep in contact with their customers.
+____
+
+Add a dependency to AWS SES SDK:
+
+dependency:ses:2.16.18[groupId=software.amazon.awssdk]
+
+Create service which uses AWS Simple Email Service client to send the email
+
+source:AwsSesMailService[]
+
+<1> Use `javax.inject.Singleton` to designate a class a a singleton
+<2> Bean will not loaded unless condition is met.
+<3> In case of multiple possible interface implementations of `EmailService`, `@Secondary` reduces the priority.
+<4> Values for region and source email are resolved from environment variables or system properties.
+
+We annotated the previous class with `@Requires(condition = AwsResourceAccessCondition.class)`.
+
+The `AwsResourceAccessCondition` ensures the bean is not loaded unless certain conditions are fulfilled.
+
+https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/java-dg-roles.html[_Configure IAM Roles for Amazon EC2_]
+
+____
+> If your application creates an AWS client using the create method, the client searches for credentials using the default credentials provider chain, in the following order:
+
+> * In the Java system properties: `aws.accessKeyId` and `aws.secretAccessKey`.
+> * In system environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+> * In the default credentials file (the location of this file varies by platform).
+> * n the Amazon ECS environment variable: `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`.
+> * In the instance profile credentials, which exist within the instance metadata associated with the IAM role for the EC2 instance.
+____
+
+source:AwsResourceAccessCondition[]
+
+Add a test to verify the service is loaded:
+
+test:AwsSesMailServiceTest[]
+
+
+==== SendGrid
+
+http://sendgrid.com[SendGrid] is a transactional email service.
+
+____
+SendGrid is responsible for sending billions of emails for some of the best and brightest companies in the world.
+____
+
+Add a dependency to SendGrid SDK:
+
+dependency:sendgrid-java:4.7.2[groupId=com.sendgrid]
+
+Create a service which encapsulates the integration with SendGrid. The bean will not be loaded if the
+system properties (`sendgrid.apikey`, `sendgrid.fromemail`) or environment variables (`SENDGRID_APIKEY`, `SENDGRID_FROM_EMAIL`) are not present.
+
+source:SendGridEmailCondition[]
+
+Add a test:
+
+test:SendGridEmailConditionTest[]
+
+
+source:SendGridEmailService[]
+
+<1> Use `javax.inject.Singleton` to designate a class a a singleton
+<2> Bean will not loaded unless condition is met.
+<3> Values will be resolved from system properties.
+
+Add a test:
+
+test:SendGridEmailServiceTest[]
+
+
+=== Run the app
+
+Add a logger to get more visibility:
+
+resource:logback.xml[tag=logger]
+
+To use SendGrid, define the required environment variables and run the app
+
+[source, bash]
+----
+$ export SENDGRID_FROM_EMAIL=email@email.com
+$ export SENDGRID_APIKEY=XXXXXX
+:exclude-for-build:maven
+$ ./gradlew run
+:exclude-for-build:
+:exclude-for-build:gradle
+$ ./mvnw mn:run
+:exclude-for-build:
+----
+
+
+To use AWS SES, define the required environment variables and run the app
+
+[source, bash]
+----
+$ export AWS_REGION=eu-west-1
+$ export AWS_SOURCE_EMAIL=email@email.com
+$ export AWS_ACCESS_KEY_ID=XXXXXXXX
+$ export AWS_SECRET_KEY=XXXXXXXX
+:exclude-for-build:maven
+$ ./gradlew run
+:exclude-for-build:
+:exclude-for-build:gradle
+$ ./mvnw mn:run
+:exclude-for-build:
+----
+
+
+If you supply both AWS SES and SendGrid  system properties, the SendGrid `EmailService` implementation will be used due to the `@Secondary` annotation in `AwsSesMailService`.
+
+[source,bash]
+----
+curl -X "POST" "http://localhost:8080/mail/send" \
+-H 'Content-Type: application/json; charset=utf-8' \
+-d $'{
+"subject": "Test Email",
+"recipient": "recipient@email.com",
+"textBody": "Foo"
+}'
+----
+
+=== Test
+
+In our acceptance test, beans `SendGridEmailService` or `AwsSesMailService` will not be loaded since system properties are not present.
+
+Instead, we setup a Mock which we can verify interactions against.
+
+test:MockEmailService[]
+
+Create the next test:
+
+test:MailControllerTest[]
+
+<1> Annotate the class with `@MicronatTest` to let Micronaut starts the embedded server and inject the beans. More info: https://micronaut-projects.github.io/micronaut-test/latest/guide/index.html[https://micronaut-projects.github.io/micronaut-test/latest/guide/index.html]
+<2> Define a property used to run the test
+<3> Inject the `ApplicationContext` bean
+<4> Inject the `RxHttpClient` bean
+<5> Creating HTTP Requests is easy thanks to Micronaut's fluid API.
+<6> `emailService.send` method is invoked once.
+
+=== Validation
+
+We want to ensure any email request contains a subject, recipient and a text body or html body.
+
+include::{commondir}/common-validation.adoc[]
+
+
+Create the next test:
+
+test:MailControllerValidationTest[]
+
+<1> Annotate the class with `@MicronatTest` to let Micronaut starts the embedded server and inject the beans. More info: https://micronaut-projects.github.io/micronaut-test/latest/guide/index.html[https://micronaut-projects.github.io/micronaut-test/latest/guide/index.html].
+<2> Define a property available for the application.
+<3> Creating HTTP Requests is easy thanks to Micronaut's fluid API.
+
+In order to satisfy the test, create an email constraints annotation
+
+source:EmailConstraints[]
+
+and a constraint validator in a `@Factory` class:
+
+source:EmailConstraintsFactory[]
+
+Annotate `EmailCmd` with `EmailConstraints` and `@Introspected` (to generate the
+https://docs.micronaut.io/latest/guide/index.html#introspection[Bean Introspection information]).
+
+source:EmailCmd[tags=clazzwithannotations|clazz|properties|close]
+
+
+include::{commondir}/common-testApp.adoc[]
+
+include::{commondir}/common-next.adoc[]
+
+include::{commondir}/common-helpWithMicronaut.adoc[]


### PR DESCRIPTION
Closes #42

I've configured the guide to only generate the Java and Groovy versions because there are some tests that are failing in the Kotlin guide and I'm not really sure why they fail or how to fix them.
I'll open and issue to track them. 

Once they are fixed we can revert this change: https://github.com/micronaut-projects/micronaut-guides-poc/commit/5b14c07e0884d9f3d54cd2f9e6b86167d78d96e4
