### PR TITLE
add @NonNull annotations to fields

### DIFF
--- a/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
@@ -22,17 +22,21 @@ class GameDTO {
 
     @Size(max = 36)
     @NotNull
+    @NonNull
     final String id
 
     @Size(max = 255)
+    @Nullable
     final String blackName
 
     @Size(max = 255)
+    @Nullable
     final String whiteName
 
     final boolean draw
 
     @Size(max = 1)
+    @Nullable
     final String winner
 
     /**

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
@@ -20,25 +20,31 @@ class GameStateDTO {
 
     @Size(max = 36)
     @NotNull
+    @NonNull
     final String id
 
     @Size(max = 36)
     @NotNull
+    @NonNull
     final String gameId
 
     @Size(max = 1)
     @NotNull
+    @NonNull
     final String player
 
     @Size(max = 100)
     @NotNull
+    @NonNull
     final String fen
 
     @NotNull
+    @NonNull
     final String pgn
 
     @Size(max = 10)
     @NotNull
+    @NonNull
     final String move
 
     GameStateDTO(@NonNull String id,

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
@@ -20,9 +20,11 @@ public class GameDTO {
     private final String id;
 
     @Size(max = 255)
+    @Nullable
     private final String blackName;
 
     @Size(max = 255)
+    @Nullable
     private final String whiteName;
 
     private final boolean draw;

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/GameService.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/GameService.groovy
@@ -9,7 +9,7 @@ import example.micronaut.chess.repository.GameStateRepository
 import groovy.transform.CompileStatic
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
+import io.micronaut.core.annotation.NonNull
 import javax.inject.Singleton
 import javax.transaction.Transactional
 
@@ -84,6 +84,7 @@ class GameService {
         gameRepository.update game
     }
 
+    @NonNull
     private Game findGame(String gameId) {
         gameRepository.findById(UUID.fromString(gameId)).orElseThrow(() ->
                 new IllegalArgumentException("Game with id '" + gameId + "' not found"))

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
@@ -6,8 +6,7 @@ import io.micronaut.core.annotation.Creator
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
-
-import javax.validation.constraints.NotNull
+import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
 
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
@@ -21,18 +20,22 @@ import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
 class GameDTO {
 
     @Size(max = 36)
-    @NotNull
+    @NotBlank
+    @NonNull
     final String id
 
     @Size(max = 255)
+    @Nullable
     final String blackName
 
     @Size(max = 255)
+    @Nullable
     final String whiteName
 
     final boolean draw
 
     @Size(max = 1)
+    @Nullable
     final String winner
 
     /**

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.annotation.NonNull
-
-import javax.validation.constraints.NotNull
+import io.micronaut.core.annotation.Nullable
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
 import javax.validation.constraints.Size
 
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
@@ -19,26 +20,32 @@ import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
 class GameStateDTO {
 
     @Size(max = 36)
-    @NotNull
+    @NotBlank
+    @NonNull
     final String id
 
     @Size(max = 36)
-    @NotNull
+    @NotBlank
+    @NonNull
     final String gameId
 
     @Size(max = 1)
-    @NotNull
+    @NotBlank
+    @NonNull
     final String player
 
     @Size(max = 100)
-    @NotNull
+    @NotBlank
+    @NonNull
     final String fen
 
-    @NotNull
+    @NotBlank
+    @NonNull
     final String pgn
 
     @Size(max = 10)
-    @NotNull
+    @NotBlank
+    @NonNull
     final String move
 
     GameStateDTO(@NonNull String id,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/entity/Game.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/entity/Game.groovy
@@ -4,6 +4,7 @@ import example.micronaut.chess.dto.GameDTO
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
+import javax.validation.constraints.NotBlank
 import io.micronaut.data.annotation.DateCreated
 import io.micronaut.data.annotation.DateUpdated
 import io.micronaut.data.annotation.Id
@@ -25,9 +26,13 @@ class Game {
     final UUID id
 
     @Size(max = 255)
+    @NotBlank
+    @NonNull
     final String blackName
 
     @Size(max = 255)
+    @NotBlank
+    @NonNull
     final String whiteName
 
     @DateCreated

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/entity/GameState.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/entity/GameState.groovy
@@ -8,6 +8,7 @@ import io.micronaut.data.annotation.Id
 import io.micronaut.data.annotation.MappedEntity
 import io.micronaut.data.annotation.Relation
 import javax.validation.constraints.NotNull
+import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
 
 import java.time.LocalDateTime
@@ -23,28 +24,34 @@ class GameState {
 
     @Id
     @NotNull
+    @NonNull
     final UUID id
 
     @Relation(MANY_TO_ONE)
     @NotNull
+    @NonNull
     final Game game
 
     @DateCreated
     LocalDateTime dateCreated
 
     @Size(max = 1)
-    @NotNull
+    @NotBlank
+    @NonNull
     final String player
 
     @Size(max = 100)
-    @NotNull
+    @NotBlank
+    @NonNull
     final String fen
 
-    @NotNull
+    @NotBlank
+    @NonNull
     final String pgn
 
     @Size(max = 10)
-    @NotNull
+    @NotBlank
+    @NonNull
     final String move
 
     /**
@@ -69,6 +76,7 @@ class GameState {
         this.pgn = pgn
     }
 
+    @NonNull
     GameStateDTO toDto() {
         new GameStateDTO(id.toString(), game.getId().toString(), player, move, fen, pgn)
     }

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/GameService.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/GameService.java
@@ -8,7 +8,7 @@ import example.micronaut.chess.repository.GameRepository;
 import example.micronaut.chess.repository.GameStateRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import io.micronaut.core.annotation.NonNull;
 import javax.inject.Singleton;
 import javax.transaction.Transactional;
 import java.util.UUID;
@@ -60,6 +60,7 @@ public class GameService {
         gameRepository.update(game);
     }
 
+    @NonNull
     private Game findGame(String gameId) {
         return gameRepository.findById(UUID.fromString(gameId)).orElseThrow(() ->
                 new IllegalArgumentException("Game with id '" + gameId + "' not found"));

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
@@ -17,17 +17,21 @@ public class GameDTO {
 
     @Size(max = 36)
     @NotNull
+    @NonNull
     private final String id;
 
     @Size(max = 255)
+    @Nullable
     private final String blackName;
 
     @Size(max = 255)
+    @Nullable
     private final String whiteName;
 
     private final boolean draw;
 
     @Size(max = 1)
+    @NonNull
     private final String winner;
 
     @Creator // <3>

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
@@ -15,25 +15,31 @@ public class GameStateDTO {
 
     @Size(max = 36)
     @NotNull
+    @NonNull
     private final String id;
 
     @Size(max = 36)
     @NotNull
+    @NonNull
     private final String gameId;
 
     @Size(max = 1)
     @NotNull
+    @NonNull
     private final String player;
 
     @Size(max = 100)
     @NotNull
+    @NonNull
     private final String fen;
 
     @NotNull
+    @NonNull
     private final String pgn;
 
     @Size(max = 10)
     @NotNull
+    @NonNull
     private final String move;
 
     public GameStateDTO(@NonNull String id,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/entity/Game.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/entity/Game.java
@@ -18,12 +18,15 @@ public class Game {
 
     @Id
     @NotNull
+    @NonNull
     private final UUID id;
 
     @Size(max = 255)
+    @NonNull
     private final String blackName;
 
     @Size(max = 255)
+    @NonNull
     private final String whiteName;
 
     @DateCreated
@@ -46,14 +49,17 @@ public class Game {
         this.whiteName = whiteName;
     }
 
+    @NonNull
     public UUID getId() {
         return id;
     }
 
+    @NonNull
     public String getBlackName() {
         return blackName;
     }
 
+    @NonNull
     public String getWhiteName() {
         return whiteName;
     }
@@ -90,6 +96,7 @@ public class Game {
         this.winner = winner;
     }
 
+    @NonNull
     public GameDTO toDto() {
         return new GameDTO(id.toString(), blackName, whiteName, draw, winner);
     }

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/entity/GameState.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/entity/GameState.java
@@ -19,10 +19,12 @@ public class GameState {
 
     @Id
     @NotNull
+    @NonNull
     private final UUID id;
 
     @Relation(MANY_TO_ONE)
     @NotNull
+    @NonNull
     private final Game game;
 
     @DateCreated
@@ -30,19 +32,23 @@ public class GameState {
 
     @Size(max = 1)
     @NotNull
+    @NonNull
     private final String player;
 
     // https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
     @Size(max = 100)
     @NotNull
+    @NonNull
     private final String fen;
 
     // https://en.wikipedia.org/wiki/Portable_Game_Notation
     @NotNull
+    @NonNull
     private final String pgn;
 
     @Size(max = 10)
     @NotNull
+    @NonNull
     private final String move;
 
     public GameState(@NonNull UUID id,
@@ -59,10 +65,12 @@ public class GameState {
         this.pgn = pgn;
     }
 
+    @NonNull
     public UUID getId() {
         return id;
     }
 
+    @NonNull
     public Game getGame() {
         return game;
     }
@@ -75,22 +83,27 @@ public class GameState {
         this.dateCreated = dateCreated;
     }
 
+    @NonNull
     public String getPlayer() {
         return player;
     }
 
+    @NonNull
     public String getFen() {
         return fen;
     }
 
+    @NonNull
     public String getPgn() {
         return pgn;
     }
 
+    @NonNull
     public String getMove() {
         return move;
     }
 
+    @NonNull
     public GameStateDTO toDto() {
         return new GameStateDTO(id.toString(), game.getId().toString(), player, move, fen, pgn);
     }


### PR DESCRIPTION
I typically write the class with all the fields annotated with `@NonNull` annotations (`io.micronaut.core.annotations`) and also the constraint annotations (`@NotBlank`, `@Size`) and then use IntelliJ to generate getters and setters and constructors which automatically adds the nullability annotations to the getters and setters. Do you think we should not have micronaut nullability annotations in fields?

I have also changed from `@NotNull` to `@NotBlank` for Strings