### PR TITLE
Stop shared test resources server after running each test

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -159,6 +159,8 @@ cd $nestedFolder
 echo "-------------------------------------------------"
 echo "Executing '$folder' tests"
 ${buildTool == MAVEN ? './mvnw -q test' : './gradlew -q test' } || EXIT_STATUS=\$?
+echo "Stopping shared test resources service (if created)"
+${buildTool == MAVEN ? './mvnw -q mn:stop-testresources-service' : './gradlew -q stopTestResourcesService'} || true
 cd ..
 """
         if (stopIfFailure) {


### PR DESCRIPTION
When we hit the messaging guides, we have them configured to share the server.

This is so that guides with multiple components that talk to each other work as expected (you don't want your Producer and Consumer looking at a different instance of Kafka)

This has the downside that we end up with lots of docker services hanging around, which I believe is introducing flakiness into the build.  Not sure whether this is caused by some sort of race condition, or (more likely) resource exhaustion when we have many services all running inside docker on the CI machine.

We also have many tests which expect a database or channel to be empty when they start, which is potentially not the case when running multiple guides using the same resource.

This change introduces an extra line to the test running script that attempts to shut down the shared server after each build

@melix will this work?  Or will it pull the plug on another test that may be running at the time?