### PR TITLE
Add tip about using mysql:oracle docker image for Mac M1 users

### DIFF
--- a/guides/micronaut-data-jdbc-repository/micronaut-data-jdbc-repository.adoc
+++ b/guides/micronaut-data-jdbc-repository/micronaut-data-jdbc-repository.adoc
@@ -117,6 +117,8 @@ docker run -it --rm \
 	mysql:8
 ----
 
+common:docker-mysql-arm[]
+
 common:runapp-instructions.adoc[]
 
 Save one genre, and your `genre` table will now contain an entry.

--- a/src/docs/common/snippets/common-data-jdbc-mysql-configuration.adoc
+++ b/src/docs/common/snippets/common-data-jdbc-mysql-configuration.adoc
@@ -13,6 +13,8 @@ dependency:mysql[groupId=mysql-connector-java,scope=runtimeOnly]
 
 We will use the https://hub.docker.com/_/mysql[MySQL Docker Image] to start a MySQL server instance. If you have https://www.docker.com/[Docker] installed, run in the terminal:
 
+common:docker-mysql-arm[]
+
 [source, bash]
 ----
 docker network create mysql # <1>

--- a/src/docs/common/snippets/common-docker-mysql-arm.adoc
+++ b/src/docs/common/snippets/common-docker-mysql-arm.adoc
@@ -1,0 +1,1 @@
+TIP: If you are using macOS on Apple Silicon – e.g. M1, M1 Pro, etc. – Docker might fail to pull a native image for `mysql:8`. In that case substitute `mysql:oracle` and make the corresponding change for the `testcontainers datasource` in `src/test/respources/application-test.yml`.

--- a/src/docs/common/snippets/common-docker-mysql-arm.adoc
+++ b/src/docs/common/snippets/common-docker-mysql-arm.adoc
@@ -1,1 +1,1 @@
-TIP: If you are using macOS on Apple Silicon – e.g. M1, M1 Pro, etc. – Docker might fail to pull a native image for `mysql:8`. In that case substitute `mysql:oracle` and make the corresponding change for the `testcontainers datasource` in `src/test/respources/application-test.yml`.
+TIP: If you are using macOS on Apple Silicon – e.g. M1, M1 Pro, etc. – Docker might fail to pull an image for `mysql:8`. In that case substitute `mysql:oracle` and make the corresponding change for the `testcontainers datasource` in `src/test/resources/application-test.yml`.


### PR DESCRIPTION
Add tip about using mysql:oracle docker image for Mac M1 users, since there is no darwin/arm64 version of mysql:8.