### PR TITLE
derive value of asciidoctor and slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ All the guides are in the `guides` directory in separate subdirectories. Inside 
 
 ```json
 {
-  "asciidoctor": "micronaut-http-client.adoc",
-  "slug": "micronaut-http-client",
   "title": "Micronaut HTTP Client",
   "intro": "Learn how to use Micronaut low-level HTTP Client. Simplify your code with the declarative HTTP client.",
   "authors": ["Sergio del Amo", "Iván López"],
@@ -81,7 +79,6 @@ Besides, the obvious fields that doesn't need any further explanation, the other
   ]
 ```
 The features need to be **valid** features from Starter because the list is used directly when generating the applications using Starter infrastructure. If you need a feature that is not available on Starter, create it in `buildSrc/src/main/java/io/micronaut/guides/feature`. Also declare the GAV coordinates and version in `buildSrc/src/main/resources/pom.xml`. Dependabot is configured in this project to look for that file and send pull requests to update the dependencies.
-
 
 Inside the specific guide directory there should be a directory per language with the appropriate directory structure. All these files will be copied into the final guide directory after the guide is generated.
 
@@ -150,10 +147,9 @@ micronaut-microservices-distributed-tracing-zipkin
 
 ### Writing the guide
 
-There is only one Asciidoctor file per guide in the root directory of the guide (sibling to `metadata.json`). This unique file is used to generate all the combinations for the guide (language and build tool) so we need to take that into account when writing the guide.
+There is only one Asciidoctor file per guide in the root directory of the guide (sibling to `metadata.json`). This unique file is used to generate all the combinations for the guide (language and build tool) so we need to take that into account when writing the guide. Name the Asciidoctor file the same as the directory, with an "adoc" extension, e.g. `micronaut-http-client.adoc` for the `micronaut-http-client` guide directory.
 
 We don't really write a valid Asciidoctor file but our "own" Asciidoctor with custom kind-of-macros. Then during the build process we render the final HTML for the guide in two phases. In the first one we evaluate all of our custom macros and include and generate a new language-build tool version of the guide in `src/doc/asciidoc`. This directory is excluded from source control and needs to be considered temporary. Then we render the final HTML of the (up to) six guides from that generated and valid Asciidoctor file.
-
 
 #### Common snippets
 

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -70,7 +70,7 @@ class GuideProjectGenerator implements AutoCloseable {
             throw new GradleException("metadata file not found for " + dir.name)
         }
 
-        def config = new JsonSlurper().parse(configFile)
+        Map config = new JsonSlurper().parse(configFile)
         boolean publish = config.publish == null ? true : config.publish
 
         Category cat = Category.values().find {it.toString() == config.category }
