### PR TITLE
bug: @features@ and @features-words@ macros not working

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -170,13 +170,13 @@ class GuideAsciidocGenerator {
                         }
             }
 
-            text = text.replaceAll(~/@([\w-]):?features@/) { List<String> matches ->
+            text = text.replaceAll(~/@([\w-]*):?features@/) { List<String> matches ->
                 String app = matches[1] ?: 'default'
                 List<String> features = featuresForApp(metadata, guidesOption, app)
                 features.join(',')
             }
 
-            text = text.replaceAll(~/@([\w-]):?features-words@/) { List<String> matches ->
+            text = text.replaceAll(~/@([\w-]*):?features-words@/) { List<String> matches ->
                 String app = matches[1] ?: 'default'
                 featuresWordsForApp(metadata, guidesOption, app)
             }


### PR DESCRIPTION
In https://github.com/micronaut-projects/micronaut-guides/pull/1070 I had the regular expression wrong for @features@ and @features-words@ expressions.

This fixes it so they are expanded correctly again

Closes #1073