### PR TITLE
remove section titles of categories

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
@@ -213,7 +213,7 @@ class IndexGenerator {
             }
         } else {
             index += "<div class='col-sm-8'>"
-            index += guidesTable(filteredMetadatas, cat.toString() + " Guides", false)
+            index += guidesTable(filteredMetadatas)
             index += "</div>"
         }
 


### PR DESCRIPTION
@JasonTypesCodes :

> The other sections have two titles.  One in the card on the left and again at the top of the table.  I think we can probably remove the title from the top of the remaining tables.