@@ -79,8 +79,8 @@ class GuideProjectGenerator implements AutoCloseable {
         }
 
         new GuideMetadata(
-                asciidoctor: config.asciidoctor,
-                slug: config.slug,
+                asciidoctor: publish ? dir.name + '.adoc' : null,
+                slug: dir.name,
                 title: config.title,
                 intro: config.intro,
                 authors: config.authors,

--- a/guides/adding-commit-info/metadata.json
+++ b/guides/adding-commit-info/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "adding-commit-info.adoc",
-  "slug": "adding-commit-info",
   "title": "Adding Commit Info to your Micronaut Application",
   "intro": "Expose the exact version of code that your application is running.",
   "authors": ["Sergio del Amo"],

--- a/guides/creating-your-first-micronaut-app/metadata.json
+++ b/guides/creating-your-first-micronaut-app/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "creating-your-first-micronaut-app.adoc",
-  "slug": "creating-your-first-micronaut-app",
   "title": "Creating your first Micronaut application",
   "intro": "Learn how to create a Hello World Micronaut application with a controller and a functional test.",
   "authors": ["Iván López", "Sergio del Amo"],

--- a/guides/micronaut-aws-lambda-eventbridge-event/metadata.json
+++ b/guides/micronaut-aws-lambda-eventbridge-event/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-aws-lambda-eventbridge-event.adoc",
-  "slug": "micronaut-aws-lambda-eventbridge-event",
   "title": "Micronaut AWS Lambda and a Cron Job",
   "intro": "Learn how to a scheduled expression with Event Bridge trigger to execute a Micronaut AWS Lambda every 5 minutes",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-aws-lambda-s3-event/metadata.json
+++ b/guides/micronaut-aws-lambda-s3-event/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-aws-lambda-s3-event.adoc",
-  "slug": "micronaut-aws-lambda-s3-event",
   "title": "Micronaut AWS Lambda and S3 Event",
   "intro": "Learn how to generate thumbnails for images uploaded to an S3 bucket with AWS Lambda and the Micronaut framework",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-aws-parameter-store/metadata.json
+++ b/guides/micronaut-aws-parameter-store/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-aws-parameter-store.adoc",
-  "slug": "micronaut-aws-parameter-store",
   "title": "Micronaut AWS Parameter Store",
   "intro": "Learn how to use AWS Parameter for Configuration Discovery in a Micronaut application.",
   "authors": ["Pavol Gressa", "Sergio del Amo"],

--- a/guides/micronaut-aws-secretsmanager-rotation/metadata.json
+++ b/guides/micronaut-aws-secretsmanager-rotation/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-aws-secretsmanager-rotation.adoc",
-  "slug": "micronaut-aws-secretsmanager-rotation",
   "title": "Secret Rotation AWS Lambda and Secrets Manager",
   "intro": "Learn how to create an AWS Lambda function with the Micronaut framework to rotate a secret stored in AWS Secrets Manager",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-aws-secretsmanager/metadata.json
+++ b/guides/micronaut-aws-secretsmanager/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-aws-secretsmanager.adoc",
-  "slug": "micronaut-aws-secretsmanager",
   "title": "Distributed Configuration with AWS Secrets Manager and the Micronaut Framework",
   "intro": "Learn how to load your secrets from AWS Secrets Manager in your Micronaut application",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-azure-cloud/metadata.json
+++ b/guides/micronaut-azure-cloud/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-azure-cloud.adoc",
-  "slug": "micronaut-azure-cloud",
   "title": "Deploy a Micronaut application to Microsoft Azure",
   "intro": "Learn how to deploy a Micronaut application to Microsoft Azure.",
   "authors": ["Bruno Borges"],

--- a/guides/micronaut-azure-http-functions/metadata.json
+++ b/guides/micronaut-azure-http-functions/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-azure-http-functions.adoc",
-  "slug": "micronaut-azure-http-functions",
   "title": "Micronaut Azure HTTP Functions",
   "intro": "Learn how to create an Azure HTTP Function with the Micronaut framework",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-cache/metadata.json
+++ b/guides/micronaut-cache/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-cache.adoc",
-  "slug": "micronaut-cache",
   "title": "Micronaut Cache",
   "intro": "Learn how to use Micronaut caching annotations",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-cli-jwkgen/metadata.json
+++ b/guides/micronaut-cli-jwkgen/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-cli-jwkgen.adoc",
-  "slug": "micronaut-cli-jwkgen",
   "title": "JWK Generation with a Micronaut Command Line Application",
   "intro": "Learn how to generate a JSON Web Key (JWK) with a Micronaut CLI (Command Line interface) application",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-configuration/metadata.json
+++ b/guides/micronaut-configuration/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-configuration.adoc",
-  "slug": "micronaut-configuration",
   "title": "@Configuration and @ConfigurationBuilder",
   "intro": "Learn how to utilize @Configuration and @ConfigurationBuilder annotations to effectively configure declared properties.",
   "authors": ["Nirav Assar"],

--- a/guides/micronaut-creating-first-graal-app/metadata.json
+++ b/guides/micronaut-creating-first-graal-app/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-creating-first-graal-app.adoc",
-  "slug": "micronaut-creating-first-graal-app",
   "title": "Creating your first Micronaut Graal application",
   "intro": "Learn how to create a Hello World Micronaut GraalVM application.",
   "authors": ["Iván López", "Sergio del Amo"],

--- a/guides/micronaut-data-access-mybatis/metadata.json
+++ b/guides/micronaut-data-access-mybatis/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-data-access-mybatis.adoc",
-  "slug": "micronaut-data-access-mybatis",
   "title": "Access a database with MyBatis",
   "intro": "Learn how to access a database with MyBatis using the Micronaut framework.",
   "authors": ["Iván López", "Sergio del Amo"],

--- a/guides/micronaut-data-jdbc-repository/metadata.json
+++ b/guides/micronaut-data-jdbc-repository/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-data-jdbc-repository.adoc",
-  "slug": "micronaut-data-jdbc-repository",
   "title": "Access a database with Micronaut Data JDBC",
   "intro": "Learn how to access a database with Micronaut JDBC repositories.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-database-authentication-provider/metadata.json
+++ b/guides/micronaut-database-authentication-provider/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-database-authentication-provider.adoc",
-  "slug": "micronaut-database-authentication-provider",
   "title": "LDAP and Database authentication providers",
   "intro": "Learn how to create a LDAP and a database authentication provider in a Micronaut Application.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-elasticbeanstalk/metadata.json
+++ b/guides/micronaut-elasticbeanstalk/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-elasticbeanstalk.adoc",
-  "slug": "micronaut-elasticbeanstalk",
   "title": "Deploy a Micronaut application to AWS Elastic Beanstalk",
   "intro": "Learn how easy is to deploy a Micronaut Application to Elastic Beanstalk.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-email-amazon-ses/metadata.json
+++ b/guides/micronaut-email-amazon-ses/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-email-amazon-ses.adoc",
-  "slug": "micronaut-email-amazon-ses",
   "title": "Send Emails with Amazon SES from the Micronaut Framework",
   "intro": "Learn how to send emails with Amazon SES from a Micronaut application",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-email-sendgrid/metadata.json
+++ b/guides/micronaut-email-sendgrid/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-email-sendgrid.adoc",
-  "slug": "micronaut-email-sendgrid",
   "title": "Send Emails with SendGrid from the Micronaut Framework",
   "intro": "Learn how to send emails with SendGrid from a Micronaut application",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-email/metadata.json
+++ b/guides/micronaut-email/metadata.json
@@ -1,6 +1,5 @@
 {
   "publish": false,
-  "slug": "micronaut-email",
   "authors": ["Sergio del Amo"],
   "tags": ["email"],
   "category": "Email",

--- a/guides/micronaut-error-handling/metadata.json
+++ b/guides/micronaut-error-handling/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-error-handling.adoc",
-  "slug": "micronaut-error-handling",
   "title": "Error Handling",
   "intro": "Learn about error handling in the Micronaut framework.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-file-download-excel/metadata.json
+++ b/guides/micronaut-file-download-excel/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-file-download-excel.adoc",
-  "slug": "micronaut-file-download-excel",
   "title": "Download an Excel file in a Micronaut Application",
   "intro": "Learn how to download an Excel file with the Micronaut framework and Spreadsheet Builder library.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-flyway/metadata.json
+++ b/guides/micronaut-flyway/metadata.json
@@ -1,17 +1,15 @@
 {
-      "asciidoctor": "micronaut-flyway.adoc",
-      "slug": "micronaut-flyway",
-      "title": "Schema Migration with Flyway",
-      "intro": "Learn how to use Flyway to manage your schema migrations",
-      "authors": ["Sergio del Amo"],
-      "tags": ["database-migration"],
-      "category": "Data Access",
-      "publicationDate": "2021-11-22",
-      "languages": ["java"],
-          "apps": [
-              {
-                  "name": "default",
-                  "features": ["graalvm","data-jdbc","flyway","postgres", "management"]
-              }
-          ]      
+  "title": "Schema Migration with Flyway",
+  "intro": "Learn how to use Flyway to manage your schema migrations",
+  "authors": ["Sergio del Amo"],
+  "tags": ["database-migration"],
+  "category": "Data Access",
+  "publicationDate": "2021-11-22",
+  "languages": ["java"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["graalvm","data-jdbc","flyway","postgres", "management"]
+    }
+  ]
 }

--- a/guides/micronaut-google-app-engine/metadata.json
+++ b/guides/micronaut-google-app-engine/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-google-app-engine.adoc",
-  "slug": "micronaut-google-app-engine",
   "title": "Deploy to Google App Engine",
   "intro": "Learn how to deploy a Micronaut application to Google App Engine Java Flexible Environment",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-google-cloud-http-function/metadata.json
+++ b/guides/micronaut-google-cloud-http-function/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-google-cloud-http-function.adoc",
-  "slug": "micronaut-google-cloud-http-function",
   "title": "Deploy an HTTP Function to Google Cloud Functions",
   "intro": "Deploy a Micronaut application as an HTTP Function to Google Cloud Functions - a scalable pay-as-you-go functions-as-a-service (FaaS) to run your code with zero server management.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-google-cloud-platform-cloud-run/metadata.json
+++ b/guides/micronaut-google-cloud-platform-cloud-run/metadata.json
@@ -1,17 +1,14 @@
 {
-    "asciidoctor": "micronaut-google-cloud-platform-cloud-run.adoc",
-      "slug": "micronaut-google-cloud-platform-cloud-run",
-      "title": "Deploy to Google Cloud Run",
-      "intro": "Deploy a Micronaut application to Google Cloud Run - a fully managed serverless platform for containerized applications.",
-      "authors": ["Sergio del Amo"],
-      "tags": ["gcp", "cloudrun"],
-      "category": "Micronaut + Google Cloud",
-      "publicationDate": "2021-10-01",
-      "apps": [
-        {
-          "name": "default",
-          "features": ["docker-push-gcr"]
-        }
-      ]
+  "title": "Deploy to Google Cloud Run",
+  "intro": "Deploy a Micronaut application to Google Cloud Run - a fully managed serverless platform for containerized applications.",
+  "authors": ["Sergio del Amo"],
+  "tags": ["gcp", "cloudrun"],
+  "category": "Micronaut + Google Cloud",
+  "publicationDate": "2021-10-01",
+  "apps": [
+    {
+      "name": "default",
+      "features": ["docker-push-gcr"]
+    }
+  ]
 }
-    

--- a/guides/micronaut-graalvm-native-image-google-cloud-platform-cloud-run/metadata.json
+++ b/guides/micronaut-graalvm-native-image-google-cloud-platform-cloud-run/metadata.json
@@ -1,18 +1,15 @@
 {
-    "asciidoctor": "micronaut-graalvm-native-image-google-cloud-platform-cloud-run.adoc",
-      "slug": "micronaut-graalvm-native-image-google-cloud-platform-cloud-run",
-      "title": "Deploy GraalVM Native Image to Google Cloud Run",
-      "intro": "Deploy a GraalVM Native Image of a Micronaut application to Google Cloud Run - a fully managed serverless platform for containerized applications.",
-      "authors": ["Sergio del Amo"],
-      "tags": ["gcp", "cloudrun"],
-      "category": "Micronaut + Google Cloud",
-      "publicationDate": "2021-10-01",
-      "languages": ["java", "kotlin"],
-      "apps": [
-        {
-          "name": "default",
-          "features": ["docker-push-native-gcr", "graalvm"]
-        }
-      ]
+  "title": "Deploy GraalVM Native Image to Google Cloud Run",
+  "intro": "Deploy a GraalVM Native Image of a Micronaut application to Google Cloud Run - a fully managed serverless platform for containerized applications.",
+  "authors": ["Sergio del Amo"],
+  "tags": ["gcp", "cloudrun"],
+  "category": "Micronaut + Google Cloud",
+  "publicationDate": "2021-10-01",
+  "languages": ["java", "kotlin"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["docker-push-native-gcr", "graalvm"]
+    }
+  ]
 }
