### PR TITLE
build: Parallelization of test runners

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuidesPlugin.groovy
@@ -19,7 +19,6 @@ import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Zip
 
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Predicate
 import java.util.stream.Collectors
 
@@ -42,8 +41,6 @@ class GuidesPlugin implements Plugin<Project> {
     private static final String KEY_DOC = "doc"
     private static final String COMMA = ","
     private static final String TASK_SUFFIX_BUILD = "Build"
-
-    private static AtomicBoolean firstGuide = new AtomicBoolean(true)
 
     @Override
     void apply(Project project) {
@@ -85,6 +82,9 @@ class GuidesPlugin implements Plugin<Project> {
                      (KEY_WORKFLOW_SNAPSHOT): githubActionSnapshotWorkflowTask,
                      (TEST_RUNNER)          : testScriptRunnerTask]
                 }).collect(Collectors.toList())
+
+        // Make sure the other tasks run after the first
+        sampleTasks.stream().skip(1).forEach(map -> map.get(TEST_RUNNER).configure(task -> task.mustRunAfter(sampleTasks.get(0).get(TEST_RUNNER))))
 
         List<TaskProvider<Task>> docTasks = sampleTasks.stream()
                 .map() { Map<String, TaskProvider<Task>> m -> m[KEY_DOC] }
@@ -206,7 +206,6 @@ class GuidesPlugin implements Plugin<Project> {
 
             it.testScript.set(testScriptTask.flatMap { t -> t.scriptFile })
             it.guideSourceDirectory.set(project.layout.projectDirectory.dir("guides/${metadata.slug}"))
-            it.await.set(firstGuide.getAndSet(false))
 
             // We tee the script output to a file, this is the cached result
             it.outputFile.set(codeDirectory.map(d -> d.file("output.log")))

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -97,7 +97,7 @@ exit 0
 #!/usr/bin/env bash
 set -e
 
-# Run app on a random port to prevent collisions when in parallel
+# Any apps that get executed should run on a random port to prevent collisions when in parallel
 export MICRONAUT_SERVER_PORT=-1
 
 FAILED_PROJECTS=()

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -97,9 +97,6 @@ exit 0
 #!/usr/bin/env bash
 set -e
 
-# Any apps that get executed should run on a random port to prevent collisions when in parallel
-export MICRONAUT_SERVER_PORT=-1
-
 FAILED_PROJECTS=()
 EXIT_STATUS=0
 ''')

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -158,7 +158,7 @@ fi
 cd $nestedFolder
 echo "-------------------------------------------------"
 echo "Executing '$folder' tests"
-${buildTool == MAVEN ? './mvnw -q test' : './gradlew -q test' } || EXIT_STATUS=\$?
+${buildTool == MAVEN ? './mvnw -q test' : './gradlew test' } || EXIT_STATUS=\$?
 cd ..
 """
         if (stopIfFailure) {

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -97,6 +97,9 @@ exit 0
 #!/usr/bin/env bash
 set -e
 
+# Run app on a random port to prevent collisions when in parallel
+export MICRONAUT_SERVER_PORT=-1
+
 FAILED_PROJECTS=()
 EXIT_STATUS=0
 ''')

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -158,7 +158,7 @@ fi
 cd $nestedFolder
 echo "-------------------------------------------------"
 echo "Executing '$folder' tests"
-${buildTool == MAVEN ? './mvnw -q test' : './gradlew test' } || EXIT_STATUS=\$?
+${buildTool == MAVEN ? './mvnw -q test' : './gradlew -q test' } || EXIT_STATUS=\$?
 cd ..
 """
         if (stopIfFailure) {

--- a/buildSrc/src/main/groovy/io/micronaut/guides/tasks/TestScriptRunnerTask.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/tasks/TestScriptRunnerTask.groovy
@@ -4,11 +4,9 @@ import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -36,10 +34,6 @@ abstract class TestScriptRunnerTask extends DefaultTask {
     @Inject
     abstract WorkerExecutor getWorkerExecutor();
 
-    // We have to wait for the first task to complete as mvnw corrupts the wrapper if downloaded in parallel
-    @Internal
-    abstract Property<Boolean> getAwait()
-
     @TaskAction
     void runScript() {
         WorkQueue queue = workerExecutor.noIsolation()
@@ -48,9 +42,5 @@ abstract class TestScriptRunnerTask extends DefaultTask {
             parameters.testScript.set(testScript)
             parameters.outputFile.set(outputFile)
         }
-
-        // Just run one at a time for now, when we try to parallelize we will need to await if
-        // getAwait() is true, so that the maven wrapper is downloaded uncorrupted.
-        queue.await()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
 org.gradle.parallel=true
 org.gradle.caching=true
+
+# Limit the max workers to prevent resource exhaustion
+org.gradle.workers.max=2

--- a/guides/micronaut-cache/groovy/src/test/groovy/example/micronaut/NewsControllerSpec.groovy
+++ b/guides/micronaut-cache/groovy/src/test/groovy/example/micronaut/NewsControllerSpec.groovy
@@ -22,7 +22,7 @@ class NewsControllerSpec extends Specification {
     @Client("/")
     HttpClient client
 
-    @Timeout(4) // <1>
+    @Timeout(5) // <1>
     void "fetching october headlines uses cache"() {
         given:
         String expected = "Micronaut AOP: Awesome flexibility without the complexity"

--- a/guides/micronaut-cache/java/src/test/java/example/micronaut/NewsControllerTest.java
+++ b/guides/micronaut-cache/java/src/test/java/example/micronaut/NewsControllerTest.java
@@ -25,7 +25,7 @@ public class NewsControllerTest {
     @Client("/")
     HttpClient client;
 
-    @Timeout(4) // <1>
+    @Timeout(5) // <1>
     @Test
     void fetchingOctoberHeadlinesUsesCache() {
         HttpRequest request = HttpRequest.GET(UriBuilder.of("/").path(Month.OCTOBER.name()).build());


### PR DESCRIPTION
- Use `mustRunAfter` instead of a boolean
- Make Gradle more verbose to triage any errors
