### PR TITLE
remove javadoc from java guide

### DIFF
--- a/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/GameController.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/GameController.java
@@ -17,9 +17,6 @@ import static io.micronaut.http.HttpStatus.NO_CONTENT;
 import static io.micronaut.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static io.micronaut.http.MediaType.TEXT_PLAIN;
 
-/**
- * Endpoints called by the front end using Ajax.
- */
 @Controller("/game") // <1>
 @ExecuteOn(TaskExecutors.IO) // <2>
 class GameController {
@@ -30,13 +27,6 @@ class GameController {
         this.gameReporter = gameReporter;
     }
 
-    /**
-     * Start a new game.
-     *
-     * @param b black's name
-     * @param w white's name
-     * @return the id of the game
-     */
     @Post(value = "/start", // <3>
           consumes = APPLICATION_FORM_URLENCODED, // <4>
           produces = TEXT_PLAIN) // <5>
@@ -47,15 +37,6 @@ class GameController {
         return gameReporter.game(game.getId(), game).map(gameDTO -> game.getId()); // <9>
     }
 
-    /**
-     * Record a move.
-     *
-     * @param gameId the <code>Game</code> id
-     * @param player b or w
-     * @param move the current move
-     * @param fen the current FEN string
-     * @param pgn the current PGN string
-     */
     @Post(value = "/move/{gameId}", // <10>
           consumes = APPLICATION_FORM_URLENCODED) // <11>
     @Status(CREATED) // <12>
@@ -69,12 +50,6 @@ class GameController {
         gameReporter.gameState(gameId, gameState).subscribe(); // <13>
     }
 
-    /**
-     * Record a checkmate.
-     *
-     * @param gameId the <code>Game</code> id
-     * @param player b or w
-     */
     @Post("/checkmate/{gameId}/{player}") // <14>
     @Status(NO_CONTENT) // <15>
     void checkmate(@PathVariable String gameId,
@@ -83,11 +58,6 @@ class GameController {
         gameReporter.game(gameId, game).subscribe(); // <16>
     }
 
-    /**
-     * Record a draw.
-     *
-     * @param gameId the <code>Game</code> id
-     */
     @Post("/draw/{gameId}") // <17>
     @Status(NO_CONTENT) // <18>
     void draw(@PathVariable String gameId) {

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/GameReporter.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/GameReporter.java
@@ -11,25 +11,11 @@ import reactor.core.publisher.Mono;
 @KafkaClient // <1>
 public interface GameReporter {
 
-    /**
-     * Send a game indicating the start or finish (checkmate or draw).
-     *
-     * @param gameId the game id
-     * @param game the game DTO
-     * @return a reactive Single to trigger non-blocking send
-     */
     @Topic("chessGame") // <2>
     @NonNull
     Mono<GameDTO> game(@NonNull @KafkaKey String gameId, // <3> <4>
                        @NonNull GameDTO game);
 
-    /**
-     * Send a game move.
-     *
-     * @param gameId the game id
-     * @param gameState the current state
-     * @return a reactive Single to trigger non-blocking send
-     */
     @Topic("chessGameState") // <2>
     @NonNull
     Mono<GameStateDTO> gameState(@NonNull @KafkaKey String gameId, // <3> <4>

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
@@ -11,9 +11,6 @@ import javax.validation.constraints.Size;
 
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
 
-/**
- * DTO for <code>Game</code> entity.
- */
 @Introspected // <1>
 @JsonTypeInfo(use = NAME, property = "_className") // <2>
 public class GameDTO {
@@ -33,15 +30,6 @@ public class GameDTO {
     @Size(max = 1)
     private final String winner;
 
-    /**
-     * Full constructor.
-     *
-     * @param id the game id
-     * @param blackName the black player name
-     * @param whiteName the white player name
-     * @param draw <code>true</code> if the game ended in a draw
-     * @param winner <code>null</code> if a new game or the game ended in a draw, "b", or "w" to indicate the winner
-     */
     @Creator // <3>
     public GameDTO(@NonNull String id,
                    @Nullable String blackName,
@@ -55,26 +43,12 @@ public class GameDTO {
         this.winner = winner;
     }
 
-    /**
-     * Constructor for a new game.
-     *
-     * @param id the game id
-     * @param blackName the black player name
-     * @param whiteName the white player name
-     */
     public GameDTO(@NonNull String id,
                    @NonNull String blackName,
                    @NonNull String whiteName) {
         this(id, blackName, whiteName, false, null);
     }
 
-    /**
-     * Constructor for declaring a draw or winner.
-     *
-     * @param id the game id
-     * @param draw <code>true</code> if the game ended in a draw
-     * @param winner <code>null</code> if the game ended in a draw, "b", or "w" to indicate the winner
-     */
     public GameDTO(@NonNull String id,
                    boolean draw,
                    @Nullable String winner) {

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/GameService.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/GameService.java
@@ -13,9 +13,6 @@ import javax.inject.Singleton;
 import javax.transaction.Transactional;
 import java.util.UUID;
 
-/**
- * Service to encapsulate business logic.
- */
 @Singleton
 @Transactional
 public class GameService {
@@ -31,12 +28,6 @@ public class GameService {
         this.gameStateRepository = gameStateRepository;
     }
 
-    /**
-     * Create a new <code>Game</code> and persist it.
-     *
-     * @param gameDTO the <code>Game</code> data
-     * @return the game
-     */
     public Game newGame(GameDTO gameDTO) {
         log.debug("New game {}, black: {}, white: {}",
                 gameDTO.getId(), gameDTO.getBlackName(), gameDTO.getWhiteName());
@@ -45,11 +36,6 @@ public class GameService {
         return gameRepository.save(game);
     }
 
-    /**
-     * Persist a game move as a <code>GameState</code>.
-     *
-     * @param gameStateDTO the <code>GameState</code> data
-     */
     public void newGameState(GameStateDTO gameStateDTO) {
         Game game = findGame(gameStateDTO.getGameId());
         GameState gameState = new GameState(
@@ -59,11 +45,6 @@ public class GameService {
         gameStateRepository.save(gameState);
     }
 
-    /**
-     * Record that a game ended in checkmate.
-     *
-     * @param gameDTO the <code>Game</code> data
-     */
     public void checkmate(GameDTO gameDTO) {
         log.debug("Game {} ended with winner: {}",
                 gameDTO.getId(), gameDTO.getWinner());
@@ -72,11 +53,6 @@ public class GameService {
         gameRepository.update(game);
     }
 
-    /**
-     * Record that a game ended in a draw.
-     *
-     * @param gameDTO the <code>Game</code> data
-     */
     public void draw(GameDTO gameDTO) {
         log.debug("Game {} ended in a draw", gameDTO.getId());
         Game game = findGame(gameDTO.getId());

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
@@ -11,9 +11,6 @@ import javax.validation.constraints.Size;
 
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
 
-/**
- * DTO for <code>Game</code> entity.
- */
 @Introspected // <1>
 @JsonTypeInfo(use = NAME, property = "_className") // <2>
 public class GameDTO {
@@ -33,15 +30,6 @@ public class GameDTO {
     @Size(max = 1)
     private final String winner;
 
-    /**
-     * Full constructor.
-     *
-     * @param id the game id
-     * @param blackName the black player name
-     * @param whiteName the white player name
-     * @param draw <code>true</code> if the game ended in a draw
-     * @param winner <code>null</code> if a new game or the game ended in a draw, "b", or "w" to indicate the winner
-     */
     @Creator // <3>
     public GameDTO(@NonNull String id,
                    @Nullable String blackName,
@@ -55,26 +43,12 @@ public class GameDTO {
         this.winner = winner;
     }
 
-    /**
-     * Constructor for a new game.
-     *
-     * @param id the game id
-     * @param blackName the black player name
-     * @param whiteName the white player name
-     */
     public GameDTO(@NonNull String id,
                    @NonNull String blackName,
                    @NonNull String whiteName) {
         this(id, blackName, whiteName, false, null);
     }
 
-    /**
-     * Constructor for declaring a draw or winner.
-     *
-     * @param id the game id
-     * @param draw <code>true</code> if the game ended in a draw
-     * @param winner <code>null</code> if the game ended in a draw, "b", or "w" to indicate the winner
-     */
     public GameDTO(@NonNull String id,
                    boolean draw,
                    @Nullable String winner) {

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
@@ -9,9 +9,6 @@ import javax.validation.constraints.Size;
 
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
 
-/**
- * DTO for <code>GameState</code> entity.
- */
 @Introspected // <1>
 @JsonTypeInfo(use = NAME, property = "_className") // <2>
 public class GameStateDTO {

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/entity/Game.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/entity/Game.java
@@ -13,9 +13,6 @@ import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-/**
- * Represents a chess game.
- */
 @MappedEntity("GAME")
 public class Game {
 

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/entity/GameState.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/entity/GameState.java
@@ -14,9 +14,6 @@ import java.util.UUID;
 
 import static io.micronaut.data.annotation.Relation.Kind.MANY_TO_ONE;
 
-/**
- * Represents the state of a chess game after a move.
- */
 @MappedEntity("GAME_STATE")
 public class GameState {
 
@@ -35,10 +32,12 @@ public class GameState {
     @NotNull
     private final String player;
 
+    // https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
     @Size(max = 100)
     @NotNull
     private final String fen;
 
+    // https://en.wikipedia.org/wiki/Portable_Game_Notation
     @NotNull
     private final String pgn;
 
@@ -46,14 +45,6 @@ public class GameState {
     @NotNull
     private final String move;
 
-    /**
-     * @param id the ID
-     * @param game the game
-     * @param player b or w
-     * @param move the current move
-     * @param fen https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
-     * @param pgn https://en.wikipedia.org/wiki/Portable_Game_Notation
-     */
     public GameState(@NonNull UUID id,
                      @NonNull Game game,
                      @NonNull String player,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/GameRepository.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/GameRepository.java
@@ -5,8 +5,5 @@ import io.micronaut.data.repository.CrudRepository;
 
 import java.util.UUID;
 
-/**
- * <code>Game</code> entity repository.
- */
 public interface GameRepository extends CrudRepository<Game, UUID> {
 }

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/GameStateRepository.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/GameStateRepository.java
@@ -11,9 +11,6 @@ import java.util.UUID;
 
 import static io.micronaut.data.annotation.Join.Type.FETCH;
 
-/**
- * <code>GameState</code> entity repository.
- */
 public interface GameStateRepository extends CrudRepository<GameState, UUID> {
 
     @Override

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/H2GameRepository.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/H2GameRepository.java
@@ -7,9 +7,6 @@ import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import static io.micronaut.context.env.Environment.DEVELOPMENT;
 import static io.micronaut.data.model.query.builder.sql.Dialect.H2;
 
-/**
- * H2 (local dev) <code>Game</code> entity repository.
- */
 @Primary
 @JdbcRepository(dialect = H2) // <1>
 @Requires(env = DEVELOPMENT) // <2>

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/H2GameStateRepository.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/H2GameStateRepository.java
@@ -7,9 +7,6 @@ import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import static io.micronaut.context.env.Environment.DEVELOPMENT;
 import static io.micronaut.data.model.query.builder.sql.Dialect.H2;
 
-/**
- * H2 (local dev) <code>GameState</code> entity repository.
- */
 @Primary
 @JdbcRepository(dialect = H2)
 @Requires(env = DEVELOPMENT)

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/OracleGameRepository.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/OracleGameRepository.java
@@ -8,9 +8,6 @@ import static io.micronaut.context.env.Environment.ORACLE_CLOUD;
 import static io.micronaut.context.env.Environment.TEST;
 import static io.micronaut.data.model.query.builder.sql.Dialect.ORACLE;
 
-/**
- * Oracle <code>Game</code> entity repository.
- */
 @Primary
 @JdbcRepository(dialect = ORACLE) // <1>
 @Requires(env = {ORACLE_CLOUD, TEST}) // <2>

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/OracleGameStateRepository.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/repository/OracleGameStateRepository.java
@@ -8,9 +8,6 @@ import static io.micronaut.context.env.Environment.ORACLE_CLOUD;
 import static io.micronaut.context.env.Environment.TEST;
 import static io.micronaut.data.model.query.builder.sql.Dialect.ORACLE;
 
-/**
- * Oracle <code>GameState</code> entity repository.
- */
 @Primary
 @JdbcRepository(dialect = ORACLE)
 @Requires(env = {ORACLE_CLOUD, TEST})


### PR DESCRIPTION
This deletes the Javadoc from the Java application of the Oracle Streaming Guide. We have not written Javadoc in other guides. Java is a verbose language plus javadoc hinders the readability. 