-    

--- a/guides/micronaut-graphql/metadata.json
+++ b/guides/micronaut-graphql/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-graphql.adoc",
-  "slug": "micronaut-graphql",
   "title": "Micronaut GraphQL",
   "intro": "Learn how to use Micronaut GraphQL.",
   "authors": ["Iván López"],

--- a/guides/micronaut-http-client/metadata.json
+++ b/guides/micronaut-http-client/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-http-client.adoc",
-  "slug": "micronaut-http-client",
   "title": "Micronaut HTTP Client",
   "intro": "Learn how to use Micronaut low-level HTTP Client. Simplify your code with the declarative HTTP client.",
   "authors": ["Sergio del Amo", "Iván López"],

--- a/guides/micronaut-java-records/metadata.json
+++ b/guides/micronaut-java-records/metadata.json
@@ -1,18 +1,16 @@
 {
-      "asciidoctor": "micronaut-java-records.adoc",
-      "slug": "micronaut-java-records",
-      "title": "Micronaut Data and Java Records",
-      "intro": "Learn how to a leverage Java records for immutable configuration, Micronaut Data Mapped Entities and Projection DTOs",
-      "authors": ["Sergio del Amo"],
-      "tags": ["record"],
-      "category": "Data Access",
-      "publicationDate": "2021-11-20",
-      "languages": ["java"],
-      "minimumJavaVersion": 17,
-      "apps": [
-              {
-                "name": "default",
-                "features": ["graalvm", "data-jdbc","liquibase","postgres"]
-              }
-            ]
+  "title": "Micronaut Data and Java Records",
+  "intro": "Learn how to a leverage Java records for immutable configuration, Micronaut Data Mapped Entities and Projection DTOs",
+  "authors": ["Sergio del Amo"],
+  "tags": ["record"],
+  "category": "Data Access",
+  "publicationDate": "2021-11-20",
+  "languages": ["java"],
+  "minimumJavaVersion": 17,
+  "apps": [
+    {
+      "name": "default",
+      "features": ["graalvm", "data-jdbc","liquibase","postgres"]
     }
+  ]
+}

