### PR TITLE
Fix email-sendgrid guide to correct property name

### DIFF
--- a/guides/micronaut-email-sendgrid/micronaut-email-sendgrid.adoc
+++ b/guides/micronaut-email-sendgrid/micronaut-email-sendgrid.adoc
@@ -40,7 +40,7 @@ export SENDGRID_API_KEY=xxx
 
 === From email address
 
-Change the property `mail.email.from.email` to match your SendGrid configuration.
+Change the property `micronaut.email.from.email` to match your SendGrid configuration.
 
 === Run
 common:runapp-instructions.adoc[]


### PR DESCRIPTION
Fix email-sendgrid guide to correct property name.