### PR TITLE
Remove the temporary -testresources suffix

### DIFF
--- a/guides/hotwire-turbo-micronaut-chat/metadata.json
+++ b/guides/hotwire-turbo-micronaut-chat/metadata.json
@@ -10,11 +10,11 @@
   "apps": [
     {
       "name": "initial",
-      "features": ["views-thymeleaf", "data-jdbc", "flyway", "jdbc-hikari" ,"mysql-testresources", "graalvm", "junit-params"]
+      "features": ["views-thymeleaf", "data-jdbc", "flyway", "jdbc-hikari" ,"mysql", "graalvm", "junit-params"]
     },
     {
       "name": "complete",
-      "features": ["views-thymeleaf","data-jdbc", "flyway", "jdbc-hikari" ,"mysql-testresources", "graalvm", "awaitility", "reactor", "junit-params"]
+      "features": ["views-thymeleaf","data-jdbc", "flyway", "jdbc-hikari" ,"mysql", "graalvm", "awaitility", "reactor", "junit-params"]
     }
   ]
 }

--- a/guides/micronaut-data-jdbc-repository/metadata.json
+++ b/guides/micronaut-data-jdbc-repository/metadata.json
@@ -9,7 +9,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["data-jdbc", "flyway", "jdbc-hikari" ,"mysql-testresources", "graalvm"]
+      "features": ["data-jdbc", "flyway", "jdbc-hikari" ,"mysql", "graalvm"]
     }
   ]
 }

--- a/guides/micronaut-data-mongodb-asynchronous/metadata.json
+++ b/guides/micronaut-data-mongodb-asynchronous/metadata.json
@@ -10,7 +10,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["data-mongodb-async-testresources","reactor","testcontainers"]
+      "features": ["data-mongodb-async","reactor","testcontainers"]
     }
   ]
 }

--- a/guides/micronaut-data-mongodb-synchronous/metadata.json
+++ b/guides/micronaut-data-mongodb-synchronous/metadata.json
@@ -10,7 +10,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["data-mongodb-testresources"]
+      "features": ["data-mongodb"]
     }
   ]
 }

--- a/guides/micronaut-flyway/metadata.json
+++ b/guides/micronaut-flyway/metadata.json
@@ -9,7 +9,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm","data-jdbc","flyway","postgres-testresources", "management"]
+      "features": ["graalvm","data-jdbc","flyway","postgres", "management"]
     }
   ]
 }

--- a/guides/micronaut-graphql-todo/metadata.json
+++ b/guides/micronaut-graphql-todo/metadata.json
@@ -10,7 +10,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graphql", "data-jdbc", "flyway", "postgres-testresources", "graalvm"]
+      "features": ["graphql", "data-jdbc", "flyway", "postgres", "graalvm"]
     }
   ]
 }

--- a/guides/micronaut-java-records/metadata.json
+++ b/guides/micronaut-java-records/metadata.json
@@ -11,7 +11,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "data-jdbc","liquibase","postgres-testresources"]
+      "features": ["graalvm", "data-jdbc","liquibase","postgres"]
     }
   ]
 }

--- a/guides/micronaut-jaxrs-jdbc/metadata.json
+++ b/guides/micronaut-jaxrs-jdbc/metadata.json
@@ -9,7 +9,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["jax-rs", "data-jdbc", "mysql-testresources", "flyway", "graalvm"]
+      "features": ["jax-rs", "data-jdbc", "mysql", "flyway", "graalvm"]
     }
   ]
 }

--- a/guides/micronaut-kafka/metadata.json
+++ b/guides/micronaut-kafka/metadata.json
@@ -10,11 +10,11 @@
   "apps": [
     {
       "name": "books",
-      "features": ["graalvm", "kafka-testresources", "awaitility", "reactor"]
+      "features": ["graalvm", "kafka", "awaitility", "reactor"]
     },
     {
       "name": "analytics",
-      "features": ["graalvm", "kafka-testresources"]
+      "features": ["graalvm", "kafka"]
     }
   ]
 }

--- a/guides/micronaut-liquibase/metadata.json
+++ b/guides/micronaut-liquibase/metadata.json
@@ -9,7 +9,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm","data-jdbc","liquibase","postgres-testresources", "management"]
+      "features": ["graalvm","data-jdbc","liquibase","postgres", "management"]
     }
   ]
 }

--- a/guides/micronaut-mongodb-asynchronous/metadata.json
+++ b/guides/micronaut-mongodb-asynchronous/metadata.json
@@ -10,7 +10,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["mongo-reactive-testresources","reactor", "graalvm"]
+      "features": ["mongo-reactive","reactor", "graalvm"]
     }
   ]
 }

--- a/guides/micronaut-mongodb-synchronous/metadata.json
+++ b/guides/micronaut-mongodb-synchronous/metadata.json
@@ -10,7 +10,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["mongo-sync-testresources", "graalvm"]
+      "features": ["mongo-sync", "graalvm"]
     }
   ]
 }

--- a/guides/micronaut-openapi-generator-server/metadata.json
+++ b/guides/micronaut-openapi-generator-server/metadata.json
@@ -12,7 +12,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["security", "reactor", "swagger-annotations", "data-jdbc", "flyway", "jdbc-hikari" ,"mysql-testresources", "graalvm", "jakarta-persistence-api"],
+      "features": ["security", "reactor", "swagger-annotations", "data-jdbc", "flyway", "jdbc-hikari" ,"mysql", "graalvm", "jakarta-persistence-api"],
       "openAPIGeneratorConfig": {
         "definitionFile": "src/main/resources/library-definition.yaml"
       }

--- a/guides/micronaut-rabbitmq-rpc/metadata.json
+++ b/guides/micronaut-rabbitmq-rpc/metadata.json
@@ -9,15 +9,15 @@
   "apps": [
     {
       "name": "bookcatalogue",
-      "features": ["rabbitmq-testresources", "graalvm"]
+      "features": ["rabbitmq", "graalvm"]
     },
     {
       "name": "bookinventory",
-      "features": ["rabbitmq-testresources", "graalvm"]
+      "features": ["rabbitmq", "graalvm"]
     },
     {
       "name": "bookrecommendation",
-      "features": ["rabbitmq-testresources", "graalvm", "reactor"]
+      "features": ["rabbitmq", "graalvm", "reactor"]
     }
   ]
 }

--- a/guides/micronaut-rabbitmq/metadata.json
+++ b/guides/micronaut-rabbitmq/metadata.json
@@ -9,11 +9,11 @@
   "apps": [
     {
       "name": "books",
-      "features": ["graalvm", "rabbitmq-testresources", "mockito", "reactor"]
+      "features": ["graalvm", "rabbitmq", "mockito", "reactor"]
     },
     {
       "name": "analytics",
-      "features": ["graalvm", "rabbitmq-testresources"]
+      "features": ["graalvm", "rabbitmq"]
     }
   ]
 }


### PR DESCRIPTION
We added the suffix for local development prior to 3.6.0