### PR TITLE
Minor cleanup: remove unused import in MessageControllerTest

### DIFF
--- a/guides/micronaut-dependency-injection-types/kotlin/src/test/kotlin/example/micronaut/MessageControllerTest.kt
+++ b/guides/micronaut-dependency-injection-types/kotlin/src/test/kotlin/example/micronaut/MessageControllerTest.kt
@@ -5,7 +5,6 @@ import io.micronaut.http.MediaType
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
-import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource


### PR DESCRIPTION
import jakarta.inject.Inject is not used in Kotlin version of the test