### PR TITLE
Add Kotlin version of the GraphQL ToDo guide

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuidesPlugin.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Zip
 
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Predicate
 import java.util.stream.Collectors
 
@@ -41,6 +42,8 @@ class GuidesPlugin implements Plugin<Project> {
     private static final String KEY_DOC = "doc"
     private static final String COMMA = ","
     private static final String TASK_SUFFIX_BUILD = "Build"
+
+    private static final AtomicBoolean firstTestRunnerTask = new AtomicBoolean(true)
 
     @Override
     void apply(Project project) {
@@ -207,6 +210,8 @@ class GuidesPlugin implements Plugin<Project> {
 
             it.testScript.set(testScriptTask.flatMap { t -> t.scriptFile })
             it.guideSourceDirectory.set(project.layout.projectDirectory.dir("guides/${metadata.slug}"))
+
+            it.firstTask.set(firstTestRunnerTask)
 
             // We tee the script output to a file, this is the cached result
             it.outputFile.set(codeDirectory.map(d -> d.file("output.log")))

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuidesPlugin.groovy
@@ -86,9 +86,6 @@ class GuidesPlugin implements Plugin<Project> {
                      (TEST_RUNNER)          : testScriptRunnerTask]
                 }).collect(Collectors.toList())
 
-        // Make sure the other tasks run after the first
-        sampleTasks.stream().skip(1).forEach(map -> map.get(TEST_RUNNER).configure(task -> task.mustRunAfter(sampleTasks.get(0).get(TEST_RUNNER))))
-
         List<TaskProvider<Task>> docTasks = sampleTasks.stream()
                 .map() { Map<String, TaskProvider<Task>> m -> m[KEY_DOC] }
                 .collect(Collectors.toList())

--- a/buildSrc/src/main/groovy/io/micronaut/guides/tasks/TestScriptRunnerTask.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/tasks/TestScriptRunnerTask.groovy
@@ -4,9 +4,11 @@ import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -15,6 +17,7 @@ import org.gradle.workers.WorkQueue
 import org.gradle.workers.WorkerExecutor
 
 import javax.inject.Inject
+import java.util.concurrent.atomic.AtomicBoolean
 
 @CacheableTask
 @CompileStatic
@@ -34,6 +37,9 @@ abstract class TestScriptRunnerTask extends DefaultTask {
     @Inject
     abstract WorkerExecutor getWorkerExecutor();
 
+    @Internal
+    abstract Property<AtomicBoolean> getFirstTask();
+
     @TaskAction
     void runScript() {
         WorkQueue queue = workerExecutor.noIsolation()
@@ -41,6 +47,13 @@ abstract class TestScriptRunnerTask extends DefaultTask {
         queue.submit(TestScriptRunnerWorkAction) { parameters ->
             parameters.testScript.set(testScript)
             parameters.outputFile.set(outputFile)
+        }
+        try {
+            if (firstTask.get().get()) {
+                queue.await()
+            }
+        } finally {
+            firstTask.get().set(false)
         }
     }
 }

--- a/guides/micronaut-graphql-todo/java/src/main/java/example/micronaut/Author.java
+++ b/guides/micronaut-graphql-todo/java/src/main/java/example/micronaut/Author.java
@@ -11,7 +11,7 @@ import static io.micronaut.data.annotation.GeneratedValue.Type.AUTO;
 @MappedEntity // <1>
 public class Author {
 
-    @Id // <1>
+    @Id // <2>
     @GeneratedValue(AUTO)
     private Long id;
 

--- a/guides/micronaut-graphql-todo/java/src/main/java/example/micronaut/AuthorDataLoader.java
+++ b/guides/micronaut-graphql-todo/java/src/main/java/example/micronaut/AuthorDataLoader.java
@@ -20,8 +20,10 @@ public class AuthorDataLoader implements MappedBatchLoader<Long, Author> {
     private final AuthorRepository authorRepository;
     private final ExecutorService executor;
 
-    public AuthorDataLoader(AuthorRepository authorRepository,
-                            @Named(TaskExecutors.IO) ExecutorService executor) {
+    public AuthorDataLoader(
+            AuthorRepository authorRepository,
+            @Named(TaskExecutors.IO) ExecutorService executor // <2>
+    ) {
         this.authorRepository = authorRepository;
         this.executor = executor;
     }

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/Author.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/Author.kt
@@ -1,0 +1,15 @@
+package example.micronaut
+
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.GeneratedValue.Type.AUTO
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import javax.validation.constraints.NotNull
+
+@MappedEntity // <1>
+class Author(val username: @NotNull String?) {
+
+    @Id // <2>
+    @GeneratedValue(AUTO)
+    var id: Long? = null
+}

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/AuthorDataFetcher.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/AuthorDataFetcher.kt
@@ -1,0 +1,16 @@
+package example.micronaut
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import jakarta.inject.Singleton
+import java.util.concurrent.CompletionStage
+
+@Singleton // <1>
+class AuthorDataFetcher : DataFetcher<CompletionStage<Author>> {
+
+    override fun get(environment: DataFetchingEnvironment): CompletionStage<Author> {
+        val toDo: ToDo = environment.getSource()
+        val authorDataLoader = environment.getDataLoader<Long, Author>("author") // <2>
+        return authorDataLoader.load(toDo.authorId)
+    }
+}

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/AuthorDataLoader.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/AuthorDataLoader.kt
@@ -1,0 +1,23 @@
+package example.micronaut
+
+import io.micronaut.scheduling.TaskExecutors
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.dataloader.MappedBatchLoader
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.ExecutorService
+
+@Singleton // <1>
+class AuthorDataLoader(
+    private val authorRepository: AuthorRepository,
+    @Named(TaskExecutors.IO) val executor: ExecutorService // <2>
+) : MappedBatchLoader<Long, Author> {
+
+    override fun load(keys: MutableSet<Long>): CompletionStage<Map<Long, Author>> =
+        CompletableFuture.supplyAsync({
+            authorRepository
+                .findByIdIn(keys.toList())
+                .associateBy { it.id!! }
+        }, executor)
+}

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/AuthorRepository.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/AuthorRepository.kt
@@ -1,0 +1,17 @@
+package example.micronaut
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect.POSTGRES
+import io.micronaut.data.repository.CrudRepository
+
+@JdbcRepository(dialect = POSTGRES) // <1>
+abstract class AuthorRepository : CrudRepository<Author, Long> { // <2>
+
+    abstract fun findByUsername(username: String): Author? // <3>
+
+    abstract fun findByIdIn(ids: Collection<Long>): Collection<Author> // <4>
+
+    fun findOrCreate(username: String): Author { // <5>
+        return findByUsername(username) ?: save(Author(username))
+    }
+}

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/CompleteToDoDataFetcher.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/CompleteToDoDataFetcher.kt
@@ -19,7 +19,7 @@ class CompleteToDoDataFetcher(
     }
 
     private fun setCompletedAndUpdate(todo: ToDo): Boolean {
-        todo.isCompleted = true // <4>
+        todo.completed = true // <4>
         toDoRepository.update(todo) // <5>
         return true
     }

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/CompleteToDoDataFetcher.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/CompleteToDoDataFetcher.kt
@@ -1,0 +1,26 @@
+package example.micronaut
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import jakarta.inject.Singleton
+
+@Singleton // <1>
+class CompleteToDoDataFetcher(
+    private val toDoRepository: ToDoRepository // <2>
+) : DataFetcher<Boolean> {
+
+    override fun get(env: DataFetchingEnvironment): Boolean {
+        val id = env.getArgument<String>("id").toLong()
+
+        return toDoRepository
+            .findById(id) // <3>
+            .map { todo -> setCompletedAndUpdate(todo!!) }
+            .orElse(false)
+    }
+
+    private fun setCompletedAndUpdate(todo: ToDo): Boolean {
+        todo.isCompleted = true // <4>
+        toDoRepository.update(todo) // <5>
+        return true
+    }
+}

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/CreateToDoDataFetcher.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/CreateToDoDataFetcher.kt
@@ -1,0 +1,22 @@
+package example.micronaut
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import jakarta.inject.Singleton
+import javax.transaction.Transactional
+
+@Singleton // <1>
+open class CreateToDoDataFetcher(
+    private val toDoRepository: ToDoRepository,  // <2>
+    private val authorRepository: AuthorRepository
+) : DataFetcher<ToDo> {
+
+    @Transactional
+    override fun get(env: DataFetchingEnvironment): ToDo {
+        val title = env.getArgument<String>("title")
+        val username = env.getArgument<String>("author")
+        val author = authorRepository.findOrCreate(username) // <3>
+        val toDo = ToDo(title, author.id!!)
+        return toDoRepository.save(toDo) // <4>
+    }
+}

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/DataLoaderRegistryFactory.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/DataLoaderRegistryFactory.kt
@@ -1,0 +1,30 @@
+package example.micronaut
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.runtime.http.scope.RequestScope
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderRegistry
+import org.slf4j.LoggerFactory
+
+@Factory // <1>
+class DataLoaderRegistryFactory {
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(DataLoaderRegistryFactory::class.java)
+    }
+
+    @Suppress("unused")
+    @RequestScope // <2>
+    fun dataLoaderRegistry(authorDataLoader: AuthorDataLoader): DataLoaderRegistry {
+        val dataLoaderRegistry = DataLoaderRegistry()
+        dataLoaderRegistry.register(
+            "author",
+            DataLoader.newMappedDataLoader(authorDataLoader)
+        ) // <3>
+
+        LOG.trace("Created new data loader registry")
+
+        return dataLoaderRegistry
+    }
+
+}

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/GraphQLFactory.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/GraphQLFactory.kt
@@ -1,0 +1,58 @@
+package example.micronaut
+
+import graphql.GraphQL
+import graphql.schema.idl.*
+import graphql.schema.idl.errors.SchemaMissingError
+import io.micronaut.context.annotation.Factory
+import io.micronaut.core.io.ResourceResolver
+import jakarta.inject.Singleton
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+@Factory // <1>
+class GraphQLFactory {
+
+    @Singleton // <2>
+    fun graphQL(
+        resourceResolver: ResourceResolver,
+        toDosDataFetcher: ToDosDataFetcher,
+        createToDoDataFetcher: CreateToDoDataFetcher,
+        completeToDoDataFetcher: CompleteToDoDataFetcher,
+        authorDataFetcher: AuthorDataFetcher
+    ): GraphQL {
+        val schemaParser = SchemaParser()
+        val schemaGenerator = SchemaGenerator()
+
+        // Load the schema
+        val schemaDefinition = resourceResolver
+            .getResourceAsStream("classpath:schema.graphqls")
+            .orElseThrow { SchemaMissingError() }
+
+        // Parse the schema and merge it into a type registry
+        val typeRegistry = TypeDefinitionRegistry()
+        typeRegistry.merge(schemaParser.parse(BufferedReader(InputStreamReader(schemaDefinition))))
+
+        // Create the runtime wiring.
+        val runtimeWiring = RuntimeWiring.newRuntimeWiring()
+            .type("Query") { typeWiring: TypeRuntimeWiring.Builder ->  // <3>
+                typeWiring
+                    .dataFetcher("toDos", toDosDataFetcher)
+            }
+            .type("Mutation") { typeWiring: TypeRuntimeWiring.Builder ->  // <4>
+                typeWiring
+                    .dataFetcher("createToDo", createToDoDataFetcher)
+                    .dataFetcher("completeToDo", completeToDoDataFetcher)
+            }
+            .type("ToDo") { typeWiring: TypeRuntimeWiring.Builder ->  // <5>
+                typeWiring
+                    .dataFetcher("author", authorDataFetcher)
+            }
+            .build()
+
+        // Create the executable schema.
+        val graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring)
+
+        // Return the GraphQL bean.
+        return GraphQL.newGraphQL(graphQLSchema).build()
+    }
+}

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/ToDo.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/ToDo.kt
@@ -1,0 +1,16 @@
+package example.micronaut
+
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.GeneratedValue.Type.AUTO
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+
+@MappedEntity // <1>
+class ToDo(var title: String, val authorId: Long) {
+
+    @Id // <2>
+    @GeneratedValue(AUTO)
+    var id: Long? = null
+
+    var isCompleted = false
+}

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/ToDo.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/ToDo.kt
@@ -12,5 +12,5 @@ class ToDo(var title: String, val authorId: Long) {
     @GeneratedValue(AUTO)
     var id: Long? = null
 
-    var isCompleted = false
+    var completed = false
 }

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/ToDoRepository.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/ToDoRepository.kt
@@ -5,4 +5,4 @@ import io.micronaut.data.model.query.builder.sql.Dialect.POSTGRES
 import io.micronaut.data.repository.PageableRepository
 
 @JdbcRepository(dialect = POSTGRES) // <1>
-interface ToDoRepository : PageableRepository<ToDo?, Long?> // <2>
+interface ToDoRepository : PageableRepository<ToDo, Long> // <2>

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/ToDoRepository.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/ToDoRepository.kt
@@ -1,0 +1,8 @@
+package example.micronaut
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect.POSTGRES
+import io.micronaut.data.repository.PageableRepository
+
+@JdbcRepository(dialect = POSTGRES) // <1>
+interface ToDoRepository : PageableRepository<ToDo?, Long?> // <2>

--- a/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/ToDosDataFetcher.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/main/kotlin/example/micronaut/ToDosDataFetcher.kt
@@ -1,0 +1,15 @@
+package example.micronaut
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import jakarta.inject.Singleton
+
+@Singleton // <1>
+class ToDosDataFetcher(
+    private val toDoRepository: ToDoRepository // <2>
+) : DataFetcher<Iterable<ToDo?>> {
+
+    override fun get(env: DataFetchingEnvironment): Iterable<ToDo?> {
+        return toDoRepository.findAll()
+    }
+}

--- a/guides/micronaut-graphql-todo/kotlin/src/test/kotlin/example/micronaut/GraphQLControllerTest.kt
+++ b/guides/micronaut-graphql-todo/kotlin/src/test/kotlin/example/micronaut/GraphQLControllerTest.kt
@@ -1,0 +1,100 @@
+package example.micronaut
+
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+@MicronautTest // <1>
+internal class GraphQLControllerTest {
+
+    @Inject
+    @field:Client("/")
+    lateinit var client: HttpClient // <2>
+
+    @Test
+    fun testGraphQLController() {
+        // when:
+        var todos = allTodos
+
+        // then:
+        assertTrue(todos.isEmpty())
+
+        // when:
+        val id = createToDo("Test GraphQL", "Tim Yates")
+
+        // then: (check it's a UUID)
+        assertEquals(1, id)
+
+        // when:
+        todos = allTodos
+
+        // then:
+        assertEquals(1, todos.size)
+        var todo = todos[0]
+        assertEquals("Test GraphQL", todo["title"])
+        assertFalse(java.lang.Boolean.parseBoolean(todo["completed"].toString()))
+        assertEquals(
+            "Tim Yates",
+            (todo["author"] as Map<*, *>?)!!["username"]
+        )
+
+        // when:
+        val completed = markAsCompleted(id)
+
+        // then:
+        assertTrue(completed)
+
+        // when:
+        todos = allTodos
+
+        // then:
+        assertEquals(1, todos.size)
+        todo = todos[0]
+        assertEquals("Test GraphQL", todo["title"])
+        assertTrue(java.lang.Boolean.parseBoolean(todo["completed"].toString()))
+        assertEquals(
+            "Tim Yates",
+            (todo["author"] as Map<*, *>?)!!["username"]
+        )
+    }
+
+    private fun fetch(query: String): HttpResponse<Map<String, Any>> {
+        val request: HttpRequest<String> = HttpRequest.POST("/graphql", query)
+        val response = client.toBlocking().exchange(
+            request, Argument.mapOf(Argument.STRING, Argument.OBJECT_ARGUMENT)
+        )
+        assertEquals(HttpStatus.OK, response.status())
+        Assertions.assertNotNull(response.body())
+        return response
+    }
+
+    private val allTodos: List<Map<String, Any>>
+        get() {
+            val query = "{\"query\":\"query { toDos { title, completed, author { id, username } } }\"}"
+            val response = fetch(query)
+            return (response.body.get()["data"] as Map<*, *>)["toDos"] as List<Map<String, Any>>
+        }
+
+    private fun createToDo(title: String, author: String): Long {
+        val query =
+            "{\"query\": \"mutation { createToDo(title: \\\"$title\\\", author: \\\"$author\\\") { id } }\" }"
+        val response = fetch(query)
+        return ((response.body.get().get("data") as Map<*, *>)["createToDo"] as Map<*, *>?)!!["id"].toString().toLong()
+    }
+
+    private fun markAsCompleted(id: Long): Boolean {
+        val query = "{\"query\": \"mutation { completeToDo(id: \\\"$id\\\") }\" }"
+        val response = fetch(query)
+        return (response.body.get()["data"] as Map<String, Any>)["completeToDo"] as Boolean
+    }
+}

--- a/guides/micronaut-graphql-todo/metadata.json
+++ b/guides/micronaut-graphql-todo/metadata.json
@@ -5,7 +5,7 @@
   "category": "GraphQL",
   "tags": ["flyway", "micronaut-data", "jdbc", "graphql"],
   "publicationDate": "2022-03-10",
-  "languages": ["java"],
+  "languages": ["java", "kotlin"],
   "apps": [
     {
       "name": "default",

--- a/guides/micronaut-graphql-todo/micronaut-graphql-todo.adoc
+++ b/guides/micronaut-graphql-todo/micronaut-graphql-todo.adoc
@@ -123,9 +123,9 @@ source:CompleteToDoDataFetcher[]
 
 callout:singleton[1]
 callout:constructor-di[number=2,arg0=ToDoRepository]
-<2> Find the existing ToDo based on its id.
-<3> If found, set completed.
-<4> And update the version in the database.
+<3> Find the existing ToDo based on its id.
+<4> If found, set completed.
+<5> And update the version in the database.
 
 ==== Wiring
 
@@ -334,6 +334,8 @@ The tests then run "as in production" with real data in a real database.
 To enable the tests to use this Dockerized database, create `application-test.yml` to overwrite the runtime datasource configuration.
 
 testResource:application-test.yml[tag=testcontainers]
+
+<1> Specify a https://www.testcontainers.org/modules/databases/jdbc/[TestContainers JDBC URL] to run our tests in a real but temporary PostgreSQL database
 
 common:testApp-noheader.adoc[]
 


### PR DESCRIPTION
This adds the Kotlin version of the GraphQL ToDo guide.

I've used ideomatic Kotlin, but found a couple of oddities:

- `AuthorRepository` has to be an abstract class, not an interface or compilation fails
- `CreateToDoDataFetcher` has to be declared as `open` or `@Transactional` will fail to be applied

I also fixed a couple of issues with the Java version (callouts) I spotted whilst doing this