--- a/guides/micronaut-jpa-hibernate/metadata.json
+++ b/guides/micronaut-jpa-hibernate/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-jpa-hibernate.adoc",
-  "slug": "micronaut-jpa-hibernate",
   "title": "Access a database with JPA and Hibernate",
   "intro": "Learn how to access a database with JPA and Hibernate using the Micronaut framework.",
   "authors": ["Iván López", "Sergio del Amo"],

--- a/guides/micronaut-kafka/metadata.json
+++ b/guides/micronaut-kafka/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-kafka.adoc",
-  "slug": "micronaut-kafka",
   "title": "Kafka and the Micronaut Framework - Event-Driven Applications",
   "intro": "Use Kafka to communicate between your Micronaut applications.",
   "authors": ["Burt Beckwith"],

--- a/guides/micronaut-kotlin-extension-fns/metadata.json
+++ b/guides/micronaut-kotlin-extension-fns/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-kotlin-extension-fns.adoc",
-  "slug": "micronaut-kotlin-extension-fns",
   "title": "Using Kotlin Extension Functions in the Micronaut Framework",
   "intro": "Take a tour of the extension functions in the Micronaut framework and learn to write your own",
   "authors": ["Will Buck"],

--- a/guides/micronaut-liquibase/metadata.json
+++ b/guides/micronaut-liquibase/metadata.json
@@ -1,17 +1,15 @@
 {
-      "asciidoctor": "micronaut-liquibase.adoc",
-      "slug": "micronaut-liquibase",
-      "title": "Schema Migration with Liquibase",
-      "intro": "Learn how to use the Liquibase to manage your schema migrations.",
-      "authors": ["Sergio del Amo"],
-      "tags": ["database-migration"],
-      "category": "Data Access",
-      "publicationDate": "2021-11-21",
-      "languages": ["java"],
-          "apps": [
-              {
-                  "name": "default",
-                  "features": ["graalvm","data-jdbc","liquibase","postgres", "management"]
-              }
-          ]      
+  "title": "Schema Migration with Liquibase",
+  "intro": "Learn how to use the Liquibase to manage your schema migrations.",
+  "authors": ["Sergio del Amo"],
+  "tags": ["database-migration"],
+  "category": "Data Access",
+  "publicationDate": "2021-11-21",
+  "languages": ["java"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["graalvm","data-jdbc","liquibase","postgres", "management"]
+    }
+  ]
 }

