### PR TITLE
Fix inputs for guides with a base

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuidesPlugin.groovy
@@ -368,6 +368,9 @@ class GuidesPlugin implements Plugin<Project> {
             it.guidesGenerator = projectGenerator
             it.slug.set(metadata.slug)
             it.inputDirectory.set(guidesDir.dir(metadata.slug))
+            if (metadata.base != null) {
+                it.baseInputDirectory.set(guidesDir.dir(metadata.base))
+            }
             it.outputDir.set(codeDir.map(s -> s.dir(metadata.slug)))
             it.guidesGenerator = projectGenerator
             it.metadata = metadata

--- a/buildSrc/src/main/groovy/io/micronaut/guides/tasks/SampleProjectGenerationTask.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/tasks/SampleProjectGenerationTask.groovy
@@ -10,6 +10,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -31,6 +32,11 @@ abstract class SampleProjectGenerationTask extends DefaultTask {
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
     abstract DirectoryProperty getInputDirectory()
+
+    @Optional
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract DirectoryProperty getBaseInputDirectory()
 
     @OutputDirectory
     abstract DirectoryProperty getOutputDir()


### PR DESCRIPTION
If we have a guide that declares a base project, ie:

https://github.com/micronaut-projects/micronaut-guides/blob/dd911994e0c54c068602389dbcbe08eac8bdf045/guides/micronaut-metrics-aws/metadata.json#L2

Then we were not taking the code from micronaut-metrics into account for the cache-key, so changes were not picked up when building micronaut-metrics-aws

This change adds the base directory as an input if it was set