### PR TITLE
Reinstate temporarily disabled failing test

### DIFF
--- a/guides/micronaut-database-authentication-provider/groovy/src/test/groovy/example/micronaut/LoginLdapSpec.groovy
+++ b/guides/micronaut-database-authentication-provider/groovy/src/test/groovy/example/micronaut/LoginLdapSpec.groovy
@@ -12,7 +12,6 @@ import io.micronaut.security.token.jwt.validator.JwtTokenValidator
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import reactor.core.publisher.Flux
 import org.reactivestreams.Publisher
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -45,7 +44,6 @@ class LoginLdapSpec extends Specification {
         rsp.body.get().accessToken
     }
 
-    @Ignore('TODO fix the timeout issue')
     void '/login with invalid credentials returns UNAUTHORIZED'() {
         when:
         HttpRequest request = HttpRequest.create(POST, '/login')


### PR DESCRIPTION
We had an issue here with a timeout

https://github.com/micronaut-projects/micronaut-guides/pull/910#issuecomment-1113598043

Reinstating this test to see if it's still the case