### PR TITLE
ldap://ldap.forumsys.com:389 is dead replace with debians open ldap

### DIFF
--- a/guides/micronaut-database-authentication-provider/groovy/src/main/resources/application.yml
+++ b/guides/micronaut-database-authentication-provider/groovy/src/main/resources/application.yml
@@ -22,14 +22,14 @@ micronaut:
     ldap:
       default: # <1>
         context:
-          server: 'ldap://ldap.forumsys.com:389'  # <2>
-          managerDn: 'cn=read-only-admin,dc=example,dc=com'  # <3>
+          server: 'ldaps://db.debian.org'  # <2>
+          managerDn: 'cn=read-only-admin,dc=debian,dc=org'  # <3>
           managerPassword: 'password'  # <4>
         search:
-          base: "dc=example,dc=com"  # <5>
+          base: "dc=debian,dc=org"  # <5>
         groups:
           enabled: true  # <6>
-          base: "dc=example,dc=com" # <7>
+          base: "dc=debian,dc=org" # <7>
 #end::ldap[]
 ---
 #tag::datasource[]

--- a/guides/micronaut-database-authentication-provider/groovy/src/test/groovy/example/micronaut/LoginLdapSpec.groovy
+++ b/guides/micronaut-database-authentication-provider/groovy/src/test/groovy/example/micronaut/LoginLdapSpec.groovy
@@ -12,7 +12,6 @@ import io.micronaut.security.token.jwt.validator.JwtTokenValidator
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import reactor.core.publisher.Flux
 import org.reactivestreams.Publisher
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -45,7 +44,6 @@ class LoginLdapSpec extends Specification {
         rsp.body.get().accessToken
     }
 
-    @Ignore('TODO fix the timeout issue')
     void '/login with invalid credentials returns UNAUTHORIZED'() {
         when:
         HttpRequest request = HttpRequest.create(POST, '/login')

--- a/guides/micronaut-database-authentication-provider/micronaut-database-authentication-provider.adoc
+++ b/guides/micronaut-database-authentication-provider/micronaut-database-authentication-provider.adoc
@@ -39,9 +39,9 @@ resource:application.yml[tag=security]
 
 The Micronaut framework supports authentication with LDAP out of the box.
 
-We will use an https://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/[Online LDAP test server] for this guide.
+We will use the open Debian LDAP service for this guide.
 
-Create several configuration properties matching those of the test LDAP Server.
+Create the configuration properties matching those of the LDAP Server.
 
 resource:application.yml[tag=ldap]
 


### PR DESCRIPTION
The death of the forumsys ldap test service was causing the test to time out.

We do not rely on any data in the service, just the ascence of a user, so I switched to the
debian ldap service

Closes #998