### PR TITLE
feat(auth0): use Authentication object in the example and display informations

### DIFF
--- a/guides/micronaut-oauth2-auth0/java/src/main/java/example/micronaut/HomeController.java
+++ b/guides/micronaut-oauth2-auth0/java/src/main/java/example/micronaut/HomeController.java
@@ -15,7 +15,13 @@ public class HomeController {
     @Secured(SecurityRule.IS_ANONYMOUS) // <2>
     @View("home") // <3>
     @Get // <4>
-    public Map<String, Object> index() {
-        return new HashMap<>();
+    public HttpResponse<Map<String, Object>> index(@Nullable Authentication authentication) {
+
+        HashMap<String, Object> variables = new HashMap<>();
+        if (authentication != null) {
+            variables.putAll(authentication.getAttributes());
+        }
+
+        return HttpResponse.ok(variables);
     }
 }

--- a/guides/micronaut-oauth2-auth0/java/src/main/java/example/micronaut/HomeController.java
+++ b/guides/micronaut-oauth2-auth0/java/src/main/java/example/micronaut/HomeController.java
@@ -17,7 +17,7 @@ public class HomeController {
     @Get // <4>
     public HttpResponse<Map<String, Object>> index(@Nullable Authentication authentication) {
 
-        HashMap<String, Object> variables = new HashMap<>();
+        Map<String, Object> variables = new HashMap<>();
         if (authentication != null) {
             variables.putAll(authentication.getAttributes());
         }

--- a/guides/micronaut-oauth2-auth0/src/main/resources/views/home.html
+++ b/guides/micronaut-oauth2-auth0/src/main/resources/views/home.html
@@ -6,8 +6,9 @@
 <body>
 <h1>Micronaut - Auth0 example</h1>
 
-<h2 th:if="${security}">username: <span th:text="${security.attributes.get('email')}"></span></h2>
-<h2 th:unless="${security}">username: Anonymous</h2>
+<h2 th:if="${security && nickname}">nickname: <span th:text="(${nickname})"></span></h2>
+<img th:if="${picture}" style="border-radius: 50%;" height="75" alt="Profil picture" th:src="${picture}"/>
+<h2 th:unless="${security}">nickname: Anonymous</h2>
 
 <nav>
     <ul>
@@ -15,5 +16,34 @@
         <li th:if="${security}"><a href="/oauth/logout">Logout</a></li>
     </ul>
 </nav>
+
+<div class="container">
+    <div class="splash" th:if="${security}">
+        <h1 class="splash-head">Data about the principal retrieved from Auth0</h1>
+        <p class="splash-subhead">
+        <pre class="code" data-lang="JSON">
+<code>{
+    "aud": "<span th:text="${aud}"></span>",
+    "email": "<span th:text="${email}"></span>",
+    "email_verified": "<span th:text="${email_verified}"></span>",
+    "exp": "<span th:text="${exp}"></span>",
+    "family_name": "<span th:text="${family_name}"></span>",
+    "given_name": "<span th:text="${given_name}"></span>",
+    "iat": "<span th:text="${iat}"></span>",
+    "iss": "<span th:text="${iss}"></span>",
+    "locale": "<span th:text="${locale}"></span>",
+    "picture": "<span th:text="${picture}"></span>",
+    "name": "<span th:text="${name}"></span>",
+    "nickname": "<span th:text="${nickname}"></span>",
+    "nonce": "<span th:text="${nonce}"></span>",
+    "updated_at": "<span th:text="${updated_at}"></span>",
+    "sid": "<span th:text="${sid}"></span>",
+    "sub": "<span th:text="${sub}"></span>",
+}</code>
+                </pre>
+        </p>
+    </div>
+</div>
+
 </body>
 </html>

--- a/guides/micronaut-oauth2-auth0/src/main/resources/views/home.html
+++ b/guides/micronaut-oauth2-auth0/src/main/resources/views/home.html
@@ -7,7 +7,7 @@
 <h1>Micronaut - Auth0 example</h1>
 
 <h2 th:if="${security && nickname}">nickname: <span th:text="(${nickname})"></span></h2>
-<img th:if="${picture}" style="border-radius: 50%;" height="75" alt="Profil picture" th:src="${picture}"/>
+<img th:if="${picture}" style="border-radius: 50%;" height="75" alt="Profile picture" th:src="${picture}"/>
 <h2 th:unless="${security}">nickname: Anonymous</h2>
 
 <nav>


### PR DESCRIPTION
As I am working on a Micronaut / Auth0 sample for the Auth0 website.
I came across this great guide. 

The `<span th:text="${security.attributes.get('email')}">` didn't work for me and I also wanted to show people how to get authentication informations.

Just let me know what you think.