--- a/guides/micronaut-microservices-distributed-tracing-jaeger/metadata.json
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-microservices-distributed-tracing-jaeger.adoc",
-  "slug": "micronaut-microservices-distributed-tracing-jaeger",
   "title": "Microservices Distributed Tracing with Jaeger and the Micronaut Framework",
   "intro": "Use Jaeger distributed tracing to investigate the behaviour of your Micronaut applications.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-microservices-distributed-tracing-zipkin/metadata.json
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-microservices-distributed-tracing-zipkin.adoc",
-  "slug": "micronaut-microservices-distributed-tracing-zipkin",
   "title": "Microservices Distributed Tracing with Zipkin and the Micronaut Framework",
   "intro": "Use Zipkin distributed tracing to investigate the behaviour of your Micronaut applications.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-microservices-services-discover-consul/metadata.json
+++ b/guides/micronaut-microservices-services-discover-consul/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-microservices-services-discover-consul.adoc",
-  "slug": "micronaut-microservices-services-discover-consul",
   "title": "Consul and the Micronaut Framework - Microservices Service Discovery",
   "intro": "Use Consul service discovery to expose your Micronaut applications.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-microservices-services-discover-eureka/metadata.json
+++ b/guides/micronaut-microservices-services-discover-eureka/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-microservices-services-discover-eureka.adoc",
-  "slug": "micronaut-microservices-services-discover-eureka",
   "title": "Eureka and the Micronaut Framework - Microservices Service Discovery",
   "intro": "Use Netflix Eureka service discovery to expose your Micronaut applications.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-mongodb-asynchronous/metadata.json
