### PR TITLE
Fixes missing section in trace guide

### DIFF
--- a/guides/micronaut-cloud-trace-base/create-app.adoc
+++ b/guides/micronaut-cloud-trace-base/create-app.adoc
@@ -64,7 +64,12 @@ dependency:micronaut-tracing-opentelemetry-http[groupId=io.micronaut.tracing]
 source:WarehouseClient[]
 <1> Some external service without tracing
 
+=== Warehouse Controller
 
+The `WarehouseController` class represents external service that will be called by `WarehouseClient`.
 
-
-
+source:WarehouseController[]
+callout:executes-on[1]
+callout:controller[number=2,arg0=/warehouse]
+callout:get[number=3,arg0=getItemCount,arg1=/users/{id}]
+callout:get[number=4,arg0=order,arg1=/users/{id}]

--- a/guides/micronaut-cloud-trace-base/groovy/src/main/groovy/example/micronaut/WarehouseController.groovy
+++ b/guides/micronaut-cloud-trace-base/groovy/src/main/groovy/example/micronaut/WarehouseController.groovy
@@ -10,16 +10,16 @@ import io.micronaut.scheduling.annotation.ExecuteOn
 import java.util.Random
 
 
-@ExecuteOn(TaskExecutors.IO)
-@Controller("/warehouse")
+@ExecuteOn(TaskExecutors.IO) // <1>
+@Controller("/warehouse") // <2>
 class WarehouseController {
 
-    @Get("/count")
+    @Get("/count") // <3>
     HttpResponse getItemCount() {
         HttpResponse.ok(new Random().nextInt(10)+1)
     }
 
-    @Post("/order")
+    @Post("/order") // <4>
     HttpResponse order() {
         try {
             //To simulate an external process taking time

--- a/guides/micronaut-cloud-trace-base/java/src/main/java/example/micronaut/WarehouseController.java
+++ b/guides/micronaut-cloud-trace-base/java/src/main/java/example/micronaut/WarehouseController.java
@@ -9,16 +9,16 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 
 import java.util.Random;
 
-@ExecuteOn(TaskExecutors.IO)
-@Controller("/warehouse")
+@ExecuteOn(TaskExecutors.IO) // <1>
+@Controller("/warehouse") // <2>
 public class WarehouseController {
 
-    @Get("/count")
+    @Get("/count") // <3>
     public HttpResponse getItemCount() {
         return HttpResponse.ok(new Random().nextInt(11));
     }
 
-    @Post("/order")
+    @Post("/order") // <4>
     public HttpResponse order() {
         try {
             //To simulate an external process taking time

--- a/guides/micronaut-cloud-trace-base/kotlin/src/main/kotlin/example/micronaut/WarehouseController.kt
+++ b/guides/micronaut-cloud-trace-base/kotlin/src/main/kotlin/example/micronaut/WarehouseController.kt
@@ -8,15 +8,15 @@ import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
 import java.util.Random
 
-@ExecuteOn(TaskExecutors.IO)
-@Controller("/warehouse")
+@ExecuteOn(TaskExecutors.IO) // <1>
+@Controller("/warehouse") // <2>
 class WarehouseController {
 
-    @Get("/count")
+    @Get("/count") // <3>
     fun getItemCount() : HttpResponse<Int> = HttpResponse.ok(Random().nextInt(11))
 
 
-    @Post("/order")
+    @Post("/order") // <4>
     fun order() : HttpResponse<Any> {
         try {
             //To simulate an external process taking time


### PR DESCRIPTION
Adds missing Warehouse Controller section that describes the `WarehouseController` class.

Updated OCI guide:
[OpenTelemetry Tracing with Oracle Cloud and the Micronaut Framework.pdf](https://github.com/micronaut-projects/micronaut-guides/files/10168384/OpenTelemetry.Tracing.with.Oracle.Cloud.and.the.Micronaut.Framework.pdf)
