### PR TITLE
Resolve version dependencies used in asciidoctor

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -1,11 +1,16 @@
 package io.micronaut.guides
 
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import io.micronaut.context.ApplicationContext
 import io.micronaut.core.util.StringUtils
 import io.micronaut.starter.api.TestFramework
+import io.micronaut.starter.build.dependencies.Coordinate
+import io.micronaut.starter.build.dependencies.PomDependencyVersionResolver
 
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.Map.Entry
 
 @CompileStatic
 class GuideAsciidocGenerator {
@@ -97,6 +102,10 @@ class GuideAsciidocGenerator {
             text = text.replace("@testsuffix@", guidesOption.testFramework == TestFramework.SPOCK ? 'Spec' : 'Test')
 
             text = text.replace("@sourceDir@", projectName)
+
+            for (Entry<String, Coordinate> entry : getCoordinates().entrySet()) {
+                text = text.replace("@${entry.key}Version@", entry.value.version)
+            }
 
             Path destinationPath = Paths.get(destinationFolder.absolutePath, projectName + ".adoc")
             File destination = destinationPath.toFile()
@@ -281,7 +290,17 @@ class GuideAsciidocGenerator {
             case 'xml':
                 return 'xml'
             default:
-                return ''
+                return extension.toLowerCase()
         }
+    }
+
+    private static Map<String, Coordinate> getCoordinates() {
+        ApplicationContext context = ApplicationContext.run()
+        PomDependencyVersionResolver pomDependencyVersionResolver = context.getBean(PomDependencyVersionResolver)
+        Map<String, Coordinate> coordinates = pomDependencyVersionResolver.getCoordinates()
+
+        context.close()
+
+        return coordinates
     }
 }

--- a/buildSrc/src/main/java/io/micronaut/guides/DependencyLines.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/DependencyLines.java
@@ -1,5 +1,6 @@
 package io.micronaut.guides;
 
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Language;
 
