### PR TITLE
Removed gitlab XE docker image

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/IndexGenerator.groovy
@@ -147,6 +147,7 @@ class IndexGenerator {
 
     private static List<GuideMetadata> latestGuides(List<GuideMetadata> metadatas) {
         metadatas.stream()
+                .distinct()
                 .sorted((o1, o2) -> {
                     o2.publicationDate <=> o1.publicationDate
                 })

--- a/guides/micronaut-cloud-trace-base/groovy/src/main/groovy/example/micronaut/WarehouseController.groovy
+++ b/guides/micronaut-cloud-trace-base/groovy/src/main/groovy/example/micronaut/WarehouseController.groovy
@@ -16,7 +16,7 @@ class WarehouseController {
 
     @Get("/count")
     HttpResponse getItemCount() {
-        HttpResponse.ok(new Random().nextInt(11))
+        HttpResponse.ok(new Random().nextInt(10)+1)
     }
 
     @Post("/order")

--- a/guides/micronaut-oracle-autonomous-db/metadata.json
+++ b/guides/micronaut-oracle-autonomous-db/metadata.json
@@ -6,8 +6,6 @@
   "categories": ["Micronaut + Oracle Cloud"],
   "publicationDate": "2021-05-17",
   "minimumJavaVersion": 11,
-  "skipMavenTests": true,
-  "skipGradleTests": true,
   "apps": [{
       "name": "default",
       "features": ["data-jdbc", "flyway", "graalvm", "oracle-cloud-atp", "testcontainers", "testcontainers-oracle"]

--- a/guides/micronaut-oracle-autonomous-db/micronaut-oracle-autonomous-db.adoc
+++ b/guides/micronaut-oracle-autonomous-db/micronaut-oracle-autonomous-db.adoc
@@ -156,9 +156,10 @@ dependency:oracle-xe[groupId=org.testcontainers,scope=testImplementation]
 dependency:testcontainers[groupId=org.testcontainers,scope=testImplementation]
 :dependencies:
 
-To test using Testcontainers, create a `testcontainers.properties` file in `src/test/resources` with this content:
-
-testResource:testcontainers.properties[]
+// Leaving commented out, in case we want to use the latest XE version 21.3.0-slim
+//To test using Testcontainers, create a `testcontainers.properties` file in `src/test/resources` with this content:
+//
+//testResource:testcontainers.properties[]
 
 and replace the generated `application-test.yml` with this:
 

--- a/guides/micronaut-oracle-autonomous-db/src/test/resources/testcontainers.properties
+++ b/guides/micronaut-oracle-autonomous-db/src/test/resources/testcontainers.properties
@@ -1,1 +1,0 @@
-oracle.container.image=registry.gitlab.com/micronaut-projects/micronaut-graal-tests/oracle-database:18.4.0-xe


### PR DESCRIPTION
Guide now uses default Oracle XE DB from TestContainers (18.4.0-slim)

Also, added quick fix for ensuring that guides with multiple categories only show up once in the index "Latest Guide" section.