### PR TITLE
Security Session Guide: Removed the extra dependency that could cause tests to fail

### DIFF
--- a/src/docs/common/snippets/common-geb.adoc
+++ b/src/docs/common/snippets/common-geb.adoc
@@ -6,7 +6,6 @@ To use Geb, add these dependencies:
 
 dependency:geb-spock[groupId=org.gebish,scope=testImplementation,version=@geb-spockVersion@]
 dependency:htmlunit-driver[groupId=org.seleniumhq.selenium,scope=testImplementation,version=@htmlunit-driverVersion@]
-dependency:selenium-chrome-driver[groupId=org.seleniumhq.selenium,scope=testRuntimeOnly,version=@selenium-chrome-driverVersion@]
 
 :dependencies:
 


### PR DESCRIPTION
Adding selenium-chrome-driver to build.gradle would result in a NoClassDefFoundError. selenium-chrome-driver is not present in the current zip anyway.