### PR TITLE
bug: Fix CLI command for multi-app guides

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -162,18 +162,21 @@ class GuideAsciidocGenerator {
             text = text.replace("@minJdk@", metadata.minimumJavaVersion?.toString() ?: "1.8")
             text = text.replace("@api@", 'https://docs.micronaut.io/latest/api')
 
-            text = text.replaceAll(~/@(\w*):?cli-command@/) { List<String> matches ->
+            text = text.replaceAll(~/@([\w-]*):?cli-command@/) { List<String> matches ->
                 String app = matches[1] ?: 'default'
-                cliCommandForApp(metadata, app).orElse('')
+                cliCommandForApp(metadata, app)
+                        .orElseThrow {
+                            new GradleException("No CLI command found for app: $app -- should be one of ${metadata.apps.name.collect { "@$it:cli-command@" }.join(", ")}")
+                        }
             }
 
-            text = text.replaceAll(~/@(\w*):?features@/) { List<String> matches ->
+            text = text.replaceAll(~/@([\w-]):?features@/) { List<String> matches ->
                 String app = matches[1] ?: 'default'
                 List<String> features = featuresForApp(metadata, guidesOption, app)
                 features.join(',')
             }
 
-            text = text.replaceAll(~/@(\w*):?features-words@/) { List<String> matches ->
+            text = text.replaceAll(~/@([\w-]):?features-words@/) { List<String> matches ->
                 String app = matches[1] ?: 'default'
                 featuresWordsForApp(metadata, guidesOption, app)
             }

--- a/guides/micronaut-kafka/micronaut-kafka.adoc
+++ b/guides/micronaut-kafka/micronaut-kafka.adoc
@@ -29,7 +29,7 @@ Create the `books` microservice using the https://docs.micronaut.io/latest/guide
 
 [source,bash]
 ----
-mn @cli-command@ --features=kafka,reactor,graalvm,testcontainers example.micronaut.books --build=@build@ --lang=@lang@
+mn @books:cli-command@ --features=kafka,reactor,graalvm,testcontainers example.micronaut.books --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]
@@ -68,7 +68,7 @@ Create the `analytics` microservice using the https://docs.micronaut.io/latest/g
 
 [source,bash]
 ----
-mn @cli-command@ --features=kafka,graalvm example.micronaut.analytics --build=@build@ --lang=@lang@
+mn @analytics:cli-command@ --features=kafka,graalvm example.micronaut.analytics --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]

--- a/guides/micronaut-microservices-services-discover-consul/micronaut-microservices-services-discover-consul.adoc
+++ b/guides/micronaut-microservices-services-discover-consul/micronaut-microservices-services-discover-consul.adoc
@@ -58,7 +58,7 @@ Create the `bookcatalogue` microservice using the https://docs.micronaut.io/late
 
 [source,bash]
 ----
-mn @cli-command@ --features=discovery-consul,management,graalvm example.micronaut.bookcatalogue --build=@build@ --lang=@lang@
+mn @bookcatalogue:cli-command@ --features=discovery-consul,management,graalvm example.micronaut.bookcatalogue --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]
@@ -137,7 +137,7 @@ Create the `bookinventory` microservice using the https://docs.micronaut.io/late
 
 [source,bash]
 ----
-mn @cli-command@ --features=discovery-consul,management,graalvm example.micronaut.bookinventory --build=@build@ --lang=@lang@
+mn @bookinventory:cli-command@ --features=discovery-consul,management,graalvm example.micronaut.bookinventory --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]
@@ -212,7 +212,7 @@ Create the `bookrecommendation` microservice using the https://docs.micronaut.io
 
 [source,bash]
 ----
-mn @cli-command@ --features=discovery-consul,management,reactor,graalvm example.micronaut.bookrecommendation --build=@build@ --lang=@lang@
+mn @bookrecommendation:cli-command@ --features=discovery-consul,management,reactor,graalvm example.micronaut.bookrecommendation --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]

