### PR TITLE
fix java version typo

### DIFF
--- a/src/docs/common/snippets/common-install-graalvm-sdkman.adoc
+++ b/src/docs/common/snippets/common-install-graalvm-sdkman.adoc
@@ -15,7 +15,7 @@ NOTE: If you still use Java 8, use the JDK11 version of GraalVM.
 [source, bash]
 .Java 17
 ----
-sdk install java 2.3.r17-grl
+sdk install java 22.3.r17-grl
 ----
 
 For installation on Windows, or for manual installation on Linux or Mac, see the https://www.graalvm.org/22.0/docs/getting-started/[GraalVM Getting Started] documentation.


### PR DESCRIPTION
Hi, I was going through one of the guides and think there's a typo in the SDKMAN installation command? `sdk install java 2.3.r17-grl` → `sdk install java 22.3.r17-grl`