### PR TITLE
Update HelloControllerSpec.groovy

### DIFF
--- a/guides/micronaut-rest-assured/groovy/src/test/groovy/example/micronaut/HelloControllerSpec.groovy
+++ b/guides/micronaut-rest-assured/groovy/src/test/groovy/example/micronaut/HelloControllerSpec.groovy
@@ -14,6 +14,7 @@ class HelloControllerSpec extends Specification {
     RequestSpecification spec // <2>
 
     void "test hello endpoint"() {
+        expect:
         spec    // <3>
             .when()
                 .get('/hello')


### PR DESCRIPTION
When I was trying to make rest-assured test work in Groovy/Gradle setup, any test was able to found through runner. After adding `expect:` clause code started to work.