### PR TITLE
Upgrade to GraalVM 21.2.0

### DIFF
--- a/src/docs/common/common-install-graalvm-sdkman.adoc
+++ b/src/docs/common/common-install-graalvm-sdkman.adoc
@@ -3,20 +3,23 @@ The easiest way to install GraalVM is to use https://sdkman.io/[SDKMan.io].
 [source, bash]
 .Java 8
 ----
-$ sdk install java 21.1.0.r8-grl
+$ sdk install java 21.2.0.r8-grl
 ----
 
 [source, bash]
 .Java 11
 ----
-$ sdk install java 21.1.0.r11-grl
+$ sdk install java 21.2.0.r11-grl
 ----
 
 [source, bash]
 .Java 16
 ----
-$ sdk install java 21.1.0.r16-grl
+$ sdk install java 21.2.0.r16-grl
 ----
+
+NOTE: GraalVM 21 will be the last release that supports Java 8 and, even if it's supported now, not all bugs are being
+backported from the Java 11/16 versions. Our recommended approach is to use GraalVM JDK11 even if you still use Java 8 for your project.
 
 You need to install the `native-image` component which is not installed by default.
 


### PR DESCRIPTION
Keeping it as draft because only the Java 11 version was released last week. Java 8 & 16 are expected to be released this week.