### PR TITLE
move views-form example from micronaut-examples

### DIFF
--- a/guides/views-form/java/src/main/java/views/and/forms/java/controllers/SurveyController.java
+++ b/guides/views-form/java/src/main/java/views/and/forms/java/controllers/SurveyController.java
@@ -1,0 +1,72 @@
+package views.and.forms.java.controllers;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Consumes;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Error;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.views.View;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import views.and.forms.java.model.FormData;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import java.util.Set;
+
+@Controller("/")
+public class SurveyController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SurveyController.class);
+
+    @Get
+    @View("home")
+    public FormData home() {
+
+        if (LOG.isInfoEnabled()) {
+            LOG.info("Sending home page ");
+        }
+
+        return new FormData();
+
+    }
+
+    @View("thankyou")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/survey")
+    public FormData processHomeScreen(@Body @Valid FormData formData) {
+
+        if (LOG.isInfoEnabled()) {
+            LOG.info( "{} has a chocolate preference of: {}", formData.getUserName(), formData.getChocolate());
+        }
+
+        formData.clearErrors();
+
+        return formData;
+
+    }
+
+    @View("home")
+    @Error(exception = ConstraintViolationException.class)
+    public FormData handleInvalidInput(HttpRequest<FormData> request, ConstraintViolationException cv) {
+
+        Set<ConstraintViolation<?>> constraintViolations = cv.getConstraintViolations();
+
+        if (LOG.isInfoEnabled()) {
+            LOG.info("Form validation failed with {} error(s)", constraintViolations.size());
+        }
+
+        FormData model = request.getBody(FormData.class).orElse(new FormData());
+
+        constraintViolations.forEach(constraintViolation -> {
+            model.addError(constraintViolation.getMessage());
+        });
+
+        return model;
+    }
+
+}

