### PR TITLE
cleanup from PR #684

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Besides, the obvious fields that doesn't need any further explanation, the other
 - `skipGradleTests`: Set it to `true` to skip running the tests for the Gradle applications for the guide. This is useful when it's not easy to run tests on CI, for example for some cloud guides.
 - `skipMavenTests`: Same as `skipGradleTests` but for Maven applications.
 - `minimumJavaVersion`: If the guide needs a minimum Java version (for example JDK 17 for Records), define it in this property.
+- `maximumJavaVersion`: If the guide needs a maximum Java version (for example JDK 11 for Azure Functions), define it in this property.
 - `zipIncludes`: List of additional files to include in the generated zip file for the guide.
 - `apps`: List of pairs `name`-`features` for the generated application. There are two types of guides, most of the guides only generate one application (single-app). In this case the name of the applications needs to be `default`. There are a few guides that generate multiple applications, so they need to be declared here:
 ```json

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ task generateSampleProjects {
         }
 
         try (GuideProjectGenerator generator = new GuideProjectGenerator()) {
-            generator.generate(guidesDir, codeDir, metadataConfigName, new File(projectDir, "src/docs/asciidoc"))
+            generator.generate(guidesDir, codeDir, metadataConfigName, projectDir)
         }
     }
     finalizedBy(

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 ext {
     codeDir = new File(buildDir, 'code')
-    distDir = new File(project.buildDir, 'dist')
+    distDir = new File(buildDir, 'dist')
     guidesDir = new File(projectDir, 'guides')
     metadataConfigName = 'metadata.json'
 }
@@ -74,7 +74,7 @@ task copyJavaScriptToDist(type: Copy) {
 task copyHtmlToDist(type: Copy) {
     group 'guides'
     description 'Copies HTML generated from Asciidoc from build/docs/asciidoc to build/dist'
-    from "${project.buildDir}/docs/asciidoc"
+    from "$buildDir/docs/asciidoc"
     into distDir
     exclude 'common-*.html'
 }
@@ -97,15 +97,16 @@ task generateSampleProjects {
     group 'guides'
     description 'Generates guide applications at build/code'
     doLast {
-        if (!file(buildDir).exists()) {
-           file(buildDir).mkdir()
+        if (!buildDir.exists()) {
+           buildDir.mkdir()
         }
-        if (!file(codeDir).exists()) {
-            file(codeDir).mkdir()
+        if (!codeDir.exists()) {
+            codeDir.mkdir()
         }
-        GuideProjectGenerator generator = new GuideProjectGenerator()
-        generator.generate(guidesDir, codeDir, metadataConfigName, new File(projectDir, "src/docs/asciidoc"))
-        generator.close()
+
+        try (GuideProjectGenerator generator = new GuideProjectGenerator()) {
+            generator.generate(guidesDir, codeDir, metadataConfigName, new File(projectDir, "src/docs/asciidoc"))
+        }
     }
     finalizedBy(
             'generateTestScript',
@@ -129,7 +130,7 @@ task generateTestScript {
         }
         testScript.text = generateTestScript
                 ? TestScriptGenerator.generateScript(guidesDir, metadataConfigName, false, changedFiles)
-                : TestScriptGenerator.emptyScript()
+                : TestScriptGenerator.EMPTY_SCRIPT
         testScript.executable = true
     }
 }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -11,34 +11,36 @@ import io.micronaut.starter.build.dependencies.Coordinate
 import io.micronaut.starter.build.dependencies.PomDependencyVersionResolver
 import org.gradle.api.GradleException
 
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Map.Entry
 
 import static io.micronaut.guides.GuideProjectGenerator.DEFAULT_APP_NAME
+import static io.micronaut.starter.api.TestFramework.SPOCK
 
 @CompileStatic
 class GuideAsciidocGenerator {
 
     private static final String INCLUDE_COMMONDIR = 'common:'
     private static final String CALLOUT = 'callout:'
+
     public static final int DEFAULT_MIN_JDK = 8
     public static final String EXCLUDE_FOR_LANGUAGES = ':exclude-for-languages:'
     public static final String EXCLUDE_FOR_JDK_LOWER_THAN = ':exclude-for-jdk-lower-than:'
     public static final String EXCLUDE_FOR_BUILD = ':exclude-for-build:'
 
     static void generate(GuideMetadata metadata, File inputDir, File destinationFolder) {
-        Path asciidocPath = Paths.get(inputDir.absolutePath, metadata.asciidoctor)
-        File asciidocFile = asciidocPath.toFile()
+        File asciidocFile = new File(inputDir, metadata.asciidoctor)
         assert asciidocFile.exists()
+
         if (!destinationFolder.exists()) {
             destinationFolder.mkdir()
         }
+
+        List<String> rawLinesExpanded = expandAllCommonIncludes(asciidocFile.readLines(), destinationFolder)
+
         List<GuidesOption> guidesOptionList = GuideProjectGenerator.guidesOptions(metadata)
         for (GuidesOption guidesOption : guidesOptionList) {
-            String projectName = "${metadata.slug}-${guidesOption.buildTool.toString()}-${guidesOption.language}"
-
-            List<String> rawLinesExpanded = expandAllCommonIncludes(asciidocFile.readLines(), destinationFolder)
+            String projectName = "${metadata.slug}-${guidesOption.buildTool}-${guidesOption.language}"
 
             List<String> lines = []
             boolean excludeLineForLanguage = false
@@ -87,7 +89,7 @@ class GuideAsciidocGenerator {
 
                 } else if (shouldProcessLine(line, 'dependency:')) {
                     if (groupDependencies) {
-                        groupedDependencies.add(line)
+                        groupedDependencies << line
                     } else {
                         lines.addAll(DependencyLines.asciidoc(line, guidesOption.buildTool, guidesOption.language))
                     }
@@ -104,15 +106,14 @@ class GuideAsciidocGenerator {
                     }
                 } else if (line.startsWith(EXCLUDE_FOR_JDK_LOWER_THAN)) {
                     try {
-                        String str = line.substring(EXCLUDE_FOR_JDK_LOWER_THAN.length());
+                        String str = line.substring(EXCLUDE_FOR_JDK_LOWER_THAN.length())
                         if (StringUtils.isNotEmpty(str)) {
                             Integer minJdk = Integer.valueOf(str)
                             if ((metadata.minimumJavaVersion ?: DEFAULT_MIN_JDK) >= minJdk) {
                                 excludeLineForMinJdk = true
                             }
                         }
-                    } catch(NumberFormatException e) {
-
+                    } catch(NumberFormatException ignored) {
                     }
                 } else if (shouldProcessLine(line, 'rocker:')) {
                     lines.addAll(includeRocker(line))
@@ -123,20 +124,20 @@ class GuideAsciidocGenerator {
                 }
             }
 
-            File versionFile = Paths.get(destinationFolder.absolutePath, "../../../version.txt").toFile()
+            String version = new File(destinationFolder, '../../../version.txt').text
 
             String text = lines.join('\n')
             text = text.replace("{githubSlug}", metadata.slug)
             text = text.replace("@language@", StringUtils.capitalize(guidesOption.language.toString()))
             text = text.replace("@guideTitle@", metadata.title)
             text = text.replace("@guideIntro@", metadata.intro)
-            text = text.replace("@micronaut@", versionFile.text)
+            text = text.replace("@micronaut@", version)
             text = text.replace("@lang@", guidesOption.language.toString())
             text = text.replace("@build@", guidesOption.buildTool.toString())
             text = text.replace("@testFramework@", guidesOption.testFramework.toString())
             text = text.replace("@authors@", metadata.authors.join(', '))
             text = text.replace("@languageextension@", guidesOption.language.extension)
-            text = text.replace("@testsuffix@", guidesOption.testFramework == TestFramework.SPOCK ? 'Spec' : 'Test')
+            text = text.replace("@testsuffix@", guidesOption.testFramework == SPOCK ? 'Spec' : 'Test')
             text = text.replace("@sourceDir@", projectName)
             text = text.replace("@minJdk@", metadata.minimumJavaVersion?.toString() ?: "1.8")
             text = text.replace("@api@", 'https://docs.micronaut.io/latest/api')
@@ -147,10 +148,9 @@ class GuideAsciidocGenerator {
                 }
             }
 
-            Path destinationPath = Paths.get(destinationFolder.absolutePath, projectName + ".adoc")
-            File destination = destinationPath.toFile()
-            destination.createNewFile()
-            destination.text = text
+            File renderedAsciidocFile = new File(destinationFolder, projectName + '.adoc')
+            renderedAsciidocFile.createNewFile()
+            renderedAsciidocFile.text = text
         }
     }
 
@@ -159,25 +159,9 @@ class GuideAsciidocGenerator {
 
         for (String rawLine : lines) {
             if (rawLine.startsWith(CALLOUT) && rawLine.endsWith(']')) {
-                String commonFileName = "callouts/" + parseFileName(rawLine, CALLOUT)
-                        .map(str -> 'callout-' + str)
-                        .orElseThrow(() -> new GradleException("could not parse filename from callout for line" + rawLine))
-                Optional<Integer> number = parseNumber(rawLine)
-                List<String> newLines = commonLines(destinationFolder, commonFileName)
-                String line = "${number.map(num -> '<' + num + '>').orElse('*')} ${newLines.first()}".toString()
-                for (int i = 0; i < 10; i++) {
-                    String value = extractFromParametersLine(rawLine, "arg" + i)
-                    if (value) {
-                        line = line.replace("{" + i + "}", value)
-                    }
-                }
-                rawLines.add(line)
+                rawLines << callout(rawLine, destinationFolder)
             } else if (rawLine.startsWith(INCLUDE_COMMONDIR) && rawLine.endsWith('[]')) {
-                String commonFileName = "snippets/common-" + parseFileName(rawLine, INCLUDE_COMMONDIR)
-                        .orElseThrow(() -> new GradleException("could not parse filename from commondir line" + rawLine))
-                rawLines.add("// Start: ${commonFileName}".toString())
-                rawLines.addAll(commonLines(destinationFolder, commonFileName))
-                rawLines.add("// End: ${commonFileName}".toString())
+                include rawLine, rawLines, destinationFolder
             } else {
                 rawLines << rawLine
             }
@@ -185,9 +169,38 @@ class GuideAsciidocGenerator {
         return rawLines
     }
 
-    private static Optional<String> parseFileName(String line, String preffix, String suffix = '.adoc') {
-        if (line.contains(preffix) && line.contains('[')) {
-            String name = line.substring(line.indexOf(preffix) + preffix.length(), line.indexOf('['))
+    private static String callout(String rawLine, File destinationFolder) {
+
+        String relativePath = parseFileName(rawLine, CALLOUT)
+                .orElseThrow(() -> new GradleException("could not parse filename from callout for line: " + rawLine))
+        relativePath = 'callouts/callout-' + relativePath
+
+        List<String> newLines = commonLines(destinationFolder, relativePath)
+
+        Optional<Integer> number = parseNumber(rawLine)
+        String line = number.map(num -> '<' + num + '>').orElse('*') + ' ' + newLines.first()
+
+        for (int i = 0; i < 10; i++) {
+            String value = extractFromParametersLine(rawLine, "arg" + i)
+            if (value) {
+                line = line.replace("{" + i + "}", value)
+            }
+        }
+
+        line
+    }
+
+    private static void include(String rawLine, List<String> rawLines, File destinationFolder) {
+        String commonFileName = "snippets/common-" + parseFileName(rawLine, INCLUDE_COMMONDIR)
+                .orElseThrow(() -> new GradleException("could not parse filename from commondir line" + rawLine))
+        rawLines << '// Start: ' + commonFileName
+        rawLines.addAll commonLines(destinationFolder, commonFileName)
+        rawLines << '// End: ' + commonFileName
+    }
+
+    private static Optional<String> parseFileName(String line, String prefix, String suffix = '.adoc') {
+        if (line.contains(prefix) && line.contains('[')) {
+            String name = line.substring(line.indexOf(prefix) + prefix.length(), line.indexOf('['))
             if (!name.endsWith(suffix)) {
                 name += suffix
             }
@@ -210,7 +223,7 @@ class GuideAsciidocGenerator {
     }
 
     private static List<String> commonLines(File destinationFolder, String commonFileName) {
-        File commonFile = Paths.get(destinationFolder.absolutePath, "../common/$commonFileName").toFile()
+        File commonFile = new File(destinationFolder, '../common/' + commonFileName)
         assert commonFile.exists()
         return expandAllCommonIncludes(commonFile.readLines(), destinationFolder)
     }
@@ -271,18 +284,18 @@ class GuideAsciidocGenerator {
         String sourcePath = testFramework ? testPath(appName, name, testFramework) : mainPath(appName, name)
         List<String> lines = [
             '[source,@lang@]',
-            ".${sourcePath}".toString(),
+            '.' + sourcePath,
             '----',
         ]
         if (tags) {
             for (String tag : tags) {
-                lines.add("include::{sourceDir}/@sourceDir@/${sourcePath}[${tag}]\n".toString())
+                lines << "include::{sourceDir}/@sourceDir@/${sourcePath}[${tag}]\n".toString()
             }
         } else {
-            lines.add("include::{sourceDir}/@sourceDir@/${sourcePath}[]".toString())
+            lines << "include::{sourceDir}/@sourceDir@/${sourcePath}[]".toString()
         }
 
-        lines.add('----')
+        lines << '----'
         lines
     }
 
@@ -300,7 +313,7 @@ class GuideAsciidocGenerator {
         if (testFramework) {
             if (name.endsWith('Test')) {
                 fileName = name.substring(0, name.indexOf('Test'))
-                fileName += testFramework == TestFramework.SPOCK ? 'Spec' : 'Test'
+                fileName += testFramework == SPOCK ? 'Spec' : 'Test'
             }
         }
 
@@ -312,8 +325,8 @@ class GuideAsciidocGenerator {
                                        @NonNull String fileName,
                                        String folder) {
 
-        String module = appName ? "${appName}/" : ""
-        "${module}src/${folder}/@lang@/example/micronaut/${fileName}.@languageextension@".toString()
+        String module = appName ? appName + '/' : ''
+        "${module}src/${folder}/@lang@/example/micronaut/${fileName}.@languageextension@"
     }
 
     private static List<String> rawTestIncludeLines(String line, TestFramework testFramework) {
@@ -321,7 +334,7 @@ class GuideAsciidocGenerator {
         String appName = extractAppName(line)
         List<String> tagNames = extractTags(line)
 
-        String module = appName ? "${appName}/" : ""
+        String module = appName ? appName + '/' : ""
         List<String> tags = tagNames ? tagNames.collect { "tag=" + it } : []
 
         String fileExtension = testFramework.toTestFramework().defaultLanguage.getExtension()
@@ -349,7 +362,7 @@ class GuideAsciidocGenerator {
         String appName = extractAppName(line)
         List<String> tagNames = extractTags(line)
 
-        String module = appName ? "${appName}/" : ""
+        String module = appName ? appName + '/' : ""
         List<String> tags = tagNames ? tagNames.collect { "tag=" + it } : []
         String asciidoctorLang = resolveAsciidoctorLanguage(fileName)
 

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideMetadata.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideMetadata.groovy
@@ -25,6 +25,7 @@ class GuideMetadata {
     boolean skipMavenTests
 
     Integer minimumJavaVersion
+    Integer maximumJavaVersion
 
     List<String> zipIncludes
 

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -88,6 +88,7 @@ class GuideProjectGenerator implements AutoCloseable {
                 skipGradleTests: config.skipGradleTests ?: false,
                 skipMavenTests: config.skipMavenTests ?: false,
                 minimumJavaVersion: config.minimumJavaVersion,
+                maximumJavaVersion: config.maximumJavaVersion,
                 zipIncludes: config.zipIncludes ?: [],
                 apps: config.apps.collect { it -> new App(
                         name: it.name,

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -103,14 +103,19 @@ class GuideProjectGenerator implements AutoCloseable {
     void generate(File guidesDir,
                   File output,
                   String metadataConfigName,
-                  File asciidocDir) {
+                  File projectDir) {
+
+        File asciidocDir = new File(projectDir, 'src/docs/asciidoc')
+        if (!asciidocDir.exists()) {
+            asciidocDir.mkdir()
+        }
 
         guidesDir.eachDir { dir ->
             GuideMetadata metadata = parseGuideMetadata(dir, metadataConfigName)
             try {
                 if (Utils.process(metadata, false)) {
                     generateOne(metadata, dir, output)
-                    GuideAsciidocGenerator.generate(metadata, dir, asciidocDir)
+                    GuideAsciidocGenerator.generate(metadata, dir, asciidocDir, projectDir)
                 }
             } catch(IllegalArgumentException ignored) {
             }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -118,7 +118,8 @@ class GuideProjectGenerator implements AutoCloseable {
                     generateOne(metadata, dir, output)
                     GuideAsciidocGenerator.generate(metadata, dir, asciidocDir, projectDir)
                 }
-            } catch(IllegalArgumentException ignored) {
+            } catch (IllegalArgumentException e) {
+                e.printStackTrace()
             }
         }
     }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -114,6 +114,7 @@ class GuideProjectGenerator implements AutoCloseable {
             GuideMetadata metadata = parseGuideMetadata(dir, metadataConfigName)
             try {
                 if (Utils.process(metadata, false)) {
+                    println "Generating projects for $metadata.slug"
                     generateOne(metadata, dir, output)
                     GuideAsciidocGenerator.generate(metadata, dir, asciidocDir, projectDir)
                 }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -6,7 +6,6 @@ import groovy.transform.CompileStatic
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
-import io.micronaut.core.util.StringUtils
 import io.micronaut.guides.GuideMetadata.App
 import io.micronaut.starter.api.TestFramework
 import io.micronaut.starter.application.ApplicationType
@@ -20,19 +19,16 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.LocalDate
 
+import static io.micronaut.core.util.StringUtils.EMPTY_STRING
 import static io.micronaut.starter.api.TestFramework.JUNIT
 import static io.micronaut.starter.api.TestFramework.SPOCK
-import static io.micronaut.starter.options.BuildTool.GRADLE
-import static io.micronaut.starter.options.BuildTool.MAVEN
 import static io.micronaut.starter.options.JdkVersion.JDK_11
 import static io.micronaut.starter.options.JdkVersion.JDK_8
 import static io.micronaut.starter.options.Language.GROOVY
-import static io.micronaut.starter.options.Language.JAVA
-import static io.micronaut.starter.options.Language.KOTLIN
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
 @CompileStatic
-class GuideProjectGenerator implements Closeable {
+class GuideProjectGenerator implements AutoCloseable {
 
     public static final String DEFAULT_APP_NAME = 'default'
 
@@ -49,7 +45,7 @@ class GuideProjectGenerator implements Closeable {
     }
 
     @Override
-    void close() throws IOException {
+    void close() {
         applicationContext.close()
     }
 
@@ -67,13 +63,16 @@ class GuideProjectGenerator implements Closeable {
     private static GuideMetadata parseGuideMetadata(File dir, String metadataConfigName) {
         File configFile = new File(dir, metadataConfigName)
         if (!configFile.exists()) {
-            throw new GradleException("metadata file not found for ${dir.name}")
+            throw new GradleException("metadata file not found for " + dir.name)
         }
+
         def config = new JsonSlurper().parse(configFile)
+
         Category cat = Category.values().find {it.toString() == config.category }
         if (!cat) {
             throw new GradleException("$config.category does not exist in Category enum")
         }
+
         new GuideMetadata(
                 asciidoctor: config.asciidoctor,
                 slug: config.slug,
@@ -90,52 +89,52 @@ class GuideProjectGenerator implements Closeable {
                 skipMavenTests: config.skipMavenTests ?: false,
                 minimumJavaVersion: config.minimumJavaVersion,
                 zipIncludes: config.zipIncludes ?: [],
-                apps: config.apps.collect { it -> new App(name: it.name,
+                apps: config.apps.collect { it -> new App(
+                        name: it.name,
                         features: it.features,
                         applicationType: it.applicationType ? ApplicationType.valueOf(it.applicationType.toUpperCase()) : ApplicationType.DEFAULT,
                         excludeSource:  it.excludeSource,
-                        excludeTest:  it.excludeTest,
-                )
+                        excludeTest:  it.excludeTest)
                 }
         )
     }
 
     @CompileDynamic
-    void generate(File guidesFolder,
+    void generate(File guidesDir,
                   File output,
                   String metadataConfigName,
                   File asciidocDir) {
 
-        guidesFolder.eachDir { dir ->
+        guidesDir.eachDir { dir ->
             GuideMetadata metadata = parseGuideMetadata(dir, metadataConfigName)
             try {
                 if (Utils.process(metadata, false)) {
                     generateOne(metadata, dir, output)
                     GuideAsciidocGenerator.generate(metadata, dir, asciidocDir)
                 }
-            } catch(IllegalArgumentException e) {
+            } catch(IllegalArgumentException ignored) {
             }
         }
     }
 
     static String folderName(String slug, GuidesOption guidesOption) {
-        "${slug}-${guidesOption.buildTool.toString()}-${guidesOption.language}"
+        "${slug}-${guidesOption.buildTool}-${guidesOption.language}"
     }
 
     private void generateOne(GuideMetadata metadata, File inputDir, File outputDir) {
-        String packageAndName = "${BASE_PACKAGE}.${APP_NAME}"
 
-        List<GuidesOption> guidesOptionList = guidesOptions(metadata)
+        if (!outputDir.exists()) {
+            assert outputDir.mkdir()
+        }
+
+        String packageAndName = BASE_PACKAGE + '.' + APP_NAME
         JdkVersion javaVersion = Utils.parseJdkVersion()
 
+        List<GuidesOption> guidesOptionList = guidesOptions(metadata)
         for (GuidesOption guidesOption : guidesOptionList) {
             BuildTool buildTool = guidesOption.buildTool
             TestFramework testFramework = guidesOption.testFramework
             Language lang = guidesOption.language
-
-            if (!outputDir.exists()) {
-                assert outputDir.mkdir()
-            }
 
             for (App app: metadata.apps) {
                 List<String> appFeatures = [] + app.features
@@ -149,22 +148,25 @@ class GuideProjectGenerator implements Closeable {
                     appFeatures.remove('mockito')
                 }
 
-                // Normal guide use 'default' as name, multi project guides have different modules
-                String appName = app.name == DEFAULT_APP_NAME ? StringUtils.EMPTY_STRING : app.name
-                String folder = folderName(metadata.slug, guidesOption)
-
-                Path destinationPath = Paths.get(outputDir.absolutePath, folder, appName)
-                File destination = destinationPath.toFile()
-                destination.mkdir()
-
                 if (metadata.minimumJavaVersion != null) {
                     JdkVersion minimumJavaVersion = JdkVersion.valueOf(metadata.minimumJavaVersion)
                     if (minimumJavaVersion.majorVersion() > javaVersion.majorVersion()) {
                         javaVersion = minimumJavaVersion
                     }
                 }
-                guidesGenerator.generateAppIntoDirectory(destination, app.applicationType, packageAndName, appFeatures, buildTool, testFramework, lang, javaVersion)
 
+                // typical guides use 'default' as name, multi-project guides have different modules
+                String appName = app.name == DEFAULT_APP_NAME ? EMPTY_STRING : app.name
+                String folder = folderName(metadata.slug, guidesOption)
+
+                Path destinationPath = Paths.get(outputDir.absolutePath, folder, appName)
+                File destination = destinationPath.toFile()
+                destination.mkdir()
+
+                guidesGenerator.generateAppIntoDirectory(destination, app.applicationType, packageAndName,
+                        appFeatures, buildTool, testFramework, lang, javaVersion)
+
+                // look for a common 'src' directory shared by multiple languages and copy those files first
                 final String srcFolder = 'src'
                 Path srcPath = Paths.get(inputDir.absolutePath, appName, srcFolder)
                 if (srcPath.toFile().exists()) {
@@ -176,6 +178,7 @@ class GuideProjectGenerator implements Closeable {
                     throw new GradleException("source folder " + sourcePath.toFile().absolutePath + " does not exist")
                 }
 
+                // copy source/resource files for the current language
                 Files.walkFileTree(sourcePath, new CopyFileVisitor(destinationPath))
 
                 if (app.excludeSource) {
@@ -189,6 +192,7 @@ class GuideProjectGenerator implements Closeable {
                         deleteFile(destination, GuideAsciidocGenerator.testPath(appName,  testSource, testFramework), guidesOption)
                     }
                 }
+
                 if (metadata.zipIncludes) {
                     File destinationRoot = new File(outputDir.absolutePath, folder)
                     for (String zipInclude : metadata.zipIncludes) {
@@ -207,7 +211,7 @@ class GuideProjectGenerator implements Closeable {
                 .delete()
     }
 
-    private void copyFile(File inputDir, File destinationRoot, String filePath) {
+    private static void copyFile(File inputDir, File destinationRoot, String filePath) {
         File sourceFile = new File(inputDir, filePath)
         File destinationFile = new File(destinationRoot, filePath)
 
@@ -225,28 +229,16 @@ class GuideProjectGenerator implements Closeable {
         String testFramework = guideMetadata.testFramework
         List<GuidesOption> guidesOptionList = []
 
-        if (buildTools.contains(GRADLE.toString())) {
-            if (languages.contains(JAVA.toString())) {
-                guidesOptionList << createGuidesOption(GRADLE, JAVA, testFramework)
-            }
-            if (languages.contains(KOTLIN.toString())) {
-                guidesOptionList << createGuidesOption(GRADLE, KOTLIN, testFramework)
-            }
-            if (languages.contains(GROOVY.toString())) {
-                guidesOptionList << createGuidesOption(GRADLE, GROOVY, testFramework)
+        for (BuildTool buildTool : BuildTool.values()) {
+            if (buildTools.contains(buildTool.toString())) {
+                for (Language language : Language.values()) {
+                    if (languages.contains(language.toString())) {
+                        guidesOptionList << createGuidesOption(buildTool, language, testFramework)
+                    }
+                }
             }
         }
-        if (buildTools.contains(MAVEN.toString())) {
-            if (languages.contains(JAVA.toString())) {
-                guidesOptionList << createGuidesOption(MAVEN, JAVA, testFramework)
-            }
-            if (languages.contains(KOTLIN.toString())) {
-                guidesOptionList << createGuidesOption(MAVEN, KOTLIN, testFramework)
-            }
-            if (languages.contains(GROOVY.toString())) {
-                guidesOptionList << createGuidesOption(MAVEN, GROOVY, testFramework)
-            }
-        }
+
         guidesOptionList
     }
 

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -47,20 +47,14 @@ exit 0
                                       boolean forceExecuteEveryTest) {
 
         if (!Utils.process(metadata)) {
-            println "not adding $metadata.slug projects to test.sh, Utils.process is false"
             return true
         }
 
         if (forceExecuteEveryTest) {
-            println "adding $metadata.slug projects to test.sh, forceExecuteEveryTest is true"
             return false
         }
 
-        boolean skip = !guidesChanged.contains(metadata.slug)
-        if (skip) {
-            println "not adding $metadata.slug projects to test.sh, not in guidesChanged: $guidesChanged"
-        }
-        skip
+        return !guidesChanged.contains(metadata.slug)
     }
 
     static String generateScript(File guidesFolder, String metadataConfigName,
@@ -74,20 +68,11 @@ FAILED_PROJECTS=()
 EXIT_STATUS=0
 ''')
         List<String> slugsChanged = guidesChanged(changedFiles)
-        boolean forceChangedMicronautVersion = changesMicronautVersion(changedFiles)
-        boolean forceChangedDependencies = changesDependencies(changedFiles, slugsChanged)
-        boolean forceChangedBuildScr = changesBuildScr(changedFiles)
-        boolean forceGithubWorkflow = System.getenv(ENV_GITHUB_WORKFLOW) && System.getenv(ENV_GITHUB_WORKFLOW) != GITHUB_WORKFLOW_JAVA_CI
-        boolean forceNotGithubWorkflow = !changedFiles && !System.getenv(ENV_GITHUB_WORKFLOW)
-
-        boolean forceExecuteEveryTest = forceChangedMicronautVersion ||
-                                        forceChangedDependencies ||
-                                        forceChangedBuildScr ||
-                                        forceGithubWorkflow ||
-                                        forceNotGithubWorkflow
-        if (forceExecuteEveryTest) {
-            println "forceExecuteEveryTest true: changedMicronautVersion: $forceChangedMicronautVersion, changedDependencies: $forceChangedDependencies, changedBuildScr: $forceChangedBuildScr, githubWorkflow: $forceGithubWorkflow, notGithubWorkflow: $forceNotGithubWorkflow"
-        }
+        boolean forceExecuteEveryTest = changesMicronautVersion(changedFiles) ||
+                                        changesDependencies(changedFiles, slugsChanged) ||
+                                        changesBuildScr(changedFiles) ||
+                                        (System.getenv(ENV_GITHUB_WORKFLOW) && System.getenv(ENV_GITHUB_WORKFLOW) != GITHUB_WORKFLOW_JAVA_CI) ||
+                                        (!changedFiles && !System.getenv(ENV_GITHUB_WORKFLOW))
 
         List<GuideMetadata> metadatas = GuideProjectGenerator.parseGuidesMetadata(guidesFolder, metadataConfigName)
         metadatas.sort { it.slug }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -3,19 +3,20 @@ package io.micronaut.guides
 import groovy.transform.CompileStatic
 import io.micronaut.starter.options.BuildTool
 
+import static io.micronaut.guides.GuideProjectGenerator.DEFAULT_APP_NAME
+import static io.micronaut.starter.options.BuildTool.GRADLE
+import static io.micronaut.starter.options.BuildTool.MAVEN
+
 @CompileStatic
 class TestScriptGenerator {
 
     public static final String GITHUB_WORKFLOW_JAVA_CI = 'Java CI'
     public static final String ENV_GITHUB_WORKFLOW = 'GITHUB_WORKFLOW'
-
-    static String emptyScript() {
-        '''\
+    public static final String EMPTY_SCRIPT = '''\
 #!/usr/bin/env bash
 set -e
 exit 0
 '''
-    }
 
     private static List<String> guidesChanged(List<String> changedFiles) {
         changedFiles.findAll { path ->
@@ -56,20 +57,23 @@ exit 0
         return !guidesChanged.contains(metadata.slug)
     }
 
-    static String generateScript(File guidesFolder, String metadataConfigName, boolean stopIfFailure, List<String> changedFiles) {
-        String bashScript = '''\
+    static String generateScript(File guidesFolder, String metadataConfigName,
+                                 boolean stopIfFailure, List<String> changedFiles) {
+
+        StringBuilder bashScript = new StringBuilder('''\
 #!/usr/bin/env bash
 set -e
 
 FAILED_PROJECTS=()
 EXIT_STATUS=0
-'''
+''')
         List<String> slugsChanged = guidesChanged(changedFiles)
         boolean forceExecuteEveryTest = changesMicronautVersion(changedFiles) ||
                                         changesDependencies(changedFiles, slugsChanged) ||
                                         changesBuildScr(changedFiles) ||
                                         (System.getenv(ENV_GITHUB_WORKFLOW) && System.getenv(ENV_GITHUB_WORKFLOW) != GITHUB_WORKFLOW_JAVA_CI) ||
                                         (!changedFiles && !System.getenv(ENV_GITHUB_WORKFLOW))
+
         List<GuideMetadata> metadatas = GuideProjectGenerator.parseGuidesMetadata(guidesFolder, metadataConfigName)
         for (GuideMetadata metadata : metadatas) {
             boolean skip = shouldSkip(metadata, slugsChanged, forceExecuteEveryTest)
@@ -79,23 +83,23 @@ EXIT_STATUS=0
             List<GuidesOption> guidesOptionList = GuideProjectGenerator.guidesOptions(metadata)
             for (GuidesOption guidesOption : guidesOptionList) {
                 String folder = GuideProjectGenerator.folderName(metadata.slug, guidesOption)
-                BuildTool buildTool = folder.contains(BuildTool.MAVEN.toString()) ? BuildTool.MAVEN : BuildTool.GRADLE
-                if (buildTool == BuildTool.MAVEN && metadata.skipMavenTests) {
+                BuildTool buildTool = folder.contains(MAVEN.toString()) ? MAVEN : GRADLE
+                if (buildTool == MAVEN && metadata.skipMavenTests) {
                     continue
                 }
-                if (buildTool == BuildTool.GRADLE && metadata.skipGradleTests) {
+                if (buildTool == GRADLE && metadata.skipGradleTests) {
                     continue
                 }
-                if (metadata.apps.any { it.name == GuideProjectGenerator.DEFAULT_APP_NAME } ) {
-                    bashScript += scriptForFolder(folder, folder, stopIfFailure, buildTool)
+                if (metadata.apps.any { it.name == DEFAULT_APP_NAME } ) {
+                    bashScript << scriptForFolder(folder, folder, stopIfFailure, buildTool)
                 } else {
-                    bashScript += """\
-cd ${folder}
+                    bashScript << """\
+cd $folder
 """
                     for (GuideMetadata.App app : metadata.apps) {
-                        bashScript += scriptForFolder(app.name, folder + '/' + app.name, stopIfFailure, buildTool)
+                        bashScript << scriptForFolder(app.name, folder + '/' + app.name, stopIfFailure, buildTool)
                     }
-                    bashScript += """\
+                    bashScript << """\
 cd ..
 """
                 }
@@ -103,7 +107,7 @@ cd ..
         }
 
         if (!stopIfFailure) {
-            bashScript += '''
+            bashScript << '''
 if [ ${#FAILED_PROJECTS[@]} -ne 0 ]; then
   echo ""
   echo "-------------------------------------------------"
@@ -119,29 +123,31 @@ fi
 
 '''
         }
+
         bashScript
     }
 
-    private static String scriptForFolder(String nestedFolder, String folder, boolean stopIfFailure, BuildTool buildTool) {
+    private static String scriptForFolder(String nestedFolder, String folder,
+                                          boolean stopIfFailure, BuildTool buildTool) {
         String bashScript = """\
-cd ${nestedFolder}
+cd $nestedFolder
 echo "-------------------------------------------------"
-echo "Executing '${folder}' tests"
-${buildTool == BuildTool.MAVEN ? './mvnw -q test' : './gradlew -q test' } || EXIT_STATUS=\$?
+echo "Executing '$folder' tests"
+${buildTool == MAVEN ? './mvnw -q test' : './gradlew -q test' } || EXIT_STATUS=\$?
 cd ..
 """
         if (stopIfFailure) {
             bashScript += """\
 if [ \$EXIT_STATUS -ne 0 ]; then
-  echo "'${folder}' tests failed => exit \$EXIT_STATUS"
+  echo "'$folder' tests failed => exit \$EXIT_STATUS"
   exit \$EXIT_STATUS
 fi
 """
         } else {
             bashScript += """\
 if [ \$EXIT_STATUS -ne 0 ]; then
-  FAILED_PROJECTS=("\${FAILED_PROJECTS[@]}" ${folder})
-  echo "'${folder}' tests failed => exit \$EXIT_STATUS"
+  FAILED_PROJECTS=("\${FAILED_PROJECTS[@]}" $folder)
+  echo "'$folder' tests failed => exit \$EXIT_STATUS"
 fi
 EXIT_STATUS=0
 """

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -75,6 +75,8 @@ EXIT_STATUS=0
                                         (!changedFiles && !System.getenv(ENV_GITHUB_WORKFLOW))
 
         List<GuideMetadata> metadatas = GuideProjectGenerator.parseGuidesMetadata(guidesFolder, metadataConfigName)
+        metadatas.sort { it.slug }
+
         for (GuideMetadata metadata : metadatas) {
             boolean skip = shouldSkip(metadata, slugsChanged, forceExecuteEveryTest)
             if (skip) {

--- a/buildSrc/src/main/groovy/io/micronaut/guides/ThemeProcessor.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/ThemeProcessor.groovy
@@ -2,7 +2,9 @@ package io.micronaut.guides
 
 class ThemeProcessor {
 
-    static void applyThemes(File template, File dist, File guidesFolder, String metadataConfigName) {
+    static void applyThemes(File template, File dist,
+                            File guidesFolder, String metadataConfigName) {
+
         String templateText = template.text
         List<GuideMetadata> metadatas = GuideProjectGenerator.parseGuidesMetadata(guidesFolder, metadataConfigName)
         String tocStart = '''\
@@ -15,10 +17,12 @@ class ThemeProcessor {
 <div id="content">
 '''
         String sectionbody = '<div class="sectionbody">'
+
         for (GuideMetadata metadata : metadatas) {
             if (!Utils.process(metadata, false)) {
                 continue
             }
+
             List<GuidesOption> guidesOptionList = GuideProjectGenerator.guidesOptions(metadata)
             for (GuidesOption guidesOption : guidesOptionList) {
 
@@ -28,31 +32,32 @@ class ThemeProcessor {
                     File output = new File(dist.path, folder + ".html")
                     String html = output.text
 
-                    String toc = html.indexOf(startDivContent) != -1 ? html.substring(html.indexOf(tocStart) + tocStart.length(),
-                            html.indexOf(startDivContent)) : ''
-                    String content = html.indexOf(sectionbody) != -1 ? html.substring(html.indexOf(sectionbody) + sectionbody.length(),
-                            html.indexOf('''\
+                    String toc = html.indexOf(startDivContent) == -1 ? '' :
+                            html.substring(html.indexOf(tocStart) + tocStart.length(), html.indexOf(startDivContent))
+                    String content = html.indexOf(sectionbody) == -1 ? '' :
+                            html.substring(html.indexOf(sectionbody) + sectionbody.length(), html.indexOf('''\
 </div>
 </div>
 </div>
 </body>
-''')) : ''
-                    content = content != '' ? ('''\
+'''))
+                    content = content == '' ? '' : '''\
 <div class="sect1">
 <div class="sectionbody">
-''' + content) : ''
+''' + content
+
+                    String breadcrumb = '<a href="' + metadata.slug + '.html">' + metadata.title + '</a>' +
+                            ' » <span class="breadcrumb_last" aria-current="page">' + guidesOption.buildTool + ' | ' + guidesOption.language + '</span>'
+
                     text = text.replace("@title@", metadata.title)
                     text = text.replace("@twittercard@", IndexGenerator.twitterCardHtml(dist, metadata))
-                    String breadcrumb = '<a href="' + metadata.slug + '.html">' + metadata.title + '</a> » <span class="breadcrumb_last" aria-current="page">' + guidesOption.buildTool + ' | ' + guidesOption.language + '</span>'
                     text = text.replace("@breadcrumb@", breadcrumb)
                     text = text.replace("@toctitle@", 'Table of Contents')
                     text = text.replace("@bodyclass@", 'guide')
                     text = text.replace("@toccontent@", toc)
                     text = text.replace("@content@", content)
                     output.text = text
-
-                } catch (FileNotFoundException e) {
-
+                } catch (FileNotFoundException ignored) {
                 }
             }
         }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/Utils.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/Utils.groovy
@@ -22,10 +22,14 @@ class Utils {
             return false
         }
 
-        if (checkJdk && metadata.minimumJavaVersion != null) {
+        if (checkJdk) {
             int jdkVersion = parseJdkVersion().majorVersion()
-            if (jdkVersion < metadata.minimumJavaVersion) {
+            if (metadata.minimumJavaVersion != null && jdkVersion < metadata.minimumJavaVersion) {
                 println "not processing $metadata.slug, JDK $jdkVersion < $metadata.minimumJavaVersion"
+                return false
+            }
+            if (metadata.maximumJavaVersion != null && jdkVersion > metadata.maximumJavaVersion) {
+                println "not processing $metadata.slug, JDK $jdkVersion > $metadata.maximumJavaVersion"
                 return false
             }
         }

--- a/buildSrc/src/main/groovy/io/micronaut/guides/Utils.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/Utils.groovy
@@ -22,9 +22,12 @@ class Utils {
             return false
         }
 
-        if (checkJdk) {
-            return metadata.minimumJavaVersion == null ||
-                    parseJdkVersion().majorVersion() >= metadata.minimumJavaVersion
+        if (checkJdk && metadata.minimumJavaVersion != null) {
+            int jdkVersion = parseJdkVersion().majorVersion()
+            if (jdkVersion < metadata.minimumJavaVersion) {
+                println "not processing $metadata.slug, JDK $jdkVersion < $metadata.minimumJavaVersion"
+                return false
+            }
         }
 
         return true

--- a/gradle/asciidoc.gradle
+++ b/gradle/asciidoc.gradle
@@ -23,7 +23,6 @@ asciidoctorj {
     }
 
     attributes "sourcedir"          : "build/code",
-               "commondir"          : "src/docs/common",
                "source-highlighter" : "coderay",
                "toc"                : "left",
                "toclevels"          : 2,

--- a/guides/micronaut-azure-http-functions/metadata.json
+++ b/guides/micronaut-azure-http-functions/metadata.json
@@ -6,6 +6,7 @@
   "authors": ["Sergio del Amo"],
   "tags": ["azure", "function"],
   "category": "Micronaut + Microsoft Azure",
+  "maximumJavaVersion": 11,
   "publicationDate": "2021-05-08",
   "apps": [
     {

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/AwsResourceAccessCondition.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/AwsResourceAccessCondition.groovy
@@ -15,11 +15,11 @@ class AwsResourceAccessCondition implements Condition {
     @Override
     boolean matches(ConditionContext context) {
 
-        if (StringUtils.isNotEmpty(System.getProperty("aws.accessKeyId")) &&  StringUtils.isNotEmpty(System.getProperty("aws.secretAccessKey"))) { // <1>
+        if (StringUtils.isNotEmpty(System.getProperty("aws.accessKeyId")) && StringUtils.isNotEmpty(System.getProperty("aws.secretAccessKey"))) { // <1>
             return true
         }
 
-        if (StringUtils.isNotEmpty(System.getenv("AWS_ACCESS_KEY_ID")) &&  StringUtils.isNotEmpty(System.getenv("AWS_SECRET_ACCESS_KEY"))) { // <2>
+        if (StringUtils.isNotEmpty(System.getenv("AWS_ACCESS_KEY_ID")) && StringUtils.isNotEmpty(System.getenv("AWS_SECRET_ACCESS_KEY"))) { // <2>
             return true
         }
 

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/AwsSesMailService.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/AwsSesMailService.groovy
@@ -25,15 +25,17 @@ import javax.validation.constraints.NotNull
 @Singleton // <1>
 @Requires(condition = AwsResourceAccessCondition)  // <2>
 @Secondary // <3>
-public class AwsSesMailService implements EmailService {
-    private static final Logger LOG = LoggerFactory.getLogger(AwsSesMailService.class)
+class AwsSesMailService implements EmailService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AwsSesMailService)
+
     protected final String sourceEmail
     protected final SesClient ses
 
-    public AwsSesMailService(@Nullable @Value('${AWS_REGION}') String awsRegionEnv, // <4>
-                             @Nullable @Value('${AWS_SOURCE_EMAIL}') String sourceEmailEnv,
-                             @Nullable @Value('${aws.region}') String awsRegionProp,
-                             @Nullable @Value('${aws.sourceemail}') String sourceEmailProp) {
+    AwsSesMailService(@Nullable @Value('${AWS_REGION}') String awsRegionEnv, // <4>
+                      @Nullable @Value('${AWS_SOURCE_EMAIL}') String sourceEmailEnv,
+                      @Nullable @Value('${aws.region}') String awsRegionProp,
+                      @Nullable @Value('${aws.sourceemail}') String sourceEmailProp) {
 
         this.sourceEmail = sourceEmailEnv != null ? sourceEmailEnv : sourceEmailProp
         String awsRegion = awsRegionEnv != null ? awsRegionEnv : awsRegionProp

--- a/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/SendGridEmailService.groovy
+++ b/guides/micronaut-email/groovy/src/main/groovy/example/micronaut/SendGridEmailService.groovy
@@ -13,7 +13,6 @@ import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.NonNull
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.stream.Collectors
 import jakarta.inject.Singleton
 import javax.validation.Valid
 import javax.validation.constraints.NotNull
@@ -47,7 +46,7 @@ class SendGridEmailService implements EmailService {
     }
 
     @Override
-    public void send(@NonNull @NotNull @Valid Email email) {
+    void send(@NonNull @NotNull @Valid Email email) {
 
         Personalization personalization = new Personalization()
         personalization.setSubject(email.subject)
@@ -88,13 +87,13 @@ class SendGridEmailService implements EmailService {
 
             Response response = sg.api(request)
 
-            if (LOG.isInfoEnabled()) {
-                LOG.info("Status Code: {}", String.valueOf(response.getStatusCode()))
-                LOG.info("Body: {}", response.getBody())
-                LOG.info("Headers {}", "{${response.headers.collect { k, v -> "$k=$v" }.join(", ")}}".toString())
+            if (LOG.infoEnabled) {
+                LOG.info("Status Code: {}", response.statusCode)
+                LOG.info("Body: {}", response.body)
+                LOG.info("Headers {}", response.headers.collect { k, v -> "$k=$v" }.join(", "))
             }
-        } catch (IOException ex) {
-            LOG.error(ex.getMessage())
+        } catch (IOException e) {
+            LOG.error(e.message, e)
         }
     }
 }

--- a/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
@@ -6,7 +6,6 @@ import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
-import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import javax.validation.constraints.NotBlank
 //end::packageandimports[]

--- a/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
@@ -4,7 +4,6 @@ package example.micronaut
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
-import reactor.core.publisher.Flux
 import org.reactivestreams.Publisher
 //end::packageandimports[]
 

--- a/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
@@ -6,7 +6,6 @@ import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
-import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import javax.validation.constraints.NotBlank
 //end::packageandimports[]


### PR DESCRIPTION
I re-did the remaining unmerged work from https://github.com/micronaut-projects/micronaut-guides/pull/684 (minus the changes to support includes from `src/docs/common/partial` which I'm reworking in another PR) so it's more clear what's changing.

As before, look at the individual commits. The first two are non-functional cleanup changes. The 3rd involves passing the Gradle `projectDir` to the Groovy helper classes to simplify the relative paths and make it easier to include from one guide directory to another