### PR TITLE
Fix maven mongo guides

### DIFF
--- a/guides/micronaut-data-mongodb-asynchronous/src/main/resources/application.yml
+++ b/guides/micronaut-data-mongodb-asynchronous/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 micronaut:
   application:
     name: micronautguide
+# Required for pre TestResources 1.1
+test-resources:
+  containers:
+    mongodb:
+      image-name: mongo:5

--- a/guides/micronaut-data-mongodb-synchronous/src/main/resources/application.yml
+++ b/guides/micronaut-data-mongodb-synchronous/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 micronaut:
   application:
     name: micronautguide
-
+# Required for pre TestResources 1.1
+test-resources:
+  containers:
+    mongodb:
+      image-name: mongo:5

--- a/guides/micronaut-mongodb-asynchronous/src/main/resources/application.yml
+++ b/guides/micronaut-mongodb-asynchronous/src/main/resources/application.yml
@@ -9,3 +9,8 @@ db:
   name: 'fruit'
   collection: 'fruit'
 #end::db[]
+# Required for pre TestResources 1.1
+test-resources:
+  containers:
+    mongodb:
+      image-name: mongo:5

--- a/guides/micronaut-mongodb-synchronous/src/main/resources/application.yml
+++ b/guides/micronaut-mongodb-synchronous/src/main/resources/application.yml
@@ -7,3 +7,8 @@ db:
   name: 'fruit'
   collection: 'fruit'
 #end::db[]
+# Required for pre TestResources 1.1
+test-resources:
+  containers:
+    mongodb:
+      image-name: mongo:5


### PR DESCRIPTION
There was an issue with Mongo under Test Resources v1.1.0.

There is a new Gradle plugin which uses this new version, however we don't yet have it in the Maven Plugin.

This fix specifies the mongo image to use, so that the tests pass under Maven as well as Gradle.

This can be removed once we have a new Maven plugin version with a > 1.1.0 baseline