### PR TITLE
Add missing implementation dependency and correct mistake in annotationProcessor dependency

### DIFF
--- a/guides/micronaut-jpa-hibernate/micronaut-jpa-hibernate.adoc
+++ b/guides/micronaut-jpa-hibernate/micronaut-jpa-hibernate.adoc
@@ -14,17 +14,19 @@ Add the following dependencies:
 
 :dependencies:
 
-dependency:micronaut-hibernate-jpa[groupId=io.micronaut.sql,callout=1]
-dependency:micronaut-jdbc-hikari[groupId=io.micronaut.sql,callout=2]
-dependency:h2[groupId=com.h2database,scope=runtimeOnly,callout=3]
-dependency:jakarta.persistence-api[groupId=jakarta.persistence,version=2.2.3,callout=4]
+dependency:micronaut-data-hibernate-jpa[groupId=io.micronaut.data,callout=1]
+dependency:micronaut-hibernate-jpa[groupId=io.micronaut.sql,callout=2]
+dependency:micronaut-jdbc-hikari[groupId=io.micronaut.sql,callout=3]
+dependency:h2[groupId=com.h2database,scope=runtimeOnly,callout=4]
+dependency:jakarta.persistence-api[groupId=jakarta.persistence,version=2.2.3,callout=5]
 
 :dependencies:
 
-<1> Configures Hibernate/JPA EntityManagerFactory beans.
-<2> Configures SQL DataSource instances using Hikari Connection Pool.
-<3> Add dependency to in-memory H2 Database.
-<4> Add dependency to Jakarta Persistence API.
+<1> Adds support for Hibernate/JPA.
+<2> Configures Hibernate/JPA EntityManagerFactory beans.
+<3> Configures SQL DataSource instances using Hikari Connection Pool.
+<4> Add dependency to in-memory H2 Database.
+<5> Add dependency to Jakarta Persistence API.
 
 Define the data source in `src/main/resources/application.yml`.
 
@@ -73,7 +75,7 @@ To mark the transaction demarcations, we use the https://docs.oracle.com/javaee/
 
 To use it, you have to include the `micronaut-data-processor` dependency in your annotation processor configuration:
 
-dependency:micronaut-data-hibernate-jpa[groupId=io.micronaut.data,scope=annotationProcessor]
+dependency:micronaut-data-processor[groupId=io.micronaut.data,scope=annotationProcessor]
 
 Next, create a repository interface to define the operations to access the database:
 


### PR DESCRIPTION
Add missing implementation dependency for the jpa-hibernate guide, and correct mistake in annotationProcessor dependency (that prevented a working example), making it consistent with the working solution.