+++ b/guides/micronaut-mongodb-asynchronous/metadata.json
@@ -1,18 +1,15 @@
 {
-    "asciidoctor": "micronaut-mongodb-asynchronous.adoc",
-    "slug": "micronaut-mongodb-asynchronous",
-    "title": "Micronaut MongoDB Asynchronous",
-    "intro": "Learn how to use a non-blocking reactive streams MongoDB client with a Micronaut application",
-    "authors": ["Sergio del Amo"],
-    "tags": ["mongodb"],
-    "category": "Data Access",
-    "publicationDate": "2021-10-13",
-    "languages": ["java"],
-    "apps": [
-        {
-            "name": "default",
-            "features": ["mongo-reactive","reactor"]
-        }
-    ]
+  "title": "Micronaut MongoDB Asynchronous",
+  "intro": "Learn how to use a non-blocking reactive streams MongoDB client with a Micronaut application",
+  "authors": ["Sergio del Amo"],
+  "tags": ["mongodb"],
+  "category": "Data Access",
+  "publicationDate": "2021-10-13",
+  "languages": ["java"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["mongo-reactive","reactor"]
+    }
+  ]
 }
-    

--- a/guides/micronaut-mongodb-synchronous/metadata.json
+++ b/guides/micronaut-mongodb-synchronous/metadata.json
@@ -1,18 +1,15 @@
 {
-    "asciidoctor": "micronaut-mongodb-synchronous.adoc",
-    "slug": "micronaut-mongodb-synchronous",
-    "title": "Micronaut MongoDB Synchronous",
-    "intro": "Learn how to use a blocking MongoClient with a Micronaut application",
-    "authors": ["Sergio del Amo"],
-    "tags": ["mongodb"],
-    "category": "Data Access",
-    "publicationDate": "2021-10-13",
-    "languages": ["java"],
-    "apps": [
-        {
-            "name": "default",
-            "features": ["mongo-sync"]
-        }
-    ]
+  "title": "Micronaut MongoDB Synchronous",
+  "intro": "Learn how to use a blocking MongoClient with a Micronaut application",
+  "authors": ["Sergio del Amo"],
+  "tags": ["mongodb"],
+  "category": "Data Access",
+  "publicationDate": "2021-10-13",
+  "languages": ["java"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["mongo-sync"]
+    }
+  ]
 }
-    

--- a/guides/micronaut-multitenancy-propagation/metadata.json
+++ b/guides/micronaut-multitenancy-propagation/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-multitenancy-propagation.adoc",
-  "slug": "micronaut-multitenancy-propagation",
   "title": "Micronaut Multitenancy Propagation",
   "intro": "Learn how the Micronaut framework helps you implement multitenancy in a set of microservices.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-oauth2-auth0/metadata.json
+++ b/guides/micronaut-oauth2-auth0/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oauth2-auth0.adoc",
-  "slug": "micronaut-oauth2-auth0",
   "title": "Secure a Micronaut application with Auth0",
   "intro": "Learn how to create a Micronaut application and secure it with an Authorization Server provided by Auth0.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-oauth2-client-credentials-auth0/metadata.json
+++ b/guides/micronaut-oauth2-client-credentials-auth0/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oauth2-client-credentials-auth0.adoc",
-  "slug": "micronaut-oauth2-client-credentials-auth0",
   "title": "Client Credentials Flow with  Micronaut and Auth0",
   "intro": "Learn how to use Client Credentials Flow between Micronaut microservices with an Authorization Server provided by Auth0.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-oauth2-client-credentials-cognito/metadata.json
+++ b/guides/micronaut-oauth2-client-credentials-cognito/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oauth2-client-credentials-cognito.adoc",
-  "slug": "micronaut-oauth2-client-credentials-cognito",
   "title": "Client Credentials Flow with  Micronaut and Amazon Cognito",
   "intro": "Learn how to use Client Credentials Flow between Micronaut microservices with an Authorization Server provided by Amazon Cognito.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-oauth2-cognito/metadata.json
+++ b/guides/micronaut-oauth2-cognito/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oauth2-cognito.adoc",
-  "slug": "micronaut-oauth2-cognito",
   "title": "Secure a Micronaut application with Cognito",
   "intro": "Learn how to create a Micronaut application and secure it with an Authorization Server provided by Cognito.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-oauth2-github/metadata.json
+++ b/guides/micronaut-oauth2-github/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oauth2-github.adoc",
-  "slug": "micronaut-oauth2-github",
   "title": "Secure a Micronaut application with Github",
   "intro": "Learn how to create a Micronaut application and secure it with an Authorization Server provided by Github. Learn how to write your own Authentication Mapper.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-oauth2-linkedin/metadata.json