--- a/guides/micronaut-microservices-services-discover-eureka/micronaut-microservices-services-discover-eureka.adoc
+++ b/guides/micronaut-microservices-services-discover-eureka/micronaut-microservices-services-discover-eureka.adoc
@@ -42,7 +42,7 @@ Create the `bookcatalogue` microservice using the https://docs.micronaut.io/late
 
 [source,bash]
 ----
-mn @cli-command@ --features=discovery-eureka,graalvm example.micronaut.bookcatalogue --build=@build@ --lang=@lang@
+mn @bookcatalogue:cli-command@ --features=discovery-eureka,graalvm example.micronaut.bookcatalogue --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]
@@ -121,7 +121,7 @@ Create the `bookinventory` microservice using the https://docs.micronaut.io/late
 
 [source,bash]
 ----
-mn @cli-command@ --features=discovery-eureka,graalvm example.micronaut.bookinventory --build=@build@ --lang=@lang@
+mn @bookinventory:cli-command@ --features=discovery-eureka,graalvm example.micronaut.bookinventory --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]
@@ -196,7 +196,7 @@ Create the `bookrecommendation` microservice using the https://docs.micronaut.io
 
 [source,bash]
 ----
-mn @cli-command@ --features=discovery-eureka,reactor,graalvm example.micronaut.bookrecommendation --build=@build@ --lang=@lang@
+mn @bookrecommendation:cli-command@ --features=discovery-eureka,reactor,graalvm example.micronaut.bookrecommendation --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]

--- a/guides/micronaut-multitenancy-propagation/micronaut-multitenancy-propagation.adoc
+++ b/guides/micronaut-multitenancy-propagation/micronaut-multitenancy-propagation.adoc
@@ -27,7 +27,7 @@ Create the microservice:
 
 [source,bash]
 ----
-mn @cli-command@ example.micronaut.gateway --test=spock --lang=groovy
+mn @gateway:cli-command@ example.micronaut.gateway --test=spock --lang=groovy
 ----
 
 The previous command generates a Micronaut application and tells the CLI to use https://spockframework.org[Spock] as the test framework.
@@ -164,7 +164,7 @@ Create the microservice:
 
 [source,bash]
 ----
-mn @cli-command@ example.micronaut.books --lang=groovy
+mn @books:cli-command@ example.micronaut.books --lang=groovy
 ----
 
 === GORM

--- a/guides/micronaut-oracle-cloud-streaming/micronaut-oracle-cloud-streaming.adoc
+++ b/guides/micronaut-oracle-cloud-streaming/micronaut-oracle-cloud-streaming.adoc
@@ -35,7 +35,7 @@ Create the `chess-game` microservice using the https://docs.micronaut.io/latest/
 
 [source,bash]
 ----
-mn @cli-command@ --features=kafka,graalvm,reactor,testcontainers example.micronaut.chess-game --build=@build@ --lang=@lang@
+mn @chess-game:cli-command@ --features=kafka,graalvm,reactor,testcontainers example.micronaut.chess-game --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]
@@ -131,7 +131,7 @@ resource:application-dev.yml[app=chess-game]
 
 Update `application.yml` to add static resource configuration:
 
-resource:application.yml[app=chess-game,tag=router]
+resource:application.yml[app=chess-game,tag=static-resources]
 
 callout:static-resources[1]
 
@@ -161,7 +161,7 @@ Create the `chess-listener` microservice using the https://docs.micronaut.io/lat
 
 [source,bash]
 ----
-mn @cli-command@ --features=kafka,graalvm,data-jdbc,flyway,reactor,testcontainers example.micronaut.chess-listener --build=@build@ --lang=@lang@
+mn @chess-listener:cli-command@ --features=kafka,graalvm,data-jdbc,flyway,reactor,testcontainers example.micronaut.chess-listener --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]

