### PR TITLE
Force run all tests with changes in buildSrc

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -37,6 +37,10 @@ exit 0
         changedFiles.any { str -> str.contains("pom.xml") }
     }
 
+    private static boolean changesBuildScr(String[] changedFiles) {
+        changedFiles.any { str -> str.contains('buildSrc') }
+    }
+
     private static boolean shouldSkip(GuideMetadata metadata, List<String> guidesChanged) {
         if (Utils.singleGuide()) {
             return !Utils.process(metadata)
@@ -54,8 +58,9 @@ EXIT_STATUS=0
 '''
         List<String> slugsChanged = guidesChanged(changedFiles)
         boolean forceExecuteEveryTest = changesMicronautVersion(changedFiles) ||
-                changesDependencies(changedFiles, slugsChanged) ||
-                (System.getenv(ENV_GITHUB_WORKFLOW) && System.getenv(ENV_GITHUB_WORKFLOW) != GITHUB_WORKFLOW_JAVA_CI)
+                                        changesDependencies(changedFiles, slugsChanged) ||
+                                        changesBuildScr(changedFiles) ||
+                                        (System.getenv(ENV_GITHUB_WORKFLOW) && System.getenv(ENV_GITHUB_WORKFLOW) != GITHUB_WORKFLOW_JAVA_CI)
         if (Utils.singleGuide()) {
             forceExecuteEveryTest = false
         }
@@ -81,7 +86,7 @@ EXIT_STATUS=0
                     bashScript += """\
 cd ${folder}
 """
-                    for (GuideMetadata.App app: metadata.apps) {
+                    for (GuideMetadata.App app : metadata.apps) {
                         bashScript += scriptForFolder(app.name, folder + '/' + app.name, stopIfFailure, buildTool)
                     }
                     bashScript += """\


### PR DESCRIPTION
This PR forces the execution of all the tests when there is a change in `buildSrc` directory, so we can be sure that we haven't break any guide with the change.