### PR TITLE
Update micronaut-security-jwt.adoc

### DIFF
--- a/guides/micronaut-security-jwt/micronaut-security-jwt.adoc
+++ b/guides/micronaut-security-jwt/micronaut-security-jwt.adoc
@@ -94,7 +94,7 @@ test:DeclarativeHttpClientWithJwtTest[]
 
 == Issuing a Refresh Token
 
-Access tokens expire. You can control the expiration with `micronaut.security.token.jwt.generator.access-token-expiration`. In addition to the access token, you can configure your login endpoint to also return a refresh token. You can use the refresh token to obtain a new access token.
+Access tokens expire. You can control the expiration with `micronaut.security.token.jwt.generator.access-token.expiration`. In addition to the access token, you can configure your login endpoint to also return a refresh token. You can use the refresh token to obtain a new access token.
 
 First, add the following configuration:
 


### PR DESCRIPTION
The setting `micronaut.security.token.jwt.generator.access-token-expiration` has been deprecated in favor of `micronaut.security.token.jwt.generator.access-token.expiration` since Micronaut 2.x.  (Notice the period in place of the dash.)

It seems that there may be a bug where the deprecated setting is no longer observed, but the new setting seems to work just fine.
I'm running Micronaut 2.5.11.

Regardless of the possible bug, it's probably best to keep the docs up-to-date and not recommend using deprecated settings.