### PR TITLE
Show diff link for users with existing apps

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -95,7 +95,9 @@ class GuideAsciidocGenerator {
                     lines << line
                 }
             }
+
             File versionFile = Paths.get(destinationFolder.absolutePath, "../../../version.txt").toFile()
+
             String text = lines.join('\n')
             text = text.replace("{githubSlug}", metadata.slug)
             text = text.replace("@language@", StringUtils.capitalize(guidesOption.language.toString()))
@@ -108,7 +110,6 @@ class GuideAsciidocGenerator {
             text = text.replace("@authors@", metadata.authors.join(', '))
             text = text.replace("@languageextension@", guidesOption.language.extension)
             text = text.replace("@testsuffix@", guidesOption.testFramework == TestFramework.SPOCK ? 'Spec' : 'Test')
-
             text = text.replace("@sourceDir@", projectName)
             text = text.replace("@api@", 'https://docs.micronaut.io/latest/api')
 
@@ -312,10 +313,10 @@ class GuideAsciidocGenerator {
         extractFromParametersLine(line, 'tag')
     }
 
-    private static List<String> extractTags(String line, String tagSeparator = '|') {
+    private static List<String> extractTags(String line) {
         String attributeValue = extractFromParametersLine(line, 'tags')
         if (attributeValue) {
-            return attributeValue.tokenize(tagSeparator)
+            return attributeValue.tokenize('|')
         }
 
         [extractTagName(line)].findAll { it }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -334,7 +334,7 @@ class GuideAsciidocGenerator {
         }
         featureNames.removeAll excludedFeatureNames
 
-        String url = 'https://micronaut.io/launch?' +
+        String link = 'https://micronaut.io/launch?' +
                 featureNames.collect {'features=' + it }.join('&') +
                 '&lang=' + guidesOption.language.name() +
                 '&build=' + guidesOption.buildTool.name() +
@@ -342,8 +342,11 @@ class GuideAsciidocGenerator {
                 '&name=' + (appName == DEFAULT_APP_NAME ? 'micronautguide' : appName) +
                 '&type=' + app.applicationType.name() +
                 '&package=example.micronaut' +
-                '&activity=diff'
-        url + '[view the dependency and configuration changes from the specified features, window="_blank"]'
+                '&activity=diff' +
+                '[view the dependency and configuration changes from the specified features, window="_blank"]'
+
+        "NOTE: If you have an existing Micronaut application and want to add the functionality described here, you can " +
+        link + " and apply those changes to your application."
     }
 
     private static String extractAppName(String line) {

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -1,30 +1,37 @@
 asciidoctorj {
+
     version '2.4.3'
+
     modules {
         diagram {
             version '1.5.18'
         }
     }
-    options doctype: "book", ruby: "erubis"
+
+    options doctype: "book",
+            ruby   : "erubis"
+
     docExtensions {
-        block_macro (name: 'gist') {
-            parent, target, attributes ->
-                String content = """<div class="content">
+        block_macro(name: 'gist') { parent, target, attributes ->
+
+            String content = """\
+<div class="content">
 <script src="https://gist.github.com/${target}.js"></script>
 </div>"""
-                createBlock(parent, "pass", [content], attributes, config);
+            createBlock(parent, "pass", [content], attributes, config)
         }
     }
-    attributes "sourcedir": "build/code",
-            "commondir": "src/docs/common",
-            "source-highlighter": "coderay",
-            "toc": "left",
-            "toclevels": 2,
-            "sectnums": "",
-            "idprefix": "",
-            "idseparator": "-",
-            "icons": "font",
-            "imagesdir": "images",
-            "nofooter": true,
-            "project-version": "$project.version"
+
+    attributes "sourcedir"          : "build/code",
+               "commondir"          : "src/docs/common",
+               "source-highlighter" : "coderay",
+               "toc"                : "left",
+               "toclevels"          : 2,
+               "sectnums"           : "",
+               "idprefix"           : "",
+               "idseparator"        : "-",
+               "icons"              : "font",
+               "imagesdir"          : "images",
+               "nofooter"           : true,
+               "project-version"    : "$project.version"
 }

--- a/guides/micronaut-database-authentication-provider/micronaut-database-authentication-provider.adoc
+++ b/guides/micronaut-database-authentication-provider/micronaut-database-authentication-provider.adoc
@@ -23,9 +23,7 @@ If you use Micronaut Launch, select Micronaut Application as application type an
 
 include::{commondir}/common-default-package.adoc[]
 
-NOTE: If you have an existing Micronaut application and want to add the functionality described here, you can
 diffLink:[featureExcludes=spring-security-crypto]
-and apply those changes to your application.
 
 include::{commondir}/common-annotationprocessors.adoc[]
 

--- a/guides/micronaut-database-authentication-provider/micronaut-database-authentication-provider.adoc
+++ b/guides/micronaut-database-authentication-provider/micronaut-database-authentication-provider.adoc
@@ -23,6 +23,10 @@ If you use Micronaut Launch, select Micronaut Application as application type an
 
 include::{commondir}/common-default-package.adoc[]
 
+NOTE: If you have an existing Micronaut application and want to add the functionality described here, you can
+diffLink:[featureExcludes=spring-security-crypto]
+and apply those changes to your application.
+
 include::{commondir}/common-annotationprocessors.adoc[]
 
 The generated `application.yml` includes configuration settings that enable security:


### PR DESCRIPTION
Adds a `diffLink` macro that will open a diff link of the form `https://micronaut.io/launch?features=...&lang=...&build=...&test=...&name=...&type=...&package=example.micronaut&activity=diff` so users can apply the changes resulting from the selected features to an existing application.

![difflink](https://user-images.githubusercontent.com/67817/127393044-1f95a2b8-50e8-43d4-a433-3acd8bad9cd7.png)

Fixes https://github.com/micronaut-projects/micronaut-guides/issues/375