### PR TITLE
[JDBC AWS, Azure, GCP] Fixed the env names to be compatible with the sample JDBC application + added explanations similar to the original JDBC guide.

### DIFF
--- a/guides/micronaut-cloud-database-aws/micronaut-cloud-database-aws.adoc
+++ b/guides/micronaut-cloud-database-aws/micronaut-cloud-database-aws.adoc
@@ -118,13 +118,13 @@ external:micronaut-cloud-database-base/create-app.adoc[]
 
 With almost everything in place, you can start the application and try it out. First, set environment variables to configure the application datasource. Then you can start the app.
 
-Create environment variables for `JDBC_URL`, `JDBC_USER`, and `JDBC_PASSWORD`, which will be used in the Micronaut app's `application.yml` datasource:
+Create environment variables for `DATASOURCES_DEFAULT_URL`, `DATASOURCES_DEFAULT_USERNAME`, and `DATASOURCES_DEFAULT_PASSWORD`, which will be used in the Micronaut app's `application.yml` datasource:
 
 [source,bash]
 ----
-export JDBC_URL=jdbc:mysql://${MYSQL_HOST}:3306/micronaut
-export JDBC_USER=guide_user
-export JDBC_PASSWORD=M1cr0n4ut!
+export DATASOURCES_DEFAULT_URL=jdbc:mysql://${MYSQL_HOST}:3306/micronaut
+export DATASOURCES_DEFAULT_USERNAME=guide_user
+export DATASOURCES_DEFAULT_PASSWORD=M1cr0n4ut!
 ----
 
 [NOTE]
@@ -132,12 +132,14 @@ export JDBC_PASSWORD=M1cr0n4ut!
 ====
 Command Prompt:: Change '*export*' to '*set*'
 +
-Example: `set JDBC_USER=guide_user`
+Example: `set DATASOURCES_DEFAULT_USERNAME=guide_user`
 
 PowerShell:: Change '*export* ' to '*$*' and use quotes around the value
 +
-Example: `$JDBC_USER="guide_user"`
+Example: `$DATASOURCES_DEFAULT_USERNAME="guide_user"`
 ====
+
+Micronaut Framework populates the properties `datasources.default.url`, `datasources.default.username` and `datasources.default.password` with those environment variables' values. Learn more about https://micronaut-projects.github.io/micronaut-sql/latest/guide/#jdbc-connection-pools[JDBC Connection Pools].
 
 common:runapp-instructions.adoc[]
 

--- a/guides/micronaut-cloud-database-azure/micronaut-cloud-database-azure.adoc
+++ b/guides/micronaut-cloud-database-azure/micronaut-cloud-database-azure.adoc
@@ -127,14 +127,28 @@ external:micronaut-cloud-database-base/create-app.adoc[]
 
 With almost everything in place, you can start the application and try it out. First, set environment variables to configure the application datasource, then start the app.
 
-Create environment variables for `JDBC_URL`, `JDBC_USER`, and `JDBC_PASSWORD`, which will be used in the Micronaut app's `application.yml` datasource:
+Create environment variables for `DATASOURCES_DEFAULT_URL`, `DATASOURCES_DEFAULT_USERNAME`, and `DATASOURCES_DEFAULT_PASSWORD`, which will be used in the Micronaut app's `application.yml` datasource:
 
 [source,bash]
 ----
-export JDBC_URL=jdbc:mysql://$AZURE_DATABASE_NAME.mysql.database.azure.com:3306/demo?serverTimezone=UTC
-export JDBC_USER=guide_user
-export JDBC_PASSWORD=$AZURE_DATABASE_PASSWORD
+export DATASOURCES_DEFAULT_URL=jdbc:mysql://$AZURE_DATABASE_NAME.mysql.database.azure.com:3306/demo?serverTimezone=UTC
+export DATASOURCES_DEFAULT_USERNAME=guide_user
+export DATASOURCES_DEFAULT_PASSWORD=$AZURE_DATABASE_PASSWORD
 ----
+
+[NOTE]
+.Window System
+====
+Command Prompt:: Change '*export*' to '*set*'
++
+Example: `set DATASOURCES_DEFAULT_USERNAME=guide_user`
+
+PowerShell:: Change '*export* ' to '*$*' and use quotes around the value
++
+Example: `$DATASOURCES_DEFAULT_USERNAME="guide_user"`
+====
+
+Micronaut Framework populates the properties `datasources.default.url`, `datasources.default.username` and `datasources.default.password` with those environment variables' values. Learn more about https://micronaut-projects.github.io/micronaut-sql/latest/guide/#jdbc-connection-pools[JDBC Connection Pools].
 
 common:runapp-instructions.adoc[]
 

--- a/guides/micronaut-cloud-database-google/micronaut-cloud-database-google.adoc
+++ b/guides/micronaut-cloud-database-google/micronaut-cloud-database-google.adoc
@@ -85,29 +85,31 @@ external:micronaut-cloud-database-base/create-app.adoc[]
 
 With almost everything in place, we can start the application and try it out. First, we need to set environment variables to configure the application datasource. Then we can start the app.
 
-Create environment variables for `JDBC_URL`, `JDBC_USER`, and `JDBC_PASSWORD`, which will be used in the Micronaut app's `application.yml` datasource:
+Create environment variables for `DATASOURCES_DEFAULT_URL`, `DATASOURCES_DEFAULT_USERNAME`, and `DATASOURCES_DEFAULT_PASSWORD`, which will be used in the Micronaut app's `application.yml` datasource:
 
 [source,bash]
 ----
-export JDBC_URL=jdbc:mysql://<DB_INSTANCE_IP>:3306/demo
-export JDBC_USER=<USER_NAME>
-export JDBC_PASSWORD=<USER_PASSWORD>
+export DATASOURCES_DEFAULT_URL=jdbc:mysql://<DB_INSTANCE_IP>:3306/demo
+export DATASOURCES_DEFAULT_USERNAME=<USER_NAME>
+export DATASOURCES_DEFAULT_PASSWORD=<USER_PASSWORD>
 ----
 * `DB_INSTANCE_IP` - Is your MySQL instance's primary address
 * `demo` - Change if you used a different database name
-* `JDBC_USER` - Not needed if you are using the _root_ user
+* `DATASOURCES_DEFAULT_USERNAME` - Not needed if you are using the _root_ user
 
 [NOTE]
 .Window System
 ====
 Command Prompt:: Change '*export*' to '*set*'
 +
-Example: `set JDBC_USER=<USER_NAME>`
+Example: `set DATASOURCES_DEFAULT_USERNAME=<USER_NAME>`
 
 PowerShell:: Change '*export* ' to '*$*' and use quotes around the value
 +
-Example: `$JDBC_USER="<USER_NAME>"`
+Example: `$DATASOURCES_DEFAULT_USERNAME="<USER_NAME>"`
 ====
+
+Micronaut Framework populates the properties `datasources.default.url`, `datasources.default.username` and `datasources.default.password` with those environment variables' values. Learn more about https://micronaut-projects.github.io/micronaut-sql/latest/guide/#jdbc-connection-pools[JDBC Connection Pools].
 
 common:runapp-instructions.adoc[]
 


### PR DESCRIPTION
[JDBC AWS.pdf](https://github.com/micronaut-projects/micronaut-guides/files/11385263/JDBC.AWS.pdf)
[JDBC Azure.pdf](https://github.com/micronaut-projects/micronaut-guides/files/11385264/JDBC.Azure.pdf)
[JDBC GCP.pdf](https://github.com/micronaut-projects/micronaut-guides/files/11385265/JDBC.GCP.pdf)
