### PR TITLE
Misc. MyBatis guide fixes

### DIFF
--- a/guides/micronaut-data-access-mybatis/micronaut-data-access-mybatis.adoc
+++ b/guides/micronaut-data-access-mybatis/micronaut-data-access-mybatis.adoc
@@ -34,7 +34,7 @@ resource:application.yml[tag=datasource]
 
 As there is no out-of-the-box support yet in the Micronaut framework for MyBatis, it is necessary to manually wire `SqlSessionFactory`.
 
-Create the following https://docs.micronaut.io/latest/guide/#factories[@Factory] class in  `src/main/java/example/micronaut/MybatisFactory.java`:
+Create the following https://docs.micronaut.io/latest/guide/#factories[@Factory] class:
 
 source:MybatisFactory[]
 <1> Annotate the class with `@Factory`.
@@ -49,6 +49,8 @@ callout:constructor-di[number=2,arg0=DataSource]
 Create the domain entities:
 
 source:domain/Genre[]
+
+source:domain/Book[]
 
 === Repository Access
 


### PR DESCRIPTION
Remove mention of a .java file--filename is printed automatically in language-agnostic manner when the snippet is processed. Also add the Book entity to the guide. Fixes #873