### PR TITLE
Fixes wrong callouts to WarehouseController endpoints

### DIFF
--- a/guides/micronaut-cloud-trace-base/create-app.adoc
+++ b/guides/micronaut-cloud-trace-base/create-app.adoc
@@ -71,5 +71,5 @@ The `WarehouseController` class represents external service that will be called 
 source:WarehouseController[]
 callout:executes-on[1]
 callout:controller[number=2,arg0=/warehouse]
-callout:get[number=3,arg0=getItemCount,arg1=/users/{id}]
-callout:get[number=4,arg0=order,arg1=/users/{id}]
+callout:get[number=3,arg0=getItemCount,arg1=/warehouse/count]
+callout:get[number=4,arg0=order,arg1=/warehouse/order]


### PR DESCRIPTION
Callouts in WarehouseController are targeting wrong endpoints
[OpenTelemetry Tracing with Oracle Cloud and the Micronaut Framework.pdf](https://github.com/micronaut-projects/micronaut-guides/files/10175297/OpenTelemetry.Tracing.with.Oracle.Cloud.and.the.Micronaut.Framework.pdf)
