### PR TITLE
exclude-for-jdk-lower-than

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -22,6 +22,10 @@ class GuideAsciidocGenerator {
 
     private static final String INCLUDE_COMMONDIR = 'include::{commondir}/'
     private static final String CALLOUT = 'callout:'
+    public static final int DEFAULT_MIN_JDK = 8
+    public static final String EXCLUDE_FOR_LANGUAGES = ':exclude-for-languages:'
+    public static final String EXCLUDE_FOR_MIN_JDK = ':exclude-for-min-jdk:'
+    public static final String EXCLUDE_FOR_BUILD = ':exclude-for-build:'
 
     static void generate(GuideMetadata metadata, File inputDir, File destinationFolder) {
         Path asciidocPath = Paths.get(inputDir.absolutePath, metadata.asciidoctor)
@@ -38,17 +42,20 @@ class GuideAsciidocGenerator {
 
             List<String> lines = []
             boolean excludeLineForLanguage = false
+            boolean excludeLineForMinJdk = false
             boolean excludeLineForBuild = false
             boolean groupDependencies = false
             List<String> groupedDependencies = []
             for (String line : rawLinesExpanded) {
 
-                if (line == ':exclude-for-build:') {
+                if (line == EXCLUDE_FOR_BUILD) {
                     excludeLineForBuild = false
-                } else if (line == ':exclude-for-languages:') {
+                } else if (line == EXCLUDE_FOR_LANGUAGES) {
                     excludeLineForLanguage = false
+                } else if (line == EXCLUDE_FOR_MIN_JDK) {
+                    excludeLineForMinJdk = false
                 }
-                if (excludeLineForLanguage || excludeLineForBuild) {
+                if (excludeLineForLanguage || excludeLineForBuild || excludeLineForMinJdk) {
                     continue
                 }
 
@@ -85,16 +92,27 @@ class GuideAsciidocGenerator {
                         lines.addAll(DependencyLines.asciidoc(line, guidesOption.buildTool, guidesOption.language))
                     }
 
-                } else if (line.startsWith(':exclude-for-build:')) {
-                    String[] builds = line.substring(':exclude-for-build:'.length()).split(',')
+                } else if (line.startsWith(EXCLUDE_FOR_BUILD)) {
+                    String[] builds = line.substring(EXCLUDE_FOR_BUILD.length()).split(',')
                     if (builds.any { it == guidesOption.buildTool.toString() }) {
                         excludeLineForBuild = true
                     }
-
-                } else if (line.startsWith(':exclude-for-languages:')) {
-                    String[] languages = line.substring(':exclude-for-languages:'.length()).split(',')
+                } else if (line.startsWith(EXCLUDE_FOR_LANGUAGES)) {
+                    String[] languages = line.substring(EXCLUDE_FOR_LANGUAGES.length()).split(',')
                     if (languages.any { it == guidesOption.language.toString() }) {
                         excludeLineForLanguage = true
+                    }
+                } else if (line.startsWith(EXCLUDE_FOR_MIN_JDK)) {
+                    try {
+                        String str = line.substring(EXCLUDE_FOR_MIN_JDK.length());
+                        if (StringUtils.isNotEmpty(str)) {
+                            Integer minJdk = Integer.valueOf(str)
+                            if ((metadata.minimumJavaVersion ?: DEFAULT_MIN_JDK) >= minJdk) {
+                                excludeLineForMinJdk = true
+                            }
+                        }
+                    } catch(NumberFormatException e) {
+
                     }
                 } else if (shouldProcessLine(line, 'rocker:')) {
                     lines.addAll(includeRocker(line))

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -24,7 +24,7 @@ class GuideAsciidocGenerator {
     private static final String CALLOUT = 'callout:'
     public static final int DEFAULT_MIN_JDK = 8
     public static final String EXCLUDE_FOR_LANGUAGES = ':exclude-for-languages:'
-    public static final String EXCLUDE_FOR_MIN_JDK = ':exclude-for-min-jdk:'
+    public static final String EXCLUDE_FOR_JDK_LOWER_THAN = ':exclude-for-jdk-lower-than:'
     public static final String EXCLUDE_FOR_BUILD = ':exclude-for-build:'
 
     static void generate(GuideMetadata metadata, File inputDir, File destinationFolder) {
@@ -52,7 +52,7 @@ class GuideAsciidocGenerator {
                     excludeLineForBuild = false
                 } else if (line == EXCLUDE_FOR_LANGUAGES) {
                     excludeLineForLanguage = false
-                } else if (line == EXCLUDE_FOR_MIN_JDK) {
+                } else if (line == EXCLUDE_FOR_JDK_LOWER_THAN) {
                     excludeLineForMinJdk = false
                 }
                 if (excludeLineForLanguage || excludeLineForBuild || excludeLineForMinJdk) {
@@ -102,9 +102,9 @@ class GuideAsciidocGenerator {
                     if (languages.any { it == guidesOption.language.toString() }) {
                         excludeLineForLanguage = true
                     }
-                } else if (line.startsWith(EXCLUDE_FOR_MIN_JDK)) {
+                } else if (line.startsWith(EXCLUDE_FOR_JDK_LOWER_THAN)) {
                     try {
-                        String str = line.substring(EXCLUDE_FOR_MIN_JDK.length());
+                        String str = line.substring(EXCLUDE_FOR_JDK_LOWER_THAN.length());
                         if (StringUtils.isNotEmpty(str)) {
                             Integer minJdk = Integer.valueOf(str)
                             if ((metadata.minimumJavaVersion ?: DEFAULT_MIN_JDK) >= minJdk) {

--- a/src/docs/common/common-install-graalvm-sdkman.adoc
+++ b/src/docs/common/common-install-graalvm-sdkman.adoc
@@ -1,18 +1,22 @@
 The easiest way to install GraalVM is to use https://sdkman.io/[SDKMan.io].
 
+:exclude-for-min-jdk:17
+
 [source, bash]
 .Java 11
 ----
 $ sdk install java 21.3.0.r11-grl
 ----
 
+NOTE: If you still use Java 8 use the GraalVM JDK11 version.
+
+:exclude-for-min-jdk:
+
 [source, bash]
 .Java 17
 ----
 $ sdk install java 21.3.0.r17-grl
 ----
-
-NOTE: If you still use Java 8 use the GraalVM JDK11 version.
 
 You need to install the `native-image` component, which is not installed by default.
 

--- a/src/docs/common/common-install-graalvm-sdkman.adoc
+++ b/src/docs/common/common-install-graalvm-sdkman.adoc
@@ -1,6 +1,6 @@
 The easiest way to install GraalVM is to use https://sdkman.io/[SDKMan.io].
 
-:exclude-for-min-jdk:17
+:exclude-for-jdk-lower-than:17
 
 [source, bash]
 .Java 11
@@ -10,7 +10,7 @@ $ sdk install java 21.3.0.r11-grl
 
 NOTE: If you still use Java 8 use the GraalVM JDK11 version.
 
-:exclude-for-min-jdk:
+:exclude-for-jdk-lower-than:
 
 [source, bash]
 .Java 17


### PR DESCRIPTION
this enable us to exclude snippets which do not make sense when we set a minimum JDK