### PR TITLE
Fix curl command

### DIFF
--- a/guides/micronaut-email-sendgrid/micronaut-email-sendgrid.adoc
+++ b/guides/micronaut-email-sendgrid/micronaut-email-sendgrid.adoc
@@ -48,8 +48,8 @@ common:runapp-instructions.adoc[]
 
 [source, bash]
 ----
-curl -d '{"to":"john@micronaut.example"}'
-     -H "Content-Type: application/json"
+curl -d '{"to":"john@micronaut.example"}' \
+     -H "Content-Type: application/json" \
      -X POST http://localhost:8080/mail/send
 ----
 


### PR DESCRIPTION
When copying the curl command, each new line is executed rather than waiting for the last command.