+++ b/guides/micronaut-oauth2-linkedin/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oauth2-linkedin.adoc",
-  "slug": "micronaut-oauth2-linkedin",
   "title": "Secure a Micronaut application with LinkedIn",
   "intro": "Learn how to create a Micronaut application and authenticate with LinkedIn.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-oauth2-oidc-google/metadata.json
+++ b/guides/micronaut-oauth2-oidc-google/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oauth2-oidc-google.adoc",
-  "slug": "micronaut-oauth2-oidc-google",
   "title": "Secure a Micronaut application with Google",
   "intro": "Learn how to create a Micronaut application and secure it with Google and provide authentication with OpenID Connect",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-oauth2-okta/metadata.json
+++ b/guides/micronaut-oauth2-okta/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oauth2-okta.adoc",
-  "slug": "micronaut-oauth2-okta",
   "title": "Secure a Micronaut application with Okta",
   "intro": "Learn how to create a Micronaut application and secure it with an Authorization Server provided by Okta.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-oracle-autonomous-db/metadata.json
+++ b/guides/micronaut-oracle-autonomous-db/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oracle-autonomous-db.adoc",
-  "slug": "micronaut-oracle-autonomous-db",
   "title": "Access an Oracle Autonomous Database",
   "intro": "Learn how to access an Oracle Autonomous Database using the Micronaut framework.",
   "authors": ["Burt Beckwith"],

--- a/guides/micronaut-oracle-cloud-streaming/metadata.json
+++ b/guides/micronaut-oracle-cloud-streaming/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oracle-cloud-streaming.adoc",
-  "slug": "micronaut-oracle-cloud-streaming",
   "title": "Oracle Cloud Streaming and the Micronaut Framework - Event-Driven Applications at Scale",
   "intro": "Use Oracle Cloud Streaming to communicate between your Micronaut applications.",
   "authors": ["Burt Beckwith"],

--- a/guides/micronaut-oracle-cloud/metadata.json
+++ b/guides/micronaut-oracle-cloud/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oracle-cloud.adoc",
-  "slug": "micronaut-oracle-cloud",
   "title": "Deploy a Micronaut application to Oracle Cloud",
   "intro": "Learn how to deploy a Micronaut application to Oracle Cloud.",
   "authors": ["Burt Beckwith"],

--- a/guides/micronaut-oracle-function-http/metadata.json
+++ b/guides/micronaut-oracle-function-http/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oracle-function-http.adoc",
-  "slug": "micronaut-oracle-function-http",
   "title": "Deploy a Micronaut HTTP API Gateway Function (Serverless) application to Oracle Cloud",
   "intro": "Learn how to deploy a Micronaut HTTP API Gateway Function (Serverless) application to Oracle Cloud.",
   "authors": ["Burt Beckwith"],

--- a/guides/micronaut-oracle-function/metadata.json
+++ b/guides/micronaut-oracle-function/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-oracle-function.adoc",
-  "slug": "micronaut-oracle-function",
   "title": "Deploy a Micronaut Function (Serverless) application to Oracle Cloud",
   "intro": "Learn how to deploy a Micronaut Function (Serverless) application to Oracle Cloud.",
   "authors": ["Burt Beckwith"],

--- a/guides/micronaut-rabbitmq-rpc/metadata.json
+++ b/guides/micronaut-rabbitmq-rpc/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-rabbitmq-rpc.adoc",
-  "slug": "micronaut-rabbitmq-rpc",
   "title": "RabbitMQ RPC and the Micronaut Framework",
   "intro": "Use RabbitMQ RPC to use request-reply pattern in your Micronaut applications.",
   "authors": ["Iván López"],

--- a/guides/micronaut-rabbitmq/metadata.json
+++ b/guides/micronaut-rabbitmq/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-rabbitmq.adoc",
-  "slug": "micronaut-rabbitmq",
   "title": "RabbitMQ and the Micronaut Framework - Event-Driven Applications",
   "intro": "Use RabbitMQ to communicate between your Micronaut applications.",
   "authors": ["Iván López"],

--- a/guides/micronaut-scheduled/metadata.json
+++ b/guides/micronaut-scheduled/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-scheduled.adoc",
-  "slug": "micronaut-scheduled",
   "title": "Schedule periodic tasks inside your Micronaut applications",
   "intro": "Learn how to schedule periodic tasks inside your Micronaut microservices.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-security-basicauth/metadata.json
