### PR TITLE
Upgrade to GraalVM 21.3.0

### DIFF
--- a/src/docs/common/common-install-graalvm-sdkman.adoc
+++ b/src/docs/common/common-install-graalvm-sdkman.adoc
@@ -1,28 +1,18 @@
 The easiest way to install GraalVM is to use https://sdkman.io/[SDKMan.io].
 
 [source, bash]
-.Java 8
-----
-$ sdk install java 21.2.0.r8-grl
-----
-
-[source, bash]
 .Java 11
 ----
-$ sdk install java 21.2.0.r11-grl
+$ sdk install java 21.3.0.r11-grl
 ----
 
 [source, bash]
-.Java 16
+.Java 17
 ----
-$ sdk install java 21.2.0.r16-grl
+$ sdk install java 21.3.0.r17-grl
 ----
 
-NOTE: Our recommended approach is to use GraalVM JDK11 even if you still use
-Java 8 for your project. There are no Java 8 distributions of GraalVM
-Community Edition 21.2 available for macOs. See
-https://github.com/graalvm/graalvm-ce-builds/releases[github.com/graalvm/graalvm-ce-builds/releases]
-for OS compatibility information.
+NOTE: If you still use Java 8 use the GraalVM JDK11 version.
 
 You need to install the `native-image` component, which is not installed by default.
 


### PR DESCRIPTION
Upgrade to GraalVM 21.3.0 and remove JDK8.

Starting with 21.3.0 JDK8 is no longer supported: https://www.graalvm.org/release-notes/21_3/#platform-updates

![image](https://user-images.githubusercontent.com/559192/138073016-d46e0aa8-362e-4c92-b084-1a5b1f9d11b8.png)
