### PR TITLE
Upgrade GraalVM to 22.0.0.2

### DIFF
--- a/src/docs/common/common-install-graalvm-sdkman.adoc
+++ b/src/docs/common/common-install-graalvm-sdkman.adoc
@@ -5,7 +5,7 @@ The easiest way to install GraalVM on Linux or Mac is to use https://sdkman.io/[
 [source, bash]
 .Java 11
 ----
-$ sdk install java 21.3.0.r11-grl
+$ sdk install java 22.0.0.2.r11-grl
 ----
 
 NOTE: If you still use Java 8, use the JDK11 version of GraalVM.
@@ -15,7 +15,7 @@ NOTE: If you still use Java 8, use the JDK11 version of GraalVM.
 [source, bash]
 .Java 17
 ----
-$ sdk install java 21.3.0.r17-grl
+$ sdk install java 22.0.0.2.r17-grl
 ----
 
 For installation on Windows, or for manual installation on Linux or Mac, see the https://www.graalvm.org/22.0/docs/getting-started/[GraalVM Getting Started] documentation.


### PR DESCRIPTION
GraalVM 22.0.0.2 works with Micronaut 3.2.x and 3.3.x. We can merge this now to update the 3.2.x guides to this new GraalVM version or wait until we upgrade the guides to 3.3.0 and then merge this PR.