### PR TITLE
add author to micronaut-cloud-database-oracle

### DIFF
--- a/guides/micronaut-cloud-database-oracle/metadata.json
+++ b/guides/micronaut-cloud-database-oracle/metadata.json
@@ -1,5 +1,6 @@
 {
   "base": "micronaut-cloud-database-base",
+  "authors": ["Burt Beckwith"],
   "title": "Deploy a Micronaut MySQL Database Application to Oracle Cloud",
   "intro": "Learn how to deploy a MySQL Micronaut Database Application to Oracle Cloud.",
   "tags": ["oracle"],


### PR DESCRIPTION
I removed the author element from the base guide but didn't add it to micronaut-cloud-database-oracle, so it's blank in the rendered guide