--- a/guides/micronaut-rabbitmq-rpc/micronaut-rabbitmq-rpc.adoc
+++ b/guides/micronaut-rabbitmq-rpc/micronaut-rabbitmq-rpc.adoc
@@ -35,7 +35,7 @@ Create the `bookcatalogue` microservice using the https://docs.micronaut.io/late
 
 [source,bash]
 ----
-mn @cli-command@ --features=rabbitmq,graalvm example.micronaut.bookcatalogue --build=@build@ --lang=@lang@
+mn @bookcatalogue:cli-command@ --features=rabbitmq,graalvm example.micronaut.bookcatalogue --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]
@@ -85,7 +85,7 @@ Create the `bookinventory` microservice using the https://docs.micronaut.io/late
 
 [source,bash]
 ----
-mn @cli-command@ --features=rabbitmq,graalvm example.micronaut.bookinventory --build=@build@ --lang=@lang@
+mn @bookinventory:cli-command@ --features=rabbitmq,graalvm example.micronaut.bookinventory --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]
@@ -121,7 +121,7 @@ Create the `bookrecommendation` microservice using the https://docs.micronaut.io
 
 [source,bash]
 ----
-mn @cli-command@ --features=rabbitmq,reactor,graalvm example.micronaut.bookrecommendation --build=@build@ --lang=@lang@
+mn @bookrecommendation:cli-command@ --features=rabbitmq,reactor,graalvm example.micronaut.bookrecommendation --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]

--- a/guides/micronaut-rabbitmq/micronaut-rabbitmq.adoc
+++ b/guides/micronaut-rabbitmq/micronaut-rabbitmq.adoc
@@ -30,7 +30,7 @@ Create the `books` microservice using the https://docs.micronaut.io/latest/guide
 
 [source,bash]
 ----
-mn @cli-command@ --features=rabbitmq,reactor,graalvm example.micronaut.books --build=@build@ --lang=@lang@
+mn @books:cli-command@ --features=rabbitmq,reactor,graalvm example.micronaut.books --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]
@@ -62,7 +62,7 @@ Create the `analytics` microservice using the https://docs.micronaut.io/latest/g
 
 [source,bash]
 ----
-mn @cli-command@ --features=rabbitmq,graalvm example.micronaut.analytics --build=@build@ --lang=@lang@
+mn @analytics:cli-command@ --features=rabbitmq,graalvm example.micronaut.analytics --build=@build@ --lang=@lang@
 ----
 
 common:build-lang-arguments.adoc[]

--- a/guides/micronaut-token-propagation/micronaut-token-propagation.adoc
+++ b/guides/micronaut-token-propagation/micronaut-token-propagation.adoc
@@ -29,7 +29,7 @@ Create the microservice:
 
 [source,bash]
 ----
-mn @cli-command@ example.micronaut.gateway --build=@build@ --lang=@lang@
+mn @gateway:cli-command@ example.micronaut.gateway --build=@build@ --lang=@lang@
 ----
 
 Add the security-jwt module to the configuration:
@@ -107,7 +107,7 @@ Create the microservice:
 
 [source,bash]
 ----
-mn @cli-command@ example.micronaut.userecho --build=@build@ --lang=@lang@
+mn @userecho:cli-command@ example.micronaut.userecho --build=@build@ --lang=@lang@
 ----
 
 Add the security-jwt module to the configuration:


### PR DESCRIPTION
When there are multiple apps in a guide, the format for @cli-command@ should be @app-name:cli-command@

Previously, if this was missed, we outputted a blank command into the guide.

This change catches this (easy to make) bug, and throws an exception at build time like so:

```
Execution failed for task ':micronautOracleCloudStreamingGenerateDocs'.
> No CLI command found for app: default -- should be one of @chess-game:cli-command@, @chess-listener:cli-command@
```

The regular expression previously also didn't allow hyphens in the app names, this has also been rectified

Fixes #1069