@@ -98,10 +99,15 @@ public class DependencyLines {
             String groupId = attributes.getOrDefault("groupId", "io.micronaut");
             String gradleScope = Optional.ofNullable(toGradleScope(attributes, language)).orElse(SCOPE_IMPLEMENTATION);
             String mavenScope = Optional.ofNullable(toMavenScope(attributes)).orElse(SCOPE_COMPILE);
+            String version = attributes.getOrDefault("version", "");
             String callout = extractCallout(attributes);
 
             if (buildTool == BuildTool.GRADLE) {
-                dependencyLines.add(gradleScope + "(\"" + groupId + ":" + artifactId + "\")" + callout);
+                if (StringUtils.isEmpty(version)) {
+                    dependencyLines.add(gradleScope + "(\"" + groupId + ":" + artifactId + "\")" + callout);
+                } else {
+                    dependencyLines.add(gradleScope + "(\"" + groupId + ":" + artifactId + ":" + version + "\")" + callout);
+                }
             } else if (buildTool == BuildTool.MAVEN) {
                 if (gradleScope.equals(SCOPE_ANNOTATION_PROCESSOR) || gradleScope.equals(SCOPE_ANNOTATION_PROCESSOR_KAPT)) {
                     String mavenScopeAnnotationProcessor = getMavenAnnotationScopeXMLPath(language);
@@ -110,11 +116,17 @@ public class DependencyLines {
                     dependencyLines.add("<" + mavenScopeAnnotationProcessor + ">" + callout);
                     dependencyLines.add("    <groupId>" + groupId + "</groupId>");
                     dependencyLines.add("    <artifactId>" + artifactId + "</artifactId>");
+                    if (StringUtils.isNotEmpty(version)) {
+                        dependencyLines.add("    <version>" + version + "</version>");
+                    }
                     dependencyLines.add("</" + mavenScopeAnnotationProcessor + ">");
                 } else {
                     dependencyLines.add("<dependency>" + callout);
                     dependencyLines.add("    <groupId>" + groupId + "</groupId>");
                     dependencyLines.add("    <artifactId>" + artifactId + "</artifactId>");
+                    if (StringUtils.isNotEmpty(version)) {
+                        dependencyLines.add("    <version>" + version + "</version>");
+                    }
                     dependencyLines.add("    <scope>" + mavenScope + "</scope>");
                     dependencyLines.add("</dependency>");
                 }

--- a/guides/micronaut-data-access-mybatis/micronaut-data-access-mybatis.adoc
+++ b/guides/micronaut-data-access-mybatis/micronaut-data-access-mybatis.adoc
@@ -23,7 +23,7 @@ Add the following snippet to include the necessary dependencies:
 
 :dependencies:
 
-dependency:mybatis:3.5.6[groupId=org.mybatis,callout=1]
+dependency:mybatis[groupId=org.mybatis,version=@mybatisVersion@,callout=1]
 dependency:micronaut-jdbc-hikari[groupId=io.micronaut.sql,callout=2]
 dependency:h2[groupId=com.h2database,scope=runtimeOnly,callout=3]
 

--- a/guides/micronaut-email/micronaut-email.adoc
+++ b/guides/micronaut-email/micronaut-email.adoc
@@ -50,7 +50,7 @@ ____
 
 Add a dependency to AWS SES SDK:
 
-dependency:ses:2.16.18[groupId=software.amazon.awssdk]
+dependency:ses[groupId=software.amazon.awssdk,version=@sesVersion@]
 
 Create service which uses AWS Simple Email Service client to send the email
 
@@ -94,7 +94,7 @@ ____
 
 Add a dependency to SendGrid SDK:
 
-dependency:sendgrid-java:4.7.2[groupId=com.sendgrid]
+dependency:sendgrid-java[groupId=com.sendgrid,version=@sendgrid-javaVersion@]
 
 Create a service which encapsulates the integration with SendGrid. The bean will not be loaded if the
 system properties (`sendgrid.apikey`, `sendgrid.fromemail`) or environment variables (`SENDGRID_APIKEY`, `SENDGRID_FROM_EMAIL`) are not present.

--- a/guides/micronaut-multitenancy-propagation/micronaut-multitenancy-propagation.adoc
+++ b/guides/micronaut-multitenancy-propagation/micronaut-multitenancy-propagation.adoc
@@ -145,8 +145,8 @@ Add dependencies for Geb:
 
 :dependencies:
 
-dependency:geb-spock:4.1[groupId=org.gebish,scope=testImplementation]
-dependency:htmlunit-driver:2.49.1[groupId=org.seleniumhq.selenium,scope=testImplementation]
+dependency:geb-spock[groupId=org.gebish,scope=testImplementation,version=@geb-spockVersion@]
+dependency:htmlunit-driver[groupId=org.seleniumhq.selenium,scope=testImplementation,version=@htmlunit-driverVersion@]
 
 :dependencies:
 

--- a/src/docs/common/common-geb.adoc
+++ b/src/docs/common/common-geb.adoc
@@ -4,8 +4,8 @@ To use Geb, add these dependencies:
 
 :dependencies:
 
-dependency:geb-spock:4.0[groupId=org.gebish,scope=testImplementation]
-dependency:htmlunit-driver:2.47.1[groupId=org.seleniumhq.selenium,scope=testImplementation]
+dependency:geb-spock[groupId=org.gebish,scope=testImplementation,version=@geb-spockVersion@]
+dependency:htmlunit-driver[groupId=org.seleniumhq.selenium,scope=testImplementation,version=@htmlunit-driverVersion@]
 
 :dependencies:
 


### PR DESCRIPTION
This PR allows to extract external dependencies versions from the pom.xml included in the project and use them in the asciidoctor guide.

So, given the following in `pom.xml`:
```xml
...
        <dependency>
            <groupId>org.gebish</groupId>
            <artifactId>geb-spock</artifactId>
            <version>4.1</version>
        </dependency>
...
```

We can write the following in the guide:

```
dependency:geb-spock[groupId=org.gebish,scope=testImplementation,version=@geb-spockVersion@]
```

This is the `@` + `artifactId` + `Version` + `@` and it will be replaced with the value defined in the pom (that it's automatically updated via dependabot).