### PR TITLE
Test Micronaut 2.5.x patch snapshots

### DIFF
--- a/.github/workflows/gradle-snapshot.yml
+++ b/.github/workflows/gradle-snapshot.yml
@@ -2,6 +2,7 @@ name: Java CI for Micronaut SNAPSHOT
 on:
   schedule:
     - cron: '0 5 * * 1-5'
+  workflow_dispatch:
 jobs:
   patch-snapshot:
     runs-on: ubuntu-latest
@@ -14,6 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: '2.5.x'
       - uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
@@ -24,44 +26,16 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - name: Use next snapshot version
+      - name: Use next snapshot patch version
         run: ./increment_version.sh -p
       - name: Build with Gradle
         run: ./gradlew build
       - name: Execute tests
-        run: 'cd build/code && ./test.sh ; cd ../..'
-      - name: Archive test reports
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: test-reports-${{ matrix.java }}
-          path: /home/runner/work/micronaut-guides/micronaut-guides/build/code/
-  major-snapshot:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: ['8', '11']
-    env:
-      JDK_VERSION:  ${{ matrix.java }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: '3.0.x'
-      - uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Build with Gradle
-        run: ./gradlew build
-      - name: Execute tests
-        run: 'cd build/code && ./test.sh ; cd ../..'
+        run: |
+          export AWS_ACCESS_KEY_ID=XXX
+          export AWS_SECRET_ACCESS_KEY=YYY
+          export AWS_REGION=us-east-1
+          cd build/code && ./test.sh ; cd ../..
       - name: Archive test reports
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,25 +31,14 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
       - name: Execute tests
-        run: 'export AWS_ACCESS_KEY_ID=XXX;export AWS_SECRET_ACCESS_KEY=YYY;export AWS_REGION=us-east-1;cd build/code && ./test.sh;cd ../..'
+        run: |
+          export AWS_ACCESS_KEY_ID=XXX
+          export AWS_SECRET_ACCESS_KEY=YYY
+          export AWS_REGION=us-east-1
+          cd build/code && ./test.sh ; cd ../..
       - name: Archive test reports
         uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: test-reports-${{ matrix.java }}
           path: /home/runner/work/micronaut-guides/micronaut-guides/build/code/
-      - name: Calculate version of the guides
-        id: guides_version
-        run: |
-          current_version=`cat version.txt`
-          tmp_version=( ${current_version//./ } )
-          version=`echo "${tmp_version[0]}.${tmp_version[1]}.x"`
-          echo ::set-output name=guides_version::${version}
-      - name: Publish to Github Pages
-        if: success() && github.event_name == 'push' && matrix.java == '8'
-        uses: micronaut-projects/github-pages-deploy-action@master
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: build/dist
-          VERSION: ${{ steps.guides_version.outputs.guides_version }}


### PR DESCRIPTION
- Test Micronaut 2.5.x patch snapshot versions
- Allow run CI snapshot workflow manually
- Do not publish guides for 2.5.x branch anymore