### PR TITLE
Remove ambiguity for Kotlin

### DIFF
--- a/guides/micronaut-metrics/kotlin/src/main/kotlin/example/micronaut/crypto/CryptoService.kt
+++ b/guides/micronaut-metrics/kotlin/src/main/kotlin/example/micronaut/crypto/CryptoService.kt
@@ -28,7 +28,7 @@ class CryptoService constructor(
     @Scheduled(fixedRate = "\${crypto.updateFrequency:1h}",
             initialDelay = "\${crypto.initialDelay:0s}") // <6>
     fun updatePrice() {
-        time.record { // <7>
+        time.recordCallable { // <7>
             try {
                 checks.increment() // <8>
                 latestPriceUsd.set(priceClient.latestInUSD().price.toInt()) // <9>


### PR DESCRIPTION
It couldn't work out which mathod to call as the closure had an implicit return value.

I'm not sure why this has only recently appeared...  Maybe a change to micrometer