### PR TITLE
New guideLink macro

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -12,6 +12,7 @@ import io.micronaut.starter.build.dependencies.PomDependencyVersionResolver
 import org.gradle.api.GradleException
 
 import java.util.Map.Entry
+import java.util.regex.Pattern
 
 import static io.micronaut.guides.GuideProjectGenerator.DEFAULT_APP_NAME
 import static io.micronaut.starter.api.TestFramework.SPOCK
@@ -21,6 +22,7 @@ class GuideAsciidocGenerator {
 
     private static final String INCLUDE_COMMONDIR = 'common:'
     private static final String CALLOUT = 'callout:'
+    private static final Pattern GUIDE_LINK_REGEX = ~/(.*)guideLink:(.*)\[(.*)](.*)/
 
     public static final int DEFAULT_MIN_JDK = 8
     public static final String EXCLUDE_FOR_LANGUAGES = ':exclude-for-languages:'
@@ -33,7 +35,7 @@ class GuideAsciidocGenerator {
         File asciidocFile = new File(inputDir, metadata.asciidoctor)
         assert asciidocFile.exists()
 
-        List<String> rawLinesExpanded = expandAllCommonIncludes(asciidocFile.readLines(), projectDir)
+        List<String> rawLinesExpanded = expandMacros(asciidocFile.readLines(), projectDir)
 
         List<GuidesOption> guidesOptionList = GuideProjectGenerator.guidesOptions(metadata)
         for (GuidesOption guidesOption : guidesOptionList) {
@@ -151,10 +153,15 @@ class GuideAsciidocGenerator {
         }
     }
 
-    private static List<String> expandAllCommonIncludes(List<String> lines, File projectDir) {
+    private static List<String> expandMacros(List<String> lines, File projectDir) {
         List<String> rawLines = []
 
         for (String rawLine : lines) {
+
+            if (findInlineMacro(rawLine, 'guideLink:')) {
+                rawLine = processGuideLink(rawLine)
+            }
+
             if (rawLine.startsWith(CALLOUT) && rawLine.endsWith(']')) {
                 rawLines << callout(rawLine, projectDir)
             } else if (rawLine.startsWith(INCLUDE_COMMONDIR) && rawLine.endsWith('[]')) {
@@ -227,11 +234,20 @@ class GuideAsciidocGenerator {
 
     private static List<String> commonLines(File file, File projectDir) {
         assert file.exists()
-        return expandAllCommonIncludes(file.readLines(), projectDir)
+        return expandMacros(file.readLines(), projectDir)
     }
 
     private static boolean shouldProcessLine(String line, String macro) {
         line.startsWith(macro) && line.contains('[') && line.endsWith(']')
+    }
+
+    private static boolean findInlineMacro(String line, String macro) {
+        if (line.contains(macro)) {
+            int indexBracket = line.indexOf('[')
+            indexBracket > -1 && line.indexOf(']') > indexBracket
+        } else {
+            false
+        }
     }
 
     private static String extractName(String line, String macro) {
@@ -429,6 +445,12 @@ class GuideAsciidocGenerator {
 
         "NOTE: If you have an existing Micronaut application and want to add the functionality described here, you can " +
         link + " and apply those changes to your application."
+    }
+
+    private static String processGuideLink(String line) {
+        line.find(GUIDE_LINK_REGEX) { String match, String before, String slug, String text, String after ->
+            "${before}https://guides.micronaut.io/latest/${slug}.html[$text]$after"
+        }
     }
 
     private static String extractAppName(String line) {

--- a/guides/micronaut-aws-secretsmanager-rotation/micronaut-aws-secretsmanager-rotation.adoc
+++ b/guides/micronaut-aws-secretsmanager-rotation/micronaut-aws-secretsmanager-rotation.adoc
@@ -27,8 +27,8 @@ common:function-delete-sample-code.adoc[]
 
 This guide is complementary to:
 
-* https://guides.micronaut.io/latest/micronaut-aws-secretsmanager.html[Distributed Configuration with AWS Secrets Manager and the Micronaut Framework]
-* https://guides.micronaut.io/latest/micronaut-security-keys-jwks.html[JWK Keys Endpoint]
+* guideLink:micronaut-aws-secretsmanager[Distributed Configuration with AWS Secrets Manager and the Micronaut Framework]
+* guideLink:micronaut-security-keys-jwks[JWK Keys Endpoint]
 
 === JSON Web Key Generation
 
@@ -154,7 +154,7 @@ common:next.adoc[]
 
 Check the guides:
 
-* https://guides.micronaut.io/latest/micronaut-aws-secretsmanager.html[Distributed Configuration with AWS Secrets Manager and the Micronaut Framework]
-* https://guides.micronaut.io/latest/micronaut-security-keys-jwks.html[JWK Keys Endpoint]
+* guideLink:micronaut-aws-secretsmanager[Distributed Configuration with AWS Secrets Manager and the Micronaut Framework]
+* guideLink:micronaut-security-keys-jwks[JWK Keys Endpoint]
 
 common:helpWithMicronaut.adoc[]

--- a/guides/micronaut-microservices-distributed-tracing-jaeger/micronaut-microservices-distributed-tracing-jaeger.adoc
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger/micronaut-microservices-distributed-tracing-jaeger.adoc
@@ -16,7 +16,7 @@ common:completesolution.adoc[]
 
 == Writing the Application
 
-To learn more about this sample application, read the https://guides.micronaut.io/micronaut-microservices-services-discover-consul/guide/[Consul and the Micronaut Framework - Microservices Service Discovery] guide. The application contains three microservices.
+To learn more about this sample application, read the guideLink:micronaut-microservices-services-discover-consul[Consul and the Micronaut Framework - Microservices Service Discovery] guide. The application contains three microservices.
 
 * `bookcatalogue` - This returns a list of books. It uses a domain consisting of a book name and an ISBN.
 

--- a/guides/micronaut-microservices-distributed-tracing-zipkin/micronaut-microservices-distributed-tracing-zipkin.adoc
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin/micronaut-microservices-distributed-tracing-zipkin.adoc
@@ -16,7 +16,7 @@ common:completesolution.adoc[]
 
 == Writing the Application
 
-To learn more about this sample application, read the https://guides.micronaut.io/latest/micronaut-microservices-services-discover-consul-@build@-@lang@.html[Consul and the Micronaut Framework - Microservices Service Discovery] guide. The application contains three microservices.
+To learn more about this sample application, read the guideLink:micronaut-microservices-services-discover-consul[Consul and the Micronaut Framework - Microservices Service Discovery] guide. The application contains three microservices.
 
 * `bookcatalogue` - This returns a list of books. It uses a domain consisting of a book name and an ISBN.
 

--- a/guides/micronaut-oauth2-client-credentials-auth0/micronaut-oauth2-client-credentials-auth0.adoc
+++ b/guides/micronaut-oauth2-client-credentials-auth0/micronaut-oauth2-client-credentials-auth0.adoc
@@ -8,7 +8,7 @@ common:completesolution.adoc[]
 
 == Application Diagram
 
-Download the complete solution of the https://guides.micronaut.io/latest/micronaut-microservices-services-discover-consul-@build@-@lang@.html[Consul and Micronaut Framework - Microservices Service Discovery] guide. You will use the sample app as a starting point. The application contains three microservices:
+Download the complete solution of the guideLink:micronaut-microservices-services-discover-consul[Consul and Micronaut Framework - Microservices Service Discovery] guide. You will use the sample app as a starting point. The application contains three microservices:
 
 * `bookcatalogue` - This returns a list of books. It uses a domain consisting of a book name and an ISBN.
 

--- a/guides/micronaut-oauth2-client-credentials-cognito/micronaut-oauth2-client-credentials-cognito.adoc
+++ b/guides/micronaut-oauth2-client-credentials-cognito/micronaut-oauth2-client-credentials-cognito.adoc
@@ -8,7 +8,7 @@ common:completesolution.adoc[]
 
 == Application Diagram
 
-Download the complete solution of the https://guides.micronaut.io/latest/micronaut-microservices-services-discover-consul-@build@-@lang@.html[Consul and Micronaut Framework - Microservices Service Discovery] guide. You will use the sample app as a starting point. The application contains three microservices:
+Download the complete solution of the guideLink:micronaut-microservices-services-discover-consul[Consul and Micronaut Framework - Microservices Service Discovery] guide. You will use the sample app as a starting point. The application contains three microservices:
 
 * `bookcatalogue` - Returns a list of books. It uses a domain consisting of a book name and an ISBN.
 

--- a/guides/micronaut-oracle-autonomous-db/micronaut-oracle-autonomous-db.adoc
+++ b/guides/micronaut-oracle-autonomous-db/micronaut-oracle-autonomous-db.adoc
@@ -416,6 +416,6 @@ common:next.adoc[]
 
 Read more about the https://micronaut-projects.github.io/micronaut-oracle-cloud/latest/guide/[Micronaut Oracle Cloud] integration.
 
-Optionally, you can use the approach described in https://guides.micronaut.io/latest/micronaut-oracle-cloud.html[Deploy a Micronaut application to Oracle Cloud] to deploy this application to Oracle Cloud.
+Optionally, you can use the approach described in guideLink:micronaut-oracle-cloud[Deploy a Micronaut application to Oracle Cloud] to deploy this application to Oracle Cloud.
 
 common:helpWithMicronaut.adoc[]

--- a/guides/micronaut-oracle-cloud-streaming/micronaut-oracle-cloud-streaming.adoc
+++ b/guides/micronaut-oracle-cloud-streaming/micronaut-oracle-cloud-streaming.adoc
@@ -366,7 +366,7 @@ image::oraclecloudstream/ui4.png[]
 
 Update the `chess-listener` microservice to support Oracle in addition to the in-memory H2 database.
 
-Use the https://guides.micronaut.io/latest/micronaut-oracle-autonomous-db.html[Oracle Autonomous Database guide] to provision an Oracle database at OCI.
+Use the guideLink:micronaut-oracle-autonomous-db[Oracle Autonomous Database guide] to provision an Oracle database at OCI.
 
 ==== Dependencies
 
@@ -603,7 +603,7 @@ common:testApp-noheader.adoc[]
 
 Once you've verified that the microservices work with the configured cloud resources, you can deploy the microservices to Compute instances and run everything in Oracle Cloud.
 
-Follow the steps in https://guides.micronaut.io/latest/micronaut-oracle-cloud.html[this guide] for each service.
+Follow the steps in guideLink:micronaut-oracle-cloud[this guide] for each service.
 
 === Instance Principal authentication
 
@@ -729,4 +729,4 @@ Now you can scp each native image to a Compute instance with no Java installed a
 
 Read more about https://micronaut-projects.github.io/micronaut-kafka/latest/guide/[Kafka support] in the Micronaut framework.
 
-Also see https://guides.micronaut.io/latest/micronaut-kafka.html[this guide on the Micronaut framework + Kafka].
+Also see guideLink:micronaut-kafka[this guide on the Micronaut framework + Kafka].

--- a/guides/micronaut-oracle-function-http/micronaut-oracle-function-http.adoc
+++ b/guides/micronaut-oracle-function-http/micronaut-oracle-function-http.adoc
@@ -122,7 +122,7 @@ Then open `build/reports/tests/test/index.html` in a browser to see the results.
 
 We need to configure some cloud infrastructure to support deploying functions.
 
-Initially, do all the configuration steps described in the https://guides.micronaut.io/latest/micronaut-oracle-function.html[Deploy a Micronaut Function (Serverless) application to Oracle Cloud] guide's "Configuring Oracle Cloud Resources" section since they're the same as for HTTP Gateway functions. To summarize, do the following (unless a resource exists and can be used):
+Initially, do all the configuration steps described in the guideLink:micronaut-oracle-function[Deploy a Micronaut Function (Serverless) application to Oracle Cloud] guide's "Configuring Oracle Cloud Resources" section since they're the same as for HTTP Gateway functions. To summarize, do the following (unless a resource exists and can be used):
 
 - create a compartment
 - create a function user and group
@@ -169,7 +169,7 @@ image::oraclefnhttp/function5.png[]
 
 == Configuring Oracle Cloud Resources (continued)
 
-Like earlier, do all the configuration steps described in the https://guides.micronaut.io/latest/micronaut-oracle-function.html[Deploy a Micronaut Function (Serverless) application to Oracle Cloud] guide's "Enable Tracing and Logs" section since they're the same as for HTTP Gateway functions. To summarize, do the following (unless a resource exists and can be used):
+Like earlier, do all the configuration steps described in the guideLink:micronaut-oracle-function[Deploy a Micronaut Function (Serverless) application to Oracle Cloud] guide's "Enable Tracing and Logs" section since they're the same as for HTTP Gateway functions. To summarize, do the following (unless a resource exists and can be used):
 
 - create an APM domain
 - enable logs for your HTTP function
@@ -279,7 +279,7 @@ image::oraclefnhttp/policy5.png[]
 
 == Invoking the function
 
-Since the function works with Compute Instances, make sure you have at least one running. If you don't have any, one easy option is with the https://guides.micronaut.io/latest/micronaut-oracle-cloud.html[Deploy a Micronaut application to Oracle Cloud] guide.
+Since the function works with Compute Instances, make sure you have at least one running. If you don't have any, one easy option is with the guideLink:micronaut-oracle-cloud[Deploy a Micronaut application to Oracle Cloud] guide.
 
 Now is when you need the base controller URL that you copied when creating the API Gateway; it should look something like `\https://cjrgh5e3lfqz....apigateway.us-ashburn-1.oci.customer-oci.com/compute` and end in `/compute` since that's the root URI of the controller.
 

--- a/guides/micronaut-security-keys-jwks/micronaut-security-keys-jwks.adoc
+++ b/guides/micronaut-security-keys-jwks/micronaut-security-keys-jwks.adoc
@@ -88,7 +88,7 @@ Create a test to verify that the application can generate a signed JSON Web Toke
 
 test:TokenGeneratorTest[]
 
-<1> See how to generate a JSON Web Key in the guide: https://guides.micronaut.io/latest/micronaut-cli-jwkgen.html[JWK generation with a Micronaut command line application]
+<1> See how to generate a JSON Web Key in the guide: guideLink:micronaut-cli-jwkgen[JWK generation with a Micronaut command line application]
 
 === Secondary signature validation
 
@@ -96,7 +96,7 @@ Create a test to verify that the application can validate a JSON Web Token signe
 
 test:ValidateSecondarySignedJwtTest[]
 
-<1> See how to generate a JSON Web Key in the guide: https://guides.micronaut.io/latest/micronaut-cli-jwkgen.html[JWK generation with a Micronaut command line application]
+<1> See how to generate a JSON Web Key in the guide: guideLink:micronaut-cli-jwkgen[JWK generation with a Micronaut command line application]
 
 === Keys test
 
@@ -104,7 +104,7 @@ Create a test to verify that the application exposes a `keys` endpoint:
 
 test:KeysTest[]
 
-<1> See how to generate a JSON Web Key in the guide: https://guides.micronaut.io/latest/micronaut-cli-jwkgen.html[JWK generation with a Micronaut command line application]
+<1> See how to generate a JSON Web Key in the guide: guideLink:micronaut-cli-jwkgen[JWK generation with a Micronaut command line application]
 
 == Refresh endpoint
 
@@ -162,6 +162,6 @@ common:next.adoc[]
 
 Read more about https://micronaut-projects.github.io/micronaut-security/latest/guide/[Micronaut Security].
 
-Check out the guide https://guides.micronaut.io/latest/micronaut-cli-jwkgen.html[JWK Generation with a Micronaut Command Line Application].
+Check out the guide guideLink:micronaut-cli-jwkgen[JWK Generation with a Micronaut Command Line Application].
 
 common:helpWithMicronaut.adoc[]


### PR DESCRIPTION
Simplifies and standardizes creating a link to another guide.

The syntax is

`guideLink:{slug}[{link text}]`

e.g.

`Use the guideLink:micronaut-oracle-autonomous-db[Oracle Autonomous Database guide] to provision an Oracle database at OCI.`

which will generate an inline link to https://guides.micronaut.io/latest/micronaut-oracle-autonomous-db.html with text "Oracle Autonomous Database guide"

