### PR TITLE
Generate project with Java version at least matching min JDK

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -157,6 +157,12 @@ class GuideProjectGenerator implements Closeable {
                 File destination = destinationPath.toFile()
                 destination.mkdir()
 
+                if (metadata.minimumJavaVersion != null) {
+                    JdkVersion minimumJavaVersion = JdkVersion.valueOf(metadata.minimumJavaVersion)
+                    if (minimumJavaVersion.majorVersion() > javaVersion.majorVersion()) {
+                        javaVersion = minimumJavaVersion
+                    }
+                }
                 guidesGenerator.generateAppIntoDirectory(destination, app.applicationType, packageAndName, appFeatures, buildTool, testFramework, lang, javaVersion)
 
                 final String srcFolder = 'src'


### PR DESCRIPTION
with this change: 

```
sdelamo@ig11 micronaut-guides % java -version
openjdk version "11.0.12" 2021-07-20 LTS
OpenJDK Runtime Environment Corretto-11.0.12.7.2 (build 11.0.12+7-LTS)
OpenJDK 64-Bit Server VM Corretto-11.0.12.7.2 (build 11.0.12+7-LTS, mixed mode)
sdelamo@ig11 micronaut-guides % ./gradlew -Dmicronaut.guide=micronaut-java-records build

> Task :asciidoctor
....

BUILD SUCCESSFUL in 6s
34 actionable tasks: 12 executed, 22 up-to-date
sdelamo@ig11 micronaut-guides % cat build/code/micronaut-java-records-gradle-java/build.gradle | grep 17
    sourceCompatibility = JavaVersion.toVersion("17")
    targetCompatibility = JavaVersion.toVersion("17")
````

This allows for guides to be generated with the appropriate Java version in the build file. 