### PR TITLE
Add a minimumJavaVersion metadata property

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -1,15 +1,12 @@
 package io.micronaut.guides
 
-import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.NonNull
-import io.micronaut.core.annotation.Nullable
 import io.micronaut.core.util.StringUtils
 import io.micronaut.starter.api.TestFramework
 import io.micronaut.starter.build.dependencies.Coordinate
 import io.micronaut.starter.build.dependencies.PomDependencyVersionResolver
-import io.micronaut.starter.options.Language
 
 import java.nio.file.Path
 import java.nio.file.Paths

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -206,9 +206,9 @@ class GuideAsciidocGenerator {
     }
 
     @NonNull
-    static String pathByFolder(@NonNull String appName,
-                               @NonNull String fileName,
-                               String folder) {
+    private static String pathByFolder(@NonNull String appName,
+                                       @NonNull String fileName,
+                                       String folder) {
 
         String module = appName ? "${appName}/" : ""
         "${module}src/${folder}/@lang@/example/micronaut/${fileName}.@languageextension@".toString()

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideMetadata.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideMetadata.groovy
@@ -24,6 +24,8 @@ class GuideMetadata {
     boolean skipGradleTests
     boolean skipMavenTests
 
+    Integer minimumJavaVersion
+
     List<App> apps
 
     static class App {

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -54,7 +54,7 @@ class GuideProjectGenerator implements Closeable {
     }
 
     @CompileDynamic
-    static GuideMetadata parseGuideMetadata(File dir, String metadataConfigName) {
+    private static GuideMetadata parseGuideMetadata(File dir, String metadataConfigName) {
         File configFile = new File(dir, metadataConfigName)
         if (!configFile.exists()) {
             throw new GradleException("metadata file not found for ${dir.name}")
@@ -214,14 +214,14 @@ class GuideProjectGenerator implements Closeable {
         guidesOptionList
     }
 
-    static GuidesOption createGuidesOption(@NonNull BuildTool buildTool,
-                                           @NonNull Language language,
-                                           @Nullable String testFramework) {
+    private static GuidesOption createGuidesOption(@NonNull BuildTool buildTool,
+                                                   @NonNull Language language,
+                                                   @Nullable String testFramework) {
         new GuidesOption(buildTool, language, testFrameworkOption(language, testFramework))
     }
 
-    static TestFramework testFrameworkOption(@NonNull Language language,
-                                             @Nullable String testFramework) {
+    private static TestFramework testFrameworkOption(@NonNull Language language,
+                                                     @Nullable String testFramework) {
         if (testFramework != null) {
             return TestFramework.valueOf(testFramework.toUpperCase())
         }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -22,11 +22,10 @@ import java.time.LocalDate
 
 @CompileStatic
 class GuideProjectGenerator implements Closeable {
+
     public static final List<JdkVersion> JDK_VERSIONS_SUPPORTED_BY_GRAALVM = Arrays.asList(JdkVersion.JDK_8, JdkVersion.JDK_11)
-    public static final JdkVersion DEFAULT_JAVA_VERSION = JdkVersion.JDK_11
     public static final String DEFAULT_APP_NAME = 'default'
-    public static final String ENV_JDK_VERSION = 'JDK_VERSION'
-    public static final String SYS_PROP_MICRONAUT_GUIDE = 'micronaut.guide'
+
     private final ApplicationContext applicationContext
     private final GuidesGenerator guidesGenerator
 
@@ -78,6 +77,7 @@ class GuideProjectGenerator implements Closeable {
                 testFramework: config.testFramework,
                 skipGradleTests: config.skipGradleTests ?: false,
                 skipMavenTests: config.skipMavenTests ?: false,
+                minimumJavaVersion: config.minimumJavaVersion,
                 apps: config.apps.collect { it -> new App(name: it.name,
                         features: it.features,
                         applicationType: it.applicationType ? ApplicationType.valueOf(it.applicationType.toUpperCase()) : ApplicationType.DEFAULT,
@@ -94,10 +94,10 @@ class GuideProjectGenerator implements Closeable {
                   String metadataConfigName,
                   boolean merge = true,
                   File asciidocDir = null) {
+
         guidesFolder.eachDir { dir ->
             GuideMetadata metadata = parseGuideMetadata(dir, metadataConfigName)
-            boolean process = System.getProperty(SYS_PROP_MICRONAUT_GUIDE) != null ? System.getProperty(SYS_PROP_MICRONAUT_GUIDE) == metadata.slug : true
-            if (process) {
+            if (Utils.process(metadata)) {
                 generate(metadata, dir, output, merge)
                 if (asciidocDir != null) {
                     GuideAsciidocGenerator.generate(metadata, dir, asciidocDir)
@@ -110,24 +110,11 @@ class GuideProjectGenerator implements Closeable {
         "${slug}-${guidesOption.buildTool.toString()}-${guidesOption.language}"
     }
 
-    static JdkVersion parseJdkVersion() {
-        JdkVersion javaVersion = DEFAULT_JAVA_VERSION
-        if (System.getenv(ENV_JDK_VERSION)) {
-            try {
-                int mayorVersion = Integer.valueOf(System.getenv(ENV_JDK_VERSION))
-                javaVersion = JdkVersion.valueOf(mayorVersion)
-            } catch (NumberFormatException ignored) {
-                throw new GradleException("Could not parse env " + ENV_JDK_VERSION + " to JdkVersion")
-            }
-        }
-        javaVersion
-    }
-
     void generate(GuideMetadata metadata, File inputDir, File outputDir, boolean merge = true) {
         String packageAndName = "${basePackage}.${appName}"
 
         List<GuidesOption> guidesOptionList = guidesOptions(metadata)
-        JdkVersion javaVersion = parseJdkVersion()
+        JdkVersion javaVersion = Utils.parseJdkVersion()
 
         for (GuidesOption guidesOption : guidesOptionList) {
             BuildTool buildTool = guidesOption.buildTool
@@ -142,7 +129,7 @@ class GuideProjectGenerator implements Closeable {
                 List<String> appFeatures = app.features
 
                 if (guidesOption.language == Language.GROOVY ||
-                        !JDK_VERSIONS_SUPPORTED_BY_GRAALVM.contains(parseJdkVersion())) {
+                        !JDK_VERSIONS_SUPPORTED_BY_GRAALVM.contains(javaVersion)) {
                     appFeatures.remove('graalvm')
                 }
                 // Normal guide use 'default' as name, multi project guides have different modules

--- a/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
@@ -35,7 +35,8 @@ class IndexGenerator {
         }
     }
 
-    static void save(String templateText, String filename, File buildDir, List<GuideMetadata> metadatas, String title = 'Micronaut Guides') {
+    private static void save(String templateText, String filename, File buildDir,
+                             List<GuideMetadata> metadatas, String title = 'Micronaut Guides') {
         String text = indexText(templateText, metadatas, title)
         Path path = Paths.get(buildDir.absolutePath, filename)
         File output = path.toFile()
@@ -43,7 +44,7 @@ class IndexGenerator {
         output.text = text
     }
 
-    static String indexText(String templateText, List<GuideMetadata> metadatas, String title) {
+    private static String indexText(String templateText, List<GuideMetadata> metadatas, String title) {
         boolean singleGuide = metadatas.size() == 1
 
         String baseURL = System.getenv("CI") ? LATEST_GUIDES_URL : ""
@@ -71,7 +72,7 @@ class IndexGenerator {
         text
     }
 
-    static String renderMetadatas(String baseURL, Category cat, List<GuideMetadata> metadatas, boolean singleGuide) {
+    private static String renderMetadatas(String baseURL, Category cat, List<GuideMetadata> metadatas, boolean singleGuide) {
         String index = ''
         int count = 0
         List<GuideMetadata> filteredMetadatas = System.getProperty('micronaut.guide') ?
@@ -119,12 +120,13 @@ class IndexGenerator {
         index
     }
 
-    static String guideLink(String baseURL, GuideMetadata metadata, GuidesOption guidesOption, String title = null) {
+    private static String guideLink(String baseURL, GuideMetadata metadata,
+                                    GuidesOption guidesOption, String title = null) {
         String folder = GuideProjectGenerator.folderName(metadata.slug, guidesOption)
         "<a href='${baseURL}${folder}.html'>${title ? title : (guidesOption.buildTool.toString() + ' - ' + guidesOption.language)}</a>"
     }
 
-    static String table(String baseURL, GuideMetadata metadata) {
+    private static String table(String baseURL, GuideMetadata metadata) {
         String readCopy = 'Read'
         List<GuidesOption> guidesOptionList = GuideProjectGenerator.guidesOptions(metadata)
         String kotlinImg = '<img src="./images/kotlin.svg" width="60" alt="Kotlin"/>'
@@ -181,7 +183,8 @@ class IndexGenerator {
         tableHtml
     }
 
-    static String cell(String baseURL, GuideMetadata metadata, BuildTool buildTool, Language language, List<GuidesOption> guidesOptionList) {
+    private static String cell(String baseURL, GuideMetadata metadata, BuildTool buildTool,
+                               Language language, List<GuidesOption> guidesOptionList) {
         String tableHtml = "<td>"
         GuidesOption guidesOption = guidesOptionList.find {GuidesOption option -> option.buildTool == buildTool&& option.language == language }
         if (guidesOption) {
@@ -193,7 +196,7 @@ class IndexGenerator {
         tableHtml
     }
 
-    static String imageForCategory(Category cat) {
+    private static String imageForCategory(Category cat) {
         switch (cat) {
             case Category.GCP:
                 return 'https://micronaut.io/wp-content/uploads/2021/02/Googlecloud.svg'
@@ -234,7 +237,7 @@ class IndexGenerator {
 
     }
 
-    static String category(Category cat) {
+    private static String category(Category cat) {
         String html = "<div class='category'>"
         html += '<div class="inner">'
         html += '<img width="100" style="margin-bottom: 30px" src="' + imageForCategory(cat) + '"/>'

--- a/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
@@ -14,7 +14,7 @@ class IndexGenerator {
 
     private static final String LATEST_GUIDES_URL = "https://guides.micronaut.io/latest/"
 
-    static String generateGuidesIndex(File template, File guidesFolder, File buildDir, String metadataConfigName) {
+    static void generateGuidesIndex(File template, File guidesFolder, File buildDir, String metadataConfigName) {
         List<GuideMetadata> metadatas = GuideProjectGenerator.parseGuidesMetadata(guidesFolder, metadataConfigName)
 
         String templateText = template.text
@@ -127,7 +127,6 @@ class IndexGenerator {
     }
 
     private static String table(String baseURL, GuideMetadata metadata) {
-        String readCopy = 'Read'
         List<GuidesOption> guidesOptionList = GuideProjectGenerator.guidesOptions(metadata)
         String kotlinImg = '<img src="./images/kotlin.svg" width="60" alt="Kotlin"/>'
         String groovyImg = '<img src="./images/groovy.svg" width="60" alt="Groovy"/>'
@@ -141,9 +140,9 @@ class IndexGenerator {
 <tr>
 <th></th>
 """
-            tableHtml += "<th>${javaImg}</th>"
-            tableHtml += "<th>${kotlinImg}</th>"
-            tableHtml += "<th>${groovyImg}</th>"
+        tableHtml += "<th>${javaImg}</th>"
+        tableHtml += "<th>${kotlinImg}</th>"
+        tableHtml += "<th>${groovyImg}</th>"
         tableHtml += """\
 </tr>
 </thead>

--- a/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
@@ -75,8 +75,8 @@ class IndexGenerator {
     private static String renderMetadatas(String baseURL, Category cat, List<GuideMetadata> metadatas, boolean singleGuide) {
         String index = ''
         int count = 0
-        List<GuideMetadata> filteredMetadatas = System.getProperty('micronaut.guide') ?
-                metadatas.findAll { it.slug == System.getProperty('micronaut.guide') } :
+        List<GuideMetadata> filteredMetadatas = Utils.singleGuide() ?
+                metadatas.findAll { it.slug == Utils.singleGuide() } :
                 metadatas
         if (!filteredMetadatas) {
             return index

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -6,7 +6,6 @@ import io.micronaut.starter.options.BuildTool
 @CompileStatic
 class TestScriptGenerator {
 
-
     public static final String GITHUB_WORKFLOW_JAVA_CI = 'Java CI'
     public static final String ENV_GITHUB_WORKFLOW = 'GITHUB_WORKFLOW'
 

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -37,10 +37,8 @@ exit 0
         changedFiles.any { str -> str.contains("pom.xml") }
     }
 
-    private static boolean shouldSkip(String slug, List<String> guidesChanged) {
-        return  (System.getProperty(GuideProjectGenerator.SYS_PROP_MICRONAUT_GUIDE) != null) ?
-                !(System.getProperty(GuideProjectGenerator.SYS_PROP_MICRONAUT_GUIDE) == slug) :
-                !guidesChanged.contains(slug)
+    private static boolean shouldSkip(GuideMetadata metadata, List<String> guidesChanged) {
+        return !Utils.process(metadata) || !guidesChanged.contains(metadata.slug)
     }
 
     static String generateScript(File guidesFolder, String metadataConfigName, boolean stopIfFailure, String[] changedFiles) {
@@ -55,12 +53,12 @@ EXIT_STATUS=0
         boolean forceExecuteEveryTest = changesMicronautVersion(changedFiles) ||
                 changesDependencies(changedFiles, slugsChanged) ||
                 (System.getenv(ENV_GITHUB_WORKFLOW) && System.getenv(ENV_GITHUB_WORKFLOW) != GITHUB_WORKFLOW_JAVA_CI)
-        if (System.getProperty(GuideProjectGenerator.SYS_PROP_MICRONAUT_GUIDE) != null) {
+        if (Utils.singleGuide()) {
             forceExecuteEveryTest = false
         }
         List<GuideMetadata> metadatas = GuideProjectGenerator.parseGuidesMetadata(guidesFolder, metadataConfigName)
         for (GuideMetadata metadata : metadatas) {
-            boolean skip = shouldSkip(metadata.slug, slugsChanged)
+            boolean skip = shouldSkip(metadata, slugsChanged)
             if (!forceExecuteEveryTest && skip) {
                 continue
             }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -18,7 +18,7 @@ exit 0
 '''
     }
 
-    static List<String> guidesChanged(String[] changedFiles) {
+    private static List<String> guidesChanged(String[] changedFiles) {
         changedFiles.findAll { path ->
             path.startsWith('guides')
         }.collect { path ->
@@ -27,18 +27,18 @@ exit 0
         }.unique()
     }
 
-    static boolean changesMicronautVersion(String[] changedFiles) {
+    private static boolean changesMicronautVersion(String[] changedFiles) {
         changedFiles.any { str -> str.contains("version.txt") }
     }
 
-    static boolean changesDependencies(String[] changedFiles, List<String> changedGuides) {
+    private static boolean changesDependencies(String[] changedFiles, List<String> changedGuides) {
         if (changedGuides) {
             return false
         }
         changedFiles.any { str -> str.contains("pom.xml") }
     }
 
-    static boolean shouldSkip(String slug, List<String> guidesChanged) {
+    private static boolean shouldSkip(String slug, List<String> guidesChanged) {
         return  (System.getProperty(GuideProjectGenerator.SYS_PROP_MICRONAUT_GUIDE) != null) ?
                 !(System.getProperty(GuideProjectGenerator.SYS_PROP_MICRONAUT_GUIDE) == slug) :
                 !guidesChanged.contains(slug)
@@ -111,7 +111,7 @@ fi
         bashScript
     }
 
-    static String scriptForFolder(String nestedFolder, String folder, boolean stopIfFailure, BuildTool buildTool) {
+    private static String scriptForFolder(String nestedFolder, String folder, boolean stopIfFailure, BuildTool buildTool) {
         String bashScript = """\
 cd ${nestedFolder}
 echo "-------------------------------------------------"

--- a/buildSrc/src/main/groovy/io/micronaut/guides/ThemeProcessor.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/ThemeProcessor.groovy
@@ -16,8 +16,7 @@ class ThemeProcessor {
 '''
         String sectionbody = '<div class="sectionbody">'
         for (GuideMetadata metadata : metadatas) {
-            if (System.getProperty('micronaut.guide') != null &&
-                    System.getProperty('micronaut.guide') != metadata.slug) {
+            if (!Utils.process(metadata)) {
                 continue
             }
             List<GuidesOption> guidesOptionList = GuideProjectGenerator.guidesOptions(metadata)

--- a/buildSrc/src/main/groovy/io/micronaut/guides/ThemeProcessor.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/ThemeProcessor.groovy
@@ -1,7 +1,8 @@
 package io.micronaut.guides
 
 class ThemeProcessor {
-    static String applyThemes(File template, File dist, File guidesFolder, String metadataConfigName) {
+
+    static void applyThemes(File template, File dist, File guidesFolder, String metadataConfigName) {
         String templateText = template.text
         List<GuideMetadata> metadatas = GuideProjectGenerator.parseGuidesMetadata(guidesFolder, metadataConfigName)
         String tocStart = '''\

--- a/buildSrc/src/main/groovy/io/micronaut/guides/Utils.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/Utils.groovy
@@ -1,8 +1,10 @@
 package io.micronaut.guides
 
+import groovy.transform.CompileStatic
 import io.micronaut.starter.options.JdkVersion
 import org.gradle.api.GradleException
 
+@CompileStatic
 class Utils {
 
     private static final String SYS_PROP_MICRONAUT_GUIDE = 'micronaut.guide'

--- a/buildSrc/src/main/groovy/io/micronaut/guides/Utils.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/Utils.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.guides
+
+import io.micronaut.starter.options.JdkVersion
+import org.gradle.api.GradleException
+
+class Utils {
+
+    private static final String SYS_PROP_MICRONAUT_GUIDE = 'micronaut.guide'
+    private static final String ENV_JDK_VERSION = 'JDK_VERSION'
+    private static final JdkVersion DEFAULT_JAVA_VERSION = JdkVersion.JDK_11
+
+    static String singleGuide() {
+        System.getProperty(SYS_PROP_MICRONAUT_GUIDE)
+    }
+
+    static boolean process(GuideMetadata metadata) {
+
+        boolean processGuide = singleGuide() == null || singleGuide() == metadata.slug
+        boolean jdk = metadata.minimumJavaVersion == null || parseJdkVersion().majorVersion() >= metadata.minimumJavaVersion
+
+        return processGuide && jdk
+    }
+
+    static JdkVersion parseJdkVersion() {
+        JdkVersion javaVersion = DEFAULT_JAVA_VERSION
+        if (System.getenv(ENV_JDK_VERSION)) {
+            try {
+                int majorVersion = Integer.valueOf(System.getenv(ENV_JDK_VERSION))
+                javaVersion = JdkVersion.valueOf(majorVersion)
+            } catch (NumberFormatException ignored) {
+                throw new GradleException("Could not parse env " + ENV_JDK_VERSION + " to JdkVersion")
+            }
+        }
+        javaVersion
+    }
+}

--- a/buildSrc/src/main/java/io/micronaut/guides/GuidesOption.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/GuidesOption.java
@@ -1,7 +1,7 @@
 package io.micronaut.guides;
 
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.starter.api.TestFramework;
 import io.micronaut.starter.options.BuildTool;
 import io.micronaut.starter.options.Language;

--- a/buildSrc/src/main/java/io/micronaut/guides/feature/S3.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/S3.java
@@ -7,8 +7,6 @@ import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
 import io.micronaut.starter.feature.aws.AwsV2Sdk;
-import io.micronaut.starter.feature.function.awslambda.AwsLambda;
-import io.micronaut.starter.feature.other.HttpClient;
 
 import javax.inject.Provider;
 import javax.inject.Singleton;


### PR DESCRIPTION
The https://github.com/micronaut-projects/micronaut-guides/pull/275 PR builds are failing in JDK 8 because fnproject.io only supports JDK 11+. This PR adds a `minimumJavaVersion` property that will allow skipping JDK 8 tests