### PR TITLE
Fix GraalVM support for Records guide

### DIFF
--- a/guides/micronaut-java-records/java/src/main/java/example/micronaut/BookForSale.java
+++ b/guides/micronaut-java-records/java/src/main/java/example/micronaut/BookForSale.java
@@ -2,11 +2,13 @@ package example.micronaut;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 @Introspected // <1>
-public record BookForSale(@NonNull @NotBlank String isbn,  // <2>
+@ReflectiveAccess // <2>
+public record BookForSale(@NonNull @NotBlank String isbn,  // <3>
                           @NonNull @NotBlank String title,
                           @NonNull @NotNull BigDecimal price) { }

--- a/guides/micronaut-java-records/java/src/main/resources/META-INF/native-image/example.micronaut/guide/native-image.properties
+++ b/guides/micronaut-java-records/java/src/main/resources/META-INF/native-image/example.micronaut/guide/native-image.properties
@@ -1,0 +1,1 @@
+Args = --report-unsupported-elements-at-runtime

--- a/guides/micronaut-java-records/micronaut-java-records.adoc
+++ b/guides/micronaut-java-records/micronaut-java-records.adoc
@@ -104,7 +104,8 @@ Create a Java record to represent a JSON response:
 source:BookForSale[]
 
 callout:introspected[1]
-callout:constraints[2]
+<2> Jackson requires reflection to use Records. With `@ReflectiveAccess` the Micronaut framework will add the class to the GraalVM `reflect-config.json` file.
+callout:constraints[3]
 
 Create a Controller that uses the previous record: 
 


### PR DESCRIPTION
We should document somehow in the guide the `native-image.properties` file.