### PR TITLE
Add an await when counting entities for data-hibernate-reactive

### DIFF
--- a/guides/micronaut-data-hibernate-reactive/metadata.json
+++ b/guides/micronaut-data-hibernate-reactive/metadata.json
@@ -9,7 +9,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "mysql", "graalvm", "data-hibernate-reactive", "reactor", "serialization-jackson"]
+      "features": ["yaml", "mysql", "graalvm", "data-hibernate-reactive", "reactor", "serialization-jackson", "awaitility"]
     }
   ]
 }


### PR DESCRIPTION
The data-hibernate-reactive guide is flakey and holds up the entire pipeline.

Running under the assumption that under load (and with Github Agent minimal resources), sometimes it takes time for the database to be atomically updated, so the count of genres is not correct for an amount of time.

This PR adds awaitility and waits up to 10 seconds for the count to be correct (I believe this was the failing assertion when we looked into this before)