+++ b/guides/micronaut-security-basicauth/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-security-basicauth.adoc",
-  "slug": "micronaut-security-basicauth",
   "title": "Micronaut Basic Auth",
   "intro": "Learn how to secure a Micronaut application using 'Basic' HTTP Authentication Scheme.",
   "features": ["security", "graalvm"],

--- a/guides/micronaut-security-jwt-cookie/metadata.json
+++ b/guides/micronaut-security-jwt-cookie/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-security-jwt-cookie.adoc",
-  "slug": "micronaut-security-jwt-cookie",
   "title": "Micronaut JWT authentication via Cookies",
   "intro": "Learn how to secure a Micronaut application using JWT (JSON Web Token) based authentication where the JWT tokens are transported via Cookies.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-security-jwt/metadata.json
+++ b/guides/micronaut-security-jwt/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-security-jwt.adoc",
-  "slug": "micronaut-security-jwt",
   "title": "Micronaut JWT Authentication",
   "intro": "Learn how to secure a Micronaut application using JWT (JSON Web Token) Authentication.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-security-keys-jwks/metadata.json
+++ b/guides/micronaut-security-keys-jwks/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-security-keys-jwks.adoc",
-  "slug": "micronaut-security-keys-jwks",
   "title": "JWK Keys endpoint",
   "intro": "Learn how to expose a keys endpoint with primary and secondary JSON Web Key (JWK)",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-security-session/metadata.json
+++ b/guides/micronaut-security-session/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-security-session.adoc",
-  "slug": "micronaut-security-session",
   "title": "Session based authentication",
   "intro": "Learn how to secure a Micronaut application using Session based authentication.",
   "authors": ["Sergio del Amo"],

--- a/guides/micronaut-token-propagation/metadata.json
+++ b/guides/micronaut-token-propagation/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "micronaut-token-propagation.adoc",
-  "slug": "micronaut-token-propagation",
   "title": "Micronaut Token Propagation",
   "intro": "Learn how to leverage token propagation in the Micronaut framework to simplify your code while keeping your microservices secure.",
   "authors": ["Sergio del Amo"],

--- a/guides/mn-application-aws-lambda-graalvm/metadata.json
+++ b/guides/mn-application-aws-lambda-graalvm/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "mn-application-aws-lambda-graalvm.adoc",
-  "slug": "mn-application-aws-lambda-graalvm",
   "title": "Deploy a Micronaut application as a GraalVM Native Image to AWS Lambda",
   "intro": "Learn how to distribute a Micronaut Java application built as a GraalVM Native image to AWS Lambda Custom Runtime",
   "authors": ["Sergio del Amo"],

--- a/guides/mn-application-aws-lambda-java11/metadata.json
+++ b/guides/mn-application-aws-lambda-java11/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "mn-application-aws-lambda-java11.adoc",
-  "slug": "mn-application-aws-lambda-java11",
   "title": "Deploy a Micronaut application to AWS Lambda Java 11 Runtime",
   "intro": "Learn how to distribute a Micronaut application to AWS Lambda 11 Runtime",
   "authors": ["Sergio del Amo"],

--- a/guides/mn-serverless-function-aws-lambda-graalvm/metadata.json
+++ b/guides/mn-serverless-function-aws-lambda-graalvm/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "mn-serverless-function-aws-lambda-graalvm.adoc",
-  "slug": "mn-serverless-function-aws-lambda-graalvm",
   "title": "Deploy a Micronaut function as a GraalVM Native Image to AWS Lambda",
   "intro": "Learn how to distribute a Micronaut function built as a GraalVM Native image to AWS Lambda Custom Runtime",
   "authors": ["Sergio del Amo"],

--- a/guides/mn-serverless-function-aws-lambda/metadata.json
+++ b/guides/mn-serverless-function-aws-lambda/metadata.json
@@ -1,6 +1,4 @@
 {
-  "asciidoctor": "mn-serverless-function-aws-lambda.adoc",
-  "slug": "mn-serverless-function-aws-lambda",
   "title": "Deploy a Serverless Micronaut function to AWS Lambda Java 11 Runtime",
   "intro": "Learn how to distribute a serverless Micronaut function to AWS Lambda 11 Runtime\n\n",
   "authors": ["Sergio del Amo"],


### PR DESCRIPTION
no need to specify the `asciidoctor` or `slug` attributes in metadata.json since `slug` is always the same as the guide directory name and `asciidoctor` is always (for guides where publish=true) the same as the guide directory name plus "adoc" extension