### PR TITLE
fix: incorrect test.sh when using sys prop

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -38,6 +38,9 @@ exit 0
     }
 
     private static boolean shouldSkip(GuideMetadata metadata, List<String> guidesChanged) {
+        if (Utils.singleGuide()) {
+            return !Utils.process(metadata)
+        }
         return !Utils.process(metadata) || !guidesChanged.contains(metadata.slug)
     }
 


### PR DESCRIPTION
This [commit](https://github.com/micronaut-projects/micronaut-guides/commit/1ab220d8d68d62a55096673bbb134acdaaf3b8b6) broke single guide `test.sh` generation. 

./gradlew -Dmicronaut.guide=micronaut-email build

Before this PR:

```bash
#!/usr/bin/env bash
set -e

FAILED_PROJECTS=()
EXIT_STATUS=0

if [ ${#FAILED_PROJECTS[@]} -ne 0 ]; then
  echo ""
  echo "-------------------------------------------------"
  echo "Projects with errors:"
  for p in `echo ${FAILED_PROJECTS[@]}`; do
    echo "  $p"
  done;
  echo "-------------------------------------------------"
  exit 1
else
  exit 0
fi
```

With this PR:

```bash
sdelamo@ig11 micronaut-guides % cat build/code/test.sh
#!/usr/bin/env bash
set -e

FAILED_PROJECTS=()
EXIT_STATUS=0
cd micronaut-email-gradle-java
echo "-------------------------------------------------"
echo "Executing 'micronaut-email-gradle-java' tests"
./gradlew -q test || EXIT_STATUS=$?
cd ..
if [ $EXIT_STATUS -ne 0 ]; then
  FAILED_PROJECTS=("${FAILED_PROJECTS[@]}" micronaut-email-gradle-java)
  echo "'micronaut-email-gradle-java' tests failed => exit $EXIT_STATUS"
fi
EXIT_STATUS=0
cd micronaut-email-gradle-groovy
echo "-------------------------------------------------"
echo "Executing 'micronaut-email-gradle-groovy' tests"
./gradlew -q test || EXIT_STATUS=$?
cd ..
if [ $EXIT_STATUS -ne 0 ]; then
  FAILED_PROJECTS=("${FAILED_PROJECTS[@]}" micronaut-email-gradle-groovy)
  echo "'micronaut-email-gradle-groovy' tests failed => exit $EXIT_STATUS"
fi
EXIT_STATUS=0
cd micronaut-email-maven-java
echo "-------------------------------------------------"
echo "Executing 'micronaut-email-maven-java' tests"
./mvnw -q test || EXIT_STATUS=$?
cd ..
if [ $EXIT_STATUS -ne 0 ]; then
  FAILED_PROJECTS=("${FAILED_PROJECTS[@]}" micronaut-email-maven-java)
  echo "'micronaut-email-maven-java' tests failed => exit $EXIT_STATUS"
fi
EXIT_STATUS=0
cd micronaut-email-maven-groovy
echo "-------------------------------------------------"
echo "Executing 'micronaut-email-maven-groovy' tests"
./mvnw -q test || EXIT_STATUS=$?
cd ..
if [ $EXIT_STATUS -ne 0 ]; then
  FAILED_PROJECTS=("${FAILED_PROJECTS[@]}" micronaut-email-maven-groovy)
  echo "'micronaut-email-maven-groovy' tests failed => exit $EXIT_STATUS"
fi
EXIT_STATUS=0

if [ ${#FAILED_PROJECTS[@]} -ne 0 ]; then
  echo ""
  echo "-------------------------------------------------"
  echo "Projects with errors:"
  for p in `echo ${FAILED_PROJECTS[@]}`; do
    echo "  $p"
  done;
  echo "-------------------------------------------------"
  exit 1
else
  exit 0
fi
```