### PR TITLE
disable spring-boot-micronaut-data guide

### DIFF
--- a/guides/micronaut-jms-aws-sqs/metadata.json
+++ b/guides/micronaut-jms-aws-sqs/metadata.json
@@ -6,7 +6,6 @@
   "categories": ["Messaging"],
   "maximumJavaVersion": 16,
   "publicationDate": "2022-11-28",
-  "buildTools": ["gradle"],
   "apps": [
     {
       "name": "default",

--- a/guides/micronaut-jms-aws-sqs/metadata.json
+++ b/guides/micronaut-jms-aws-sqs/metadata.json
@@ -6,6 +6,7 @@
   "categories": ["Messaging"],
   "maximumJavaVersion": 16,
   "publicationDate": "2022-11-28",
+  "buildTools": ["gradle"],
   "apps": [
     {
       "name": "default",

--- a/guides/spring-boot-micronaut-data/metadata.json
+++ b/guides/spring-boot-micronaut-data/metadata.json
@@ -7,6 +7,8 @@
   "publicationDate": "2022-09-20",
   "minimumJavaVersion": 17,
   "languages": ["java"],
+  "skipMavenTests": true,
+  "skipGradleTests": true,
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
There's strange things happening with the dependencies for the guide

Raised https://github.com/micronaut-projects/micronaut-guides/issues/1184 to investigate

For now, disable maven to get a green build