### PR TITLE
Generate guides.json with all the metadata for all the guides

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ task generateSampleProjects {
     }
     finalizedBy('generateTestScript')
     finalizedBy('generateGuidesIndex')
+    finalizedBy('generateGuidesJsonMetadata')
 }
 
 task generateTestScript {
@@ -114,5 +115,16 @@ task generateGuidesIndex {
         File output = new File("${project.buildDir}/dist/index.html")
         output.createNewFile()
         output.text = IndexGenerator.generateGuidesIndex(guides, generateSampleProjects.metadataConfigName)
+    }
+}
+
+task generateGuidesJsonMetadata {
+    group 'guides'
+    description 'Generates a guides.json with the metadata for all the guides'
+    doLast {
+        File guides = new File(generateSampleProjects.guides)
+        File output = new File("${project.buildDir}/dist/guides.json")
+        output.createNewFile()
+        output.text = IndexGenerator.generateGuidesJsonIndex(guides, generateSampleProjects.metadataConfigName)
     }
 }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
@@ -1,5 +1,7 @@
 package io.micronaut.guides
 
+import groovy.json.JsonOutput
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 
 @CompileStatic
@@ -39,4 +41,29 @@ class IndexGenerator {
 
         return index
     }
+
+    static String generateGuidesJsonIndex(File guidesFolder, String metadataConfigName) {
+        String baseURL = System.getenv("CI") ? LATEST_GUIDES_URL : ""
+
+        List<GuideMetadata> metadatas = GuideProjectGenerator.parseGuidesMetadata(guidesFolder, metadataConfigName)
+
+        List<Map> result = metadatas
+            .collect {guide -> [
+                title: guide.title,
+                intro: guide.intro,
+                authors: guide.authors,
+                tags: guide.tags,
+                category: guide.category,
+                publicationDate: guide.publicationDate.toString(),
+                slug: guide.slug,
+                options: GuideProjectGenerator.guidesOptions(guide).collect {option -> [
+                    buildTool: option.buildTool,
+                    language: option.language,
+                    url: "${baseURL}${guide.slug}-${option.buildTool.toString().toLowerCase()}-${option.language.toString().toLowerCase()}.html"
+                ]}
+            ]} as List<Map>
+
+        return JsonOutput.toJson(result)
+    }
+
 }


### PR DESCRIPTION
Closes #170

This PR generates a `build/dist/guides.json` file with all the information necessary to create dynamically the index html page for the guides.

This is the old one: https://github.com/micronaut-projects/micronaut-guides/blob/gh-pages/guides.json

I've modified the format just a little bit renaming some fields and adding the new ones. This is an example with only one guide:

```json
[

{
	"title": "Micronaut JWT Authentication",
	"intro": "Learn how to secure a Micronaut app using JWT (JSON Web Token) Authentication.",
	"authors": ["Sergio del Amo"],
	"tags": ["jwt", "security", "data", "jdbc", "graal"],
	"category": "Micronaut Security",
	"publicationDate": "2018-05-24",
	"slug": "micronaut-security-jwt",
	"options": [{
		"buildTool": "GRADLE",
		"language": "JAVA",
		"url": "https://micronaut-projects.github.io/micronaut-guides-poc/latest/micronaut-security-jwt-gradle-java.html"
	}, {
		"buildTool": "GRADLE",
		"language": "KOTLIN",
		"url": "https://micronaut-projects.github.io/micronaut-guides-poc/latest/micronaut-security-jwt-gradle-kotlin.html"
	}, {
		"buildTool": "GRADLE",
		"language": "GROOVY",
		"url": "https://micronaut-projects.github.io/micronaut-guides-poc/latest/micronaut-security-jwt-gradle-groovy.html"
	}, {
		"buildTool": "MAVEN",
		"language": "JAVA",
		"url": "https://micronaut-projects.github.io/micronaut-guides-poc/latest/micronaut-security-jwt-maven-java.html"
	}, {
		"buildTool": "MAVEN",
		"language": "KOTLIN",
		"url": "https://micronaut-projects.github.io/micronaut-guides-poc/latest/micronaut-security-jwt-maven-kotlin.html"
	}, {
		"buildTool": "MAVEN",
		"language": "GROOVY",
		"url": "https://micronaut-projects.github.io/micronaut-guides-poc/latest/micronaut-security-jwt-maven-groovy.html"
	}]
},

]
```

The `options` field contains the information regarding the build tool, language and the url to that specific guide.