--- a/guides/views-form/java/src/main/java/views/and/forms/java/model/FormData.java
+++ b/guides/views-form/java/src/main/java/views/and/forms/java/model/FormData.java
@@ -1,0 +1,62 @@
+package views.and.forms.java.model;
+
+import io.micronaut.core.annotation.Introspected;
+
+import javax.validation.constraints.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Introspected
+public class FormData {
+    private final String[] fruitChoices = {"banana", "mango", "apple", "orange", "grapes", "star"};
+
+    @Size(min=2, message="Name must be at least 2 characters long.")
+    private String userName;
+    private String chocolate;
+    @Size(max=3, message="Please choose a maximum of 3 fruits.")
+    private List<String> fruitChosen = new ArrayList<String>();
+    private List<String> errors = new ArrayList<String>();
+
+    public FormData() {
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getChocolate() {
+        return chocolate;
+    }
+
+    public void setChocolate(String chocolate) {
+        this.chocolate = chocolate;
+    }
+
+    public List<String> getFruitChosen() {
+        return fruitChosen;
+    }
+
+    public void setFruitChosen(List<String> fruitChosen) {
+        this.fruitChosen = fruitChosen;
+    }
+
+    public String[] getFruitChoices() {
+        return fruitChoices;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public void addError(String error) {
+        this.errors.add(error);
+    }
+
+    public void clearErrors() {
+        this.errors.clear();
+    }
+}

--- a/guides/views-form/java/src/main/resources/application.yml
+++ b/guides/views-form/java/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+micronaut:
+  application:
+    name: views-and-forms-java
+  router:
+    static-resources:
+      default:
+        enabled: true
+        mapping: "/static/**"
+        paths: "classpath:static"
+
+

--- a/guides/views-form/java/src/main/resources/static/css/main.css
+++ b/guides/views-form/java/src/main/resources/static/css/main.css
@@ -1,0 +1,78 @@
+    * {
+      box-sizing: border-box;
+    }
+
+    .wrapper {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      background-color: #b6b9bf;
+    }
+
+    .title-welcome {
+      padding: 2vh 2vw;
+      font-size: 3.5vw;
+      font-family: 'Roboto', Verdana, sans-serif;
+      font-weight: 600;
+      align-self: center;
+      justify-content: center;
+    }
+
+    .final-thank-you {
+      padding: 6vh 2vw;
+      font-size: 2vw;
+      font-family: 'Roboto', Verdana, sans-serif;
+      font-weight: 200;
+      align-self: center;
+      justify-content: center;
+    }
+
+    .subtitle {
+      padding: 1vh 2vw;
+      font-size: 2vw;
+      font-family: 'Roboto', Verdana, sans-serif;
+      font-weight: 300;
+      color: #000000;
+      align-self: center;
+    }
+
+    .questions {
+      padding-top: 0.5vh;
+      padding-bottom: 0.3vh;
+      padding-left: 0.5vh;
+      margin-bottom: 3vh;
+      font-size: 1.5vw;
+      font-family: 'Roboto', Verdana, sans-serif;
+      font-weight: 200;
+      align-self: left;
+    }
+
+    .user-name {
+      margin: 2vh 5vw;
+      font-size: 1vw;
+      font-family: 'Roboto', Verdana, sans-serif;
+      font-weight: 200;
+      color: #000000;
+    }
+
+    .radio-buttons {
+      margin: 5vh 1vw;
+      font-size: 1.5vw;
+      font-family: 'Roboto', Verdana, sans-serif;
+      font-weight: 200;
+      color: #000000;
+    }
+
+    .submit-button {
+      margin: 4vh 1vw;
+      font-size: 1.5vw;
+      font-family: 'Roboto', Verdana, sans-serif;
+      font-weight: 200;
+      align-self: center;
+    }
+
+    .error {
+      font-size: 1.5vw;
+      font-weight: 100;
+      color:red;
+    }

--- a/guides/views-form/java/src/main/resources/views/home.hbs
+++ b/guides/views-form/java/src/main/resources/views/home.hbs
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>Survey</title>
+
+    <link rel="stylesheet" type="text/css" href="/static/css/main.css"/>
+    <link rel="icon" href="images/favicon.png" />
+
+</head>
+
+<body>
+  <form action="/survey" method="post">
+
+    <div class="wrapper">
+        <div class="title-welcome">Welcome</div>
+        <div class="subtitle">Welcome to our example survey</div>
+        <div class="questions">What is your name?
+            <input class="user-name" name="userName" value={{userName}}></input>
+        </div>
+        <div class="questions">How do you feel about chocolate?
+            <input type="radio" id="like-chocolate" name="chocolate" value="like" checked>
+            <label class="radio-buttons" for="like-chocolate">I like it!</label>
+            <input type="radio" id="dislike-chocolate" name="chocolate" value="dislike">
+            <label class="radio-buttons" for="dislike-chocolate">Not a fan</label>
+            <input type="radio" id="meh-chocolate" name="chocolate" value="feel meh about">
+            <label class="radio-buttons" for="meh-chocolate">Meh</label>
+            <br>
+        </div>
+        <div class="questions">What is your favorite fruit? (choose up to 3)
+            {{#each fruitChoices}}
+                <input type="checkbox" id={{this}} name=fruitChosen value={{this}}>
+                <label for={{this}}>{{this}}</label>
+            {{/each}}
+            <br>
+        </div>
+        <div>
+            {{#each errors}}
+                <p class="error">{{this}}</p>
+            {{/each}}
+        </div>
+        <div>
+            <input class="submit-button" type="submit" value="Submit">
+        </div>
+    </div>
+
+  </form>
+
+</body>
+</html>

--- a/guides/views-form/java/src/main/resources/views/thankyou.hbs
+++ b/guides/views-form/java/src/main/resources/views/thankyou.hbs
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>Thanks</title>
+
+    <link rel="stylesheet" type="text/css" href="/static/css/main.css"/>
+    <link rel="icon" href="images/favicon.png" />
+
+</head>
+
+<body>
+
+    <div class="wrapper">
+        <div class="final-thank-you">{{userName}}, Thank you for replying to our survey.</div>
+        <div class="final-thank-you">I too {{chocolate}} chocolate</div>
+        <div class="final-thank-you">
+            Your choice of fruit:
+            {{#each fruitChosen}}
+                {{this}},
+            {{else}}
+                No fruits selected
+            {{/each}}
+            is spectacular!
+        </div>
+        <div class="final-thank-you">Enjoy the rest of your day.</div>
+    </div>
+
+</body>
+</html>

--- a/guides/views-form/java/src/test/groovy/views/and/forms/java/HomePage.groovy
+++ b/guides/views-form/java/src/test/groovy/views/and/forms/java/HomePage.groovy
@@ -1,0 +1,18 @@
+package views.and.forms.java
+
+import geb.Page
+
+class HomePage extends Page {
+
+    static at = { title.contains 'Survey' }
+
+    static url = '/'
+
+    static content = {
+        submitButton (to:ThankyouPage){
+          $("input", type: "submit")
+        }
+
+    }
+
+}

--- a/guides/views-form/java/src/test/groovy/views/and/forms/java/PagesSpec.groovy
+++ b/guides/views-form/java/src/test/groovy/views/and/forms/java/PagesSpec.groovy
@@ -1,0 +1,124 @@
+package views.and.forms.java
+
+import geb.spock.GebSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.annotation.MicronautTest
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+@MicronautTest
+class PagesSpec extends GebSpec {
+
+    @AutoCleanup
+    @Shared
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
+
+    def "verify home page" () {
+        given:
+        browser.baseUrl = embeddedServer.URL.toString()
+
+        when:
+        to HomePage
+
+        then:
+        at HomePage
+
+    }
+
+    def "verify valid name get to thankyou page" () {
+        given:
+        browser.baseUrl = embeddedServer.URL.toString()
+
+        when:
+        to HomePage
+        $("input", name: "userName").value("Bob")
+        $("input[type=submit]").click()
+
+        then:
+        at ThankyouPage
+
+    }
+
+    def "verify invalid name get to home page" () {
+        given:
+        browser.baseUrl = embeddedServer.URL.toString()
+
+        when:
+        to HomePage
+        $("input", name: "userName").value("B")
+        $("input[type=submit]").click()
+
+        then:
+        at HomePage
+
+    }
+
+    def "verify error message for invalid name get to home page" () {
+        given:
+        browser.baseUrl = embeddedServer.URL.toString()
+
+        when:
+        to HomePage
+        $("input", name: "userName").value("B")
+        $("input[type=submit]").click()
+
+        then:
+        at HomePage
+        assert $("p.error").text().contains("Name must be at least 2 characters long.")
+
+    }
+
+    def "verify select fruit go to thankyou page" () {
+        given:
+        browser.baseUrl = embeddedServer.URL.toString()
+
+        when:
+        to HomePage
+        $("input", name: "userName").value("Bob")
+
+        $("form").fruitChosen = ["banana", "mango", "grapes"]
+
+        $("input[type=submit]").click()
+
+        then:
+        at ThankyouPage
+
+    }
+
+    def "verify select too many fruit go to home page" () {
+        given:
+        browser.baseUrl = embeddedServer.URL.toString()
+
+        when:
+        to HomePage
+        $("input", name: "userName").value("Bob")
+
+        $("form").fruitChosen = ["banana", "mango", "grapes", "star"]
+
+        $("input[type=submit]").click()
+
+        then:
+        at HomePage
+
+    }
+
+    def "verify error message for too many fruit" () {
+        given:
+        browser.baseUrl = embeddedServer.URL.toString()
+
+        when:
+        to HomePage
+        $("input", name: "userName").value("Bob")
+
+        $("form").fruitChosen = ["banana", "mango", "grapes", "star"]
+
+        $("input[type=submit]").click()
+
+        then:
+        at HomePage
+        assert $("p.error").text().contains("Please choose a maximum of 3 fruits")
+
+    }
+
+}

--- a/guides/views-form/java/src/test/groovy/views/and/forms/java/ThankyouPage.groovy
+++ b/guides/views-form/java/src/test/groovy/views/and/forms/java/ThankyouPage.groovy
@@ -1,0 +1,15 @@
+package views.and.forms.java
+
+import geb.Page
+
+class ThankyouPage extends Page {
+
+    static at = { title.contains 'Thanks' }
+
+    static url = '/'
+
+    static content = {
+
+    }
+
+}

--- a/guides/views-form/java/src/test/resources/GebConfig.groovy
+++ b/guides/views-form/java/src/test/resources/GebConfig.groovy
@@ -1,0 +1,16 @@
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeOptions
+
+ChromeOptions options = new ChromeOptions()
+
+environments {
+    chrome {
+        driver = { new ChromeDriver(options) }
+    }
+    chromeHeadless {
+        driver = {
+            options.addArguments('headless')
+            new ChromeDriver(options)
+        }
+    }
+}


### PR DESCRIPTION
Guide should use feature [views-handlebars](https://micronaut.io/launch?type=DEFAULT&name=demo&package=com.example&javaVersion=JDK_11&lang=JAVA&build=GRADLE&test=JUNIT&features=views-handlebars&version=3.4.2). 

The guide is using Geb. I think we have other guides using geb. Check it out. We should consider rewriting the test so that we don't need geb. if we want to pursue Geb, [Micronaut security](https://github.com/micronaut-projects/micronaut-security) has a good example of using Geb with test containers and Micronaut. 

- [ ] add metadata.json
- [ ] add asciidoc file
- [ ] write guide, add callouts to files and explain
- [ ] add kotlin variation
- [ ] add java variation
- [ ] add groovy variation