### PR TITLE
Small improvements in Http Client Guide

### DIFF
--- a/guides/micronaut-http-client/groovy/src/test/groovy/example/micronaut/GithubControllerSpec.groovy
+++ b/guides/micronaut-http-client/groovy/src/test/groovy/example/micronaut/GithubControllerSpec.groovy
@@ -18,7 +18,7 @@ import spock.lang.Specification
 
 class GithubControllerSpec extends Specification {
     private static Pattern MICRONAUT_RELEASE =
-            Pattern.compile("[Micronaut|Micronaut Framework] [0-9].[0-9].[0-9]([0-9])?( (RC|M)[0-9])?")
+            Pattern.compile("Micronaut (Core |Framework )?v?\\d+.\\d+.\\d+( (RC|M)\\d)?")
 
     void "verify GithubReleases can Be fetched With Low Level Http Client"(String path) {
         given:

--- a/guides/micronaut-http-client/groovy/src/test/groovy/example/micronaut/GithubControllerSpec.groovy
+++ b/guides/micronaut-http-client/groovy/src/test/groovy/example/micronaut/GithubControllerSpec.groovy
@@ -41,14 +41,14 @@ class GithubControllerSpec extends Specification {
                 .createBean(HttpClient, embeddedServer.getURL())
         BlockingHttpClient client = httpClient.toBlocking()
         HttpRequest<?> request = HttpRequest.GET(path)
-        HttpResponse<List<GithubRelease>> rsp = client.exchange(request, // <3>
-                Argument.listOf(GithubRelease)) // <4>
+        HttpResponse<List<GithubRelease>> rsp = client.exchange(request, // <4>
+                Argument.listOf(GithubRelease)) // <5>
 
         then:
-        HttpStatus.OK == rsp.getStatus()   // <5>
+        HttpStatus.OK == rsp.getStatus()   // <6>
 
         when:
-        List<GithubRelease> releases = rsp.body() // <6>
+        List<GithubRelease> releases = rsp.body() // <7>
 
         then:
         releases
@@ -77,7 +77,7 @@ class GithubControllerSpec extends Specification {
         @Produces("application/vnd.github.v3+json")
         @Get("/repos/micronaut-projects/micronaut-core/releases")
         Optional<String> coreReleases() {
-            resourceLoader.getResourceAsStream("releases.json")
+            resourceLoader.getResourceAsStream("releases.json") // <3>
                     .map(inputStream -> inputStream.text)
         }
     }

--- a/guides/micronaut-http-client/java/src/test/java/example/micronaut/GithubControllerTest.java
+++ b/guides/micronaut-http-client/java/src/test/java/example/micronaut/GithubControllerTest.java
@@ -52,11 +52,11 @@ class GithubControllerTest {
     private static void assertReleases(BlockingHttpClient client, String path) {
         HttpRequest<Object> request = HttpRequest.GET(path);
 
-        HttpResponse<List<GithubRelease>> rsp = client.exchange(request, // <3>
-                Argument.listOf(GithubRelease.class)); // <4>
+        HttpResponse<List<GithubRelease>> rsp = client.exchange(request, // <4>
+                Argument.listOf(GithubRelease.class)); // <5>
 
-        assertEquals(HttpStatus.OK, rsp.getStatus());   // <5>
-        assertReleases(rsp.body()); // <6>
+        assertEquals(HttpStatus.OK, rsp.getStatus());   // <6>
+        assertReleases(rsp.body()); // <7>
     }
 
     private static void assertReleases(List<GithubRelease> releases) {
@@ -78,7 +78,7 @@ class GithubControllerTest {
         @Produces("application/vnd.github.v3+json")
         @Get("/repos/micronaut-projects/micronaut-core/releases")
         Optional<String> coreReleases() {
-            return resourceLoader.getResourceAsStream("releases.json")
+            return resourceLoader.getResourceAsStream("releases.json") // <3>
                     .flatMap(inputStream -> {
                         try {
                             return Optional.of(new String(inputStream.readAllBytes(), UTF_8));

--- a/guides/micronaut-http-client/java/src/test/java/example/micronaut/GithubControllerTest.java
+++ b/guides/micronaut-http-client/java/src/test/java/example/micronaut/GithubControllerTest.java
@@ -29,7 +29,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 class GithubControllerTest {
     private static Pattern MICRONAUT_RELEASE =
-            Pattern.compile("[Micronaut|Micronaut Framework] [0-9].[0-9].[0-9]([0-9])?( (RC|M)[0-9])?");
+            Pattern.compile("Micronaut (Core |Framework )?v?\\d+.\\d+.\\d+( (RC|M)\\d)?");
 
     @Test
     void verifyGithubReleasesCanBeFetchedWithLowLevelHttpClient() {

--- a/guides/micronaut-http-client/kotlin/src/test/kotlin/example/micronaut/GithubControllerTest.kt
+++ b/guides/micronaut-http-client/kotlin/src/test/kotlin/example/micronaut/GithubControllerTest.kt
@@ -24,7 +24,7 @@ import java.util.regex.Pattern
 
 class GithubControllerTest {
     val MICRONAUT_RELEASE =
-            Pattern.compile("[Micronaut|Micronaut Framework] [0-9].[0-9].[0-9]([0-9])?( (RC|M)[0-9])?")
+            Pattern.compile("Micronaut (Core |Framework )?v?\\d+.\\d+.\\d+( (RC|M)\\d)?")
 
     @Test
     fun verifyGithubReleasesCanBeFetchedWithLowLevelHttpClient() {

--- a/guides/micronaut-http-client/kotlin/src/test/kotlin/example/micronaut/GithubControllerTest.kt
+++ b/guides/micronaut-http-client/kotlin/src/test/kotlin/example/micronaut/GithubControllerTest.kt
@@ -42,12 +42,12 @@ class GithubControllerTest {
 
     fun assertReleases(client: BlockingHttpClient, path: String) {
         val request : HttpRequest<Any> = HttpRequest.GET(path)
-        val rsp = client.exchange(request, // <3>
-            Argument.listOf(GithubRelease::class.java)) // <4>
-        assertEquals(HttpStatus.OK, rsp.status)   // <5>
+        val rsp = client.exchange(request, // <4>
+            Argument.listOf(GithubRelease::class.java)) // <5>
+        assertEquals(HttpStatus.OK, rsp.status)   // <6>
         val releases = rsp.body()
         assertNotNull(releases)
-        assertReleases(releases.toList()) // <6>
+        assertReleases(releases.toList()) // <7>
     }
 
     fun assertReleases(releases: List<GithubRelease>) {
@@ -63,7 +63,7 @@ class GithubControllerTest {
         @Produces("application/vnd.github.v3+json")
         @Get("/repos/micronaut-projects/micronaut-core/releases")
         fun coreReleases() : String {
-            return resourceLoader.getResource("releases.json").orElseThrow().readText()
+            return resourceLoader.getResource("releases.json").orElseThrow().readText() // <3>
         }
     }
 

--- a/guides/micronaut-http-client/kotlin/src/test/kotlin/example/micronaut/GithubControllerTest.kt
+++ b/guides/micronaut-http-client/kotlin/src/test/kotlin/example/micronaut/GithubControllerTest.kt
@@ -11,15 +11,11 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Produces
 import io.micronaut.http.client.BlockingHttpClient
 import io.micronaut.http.client.HttpClient
-import io.micronaut.http.client.StreamingHttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
-import java.io.BufferedReader
-import java.io.InputStream
-import java.util.*
 import java.util.regex.Pattern
 
 class GithubControllerTest {
@@ -66,19 +62,8 @@ class GithubControllerTest {
     class GithubReleases(val resourceLoader : ResourceLoader) {
         @Produces("application/vnd.github.v3+json")
         @Get("/repos/micronaut-projects/micronaut-core/releases")
-        fun coreReleases() : Optional<String> {
-            return resourceLoader.getResourceAsStream("releases.json").map(this::inputStreamToString)
-        }
-
-        fun inputStreamToString(inputStream: InputStream) : String {
-            val reader = BufferedReader(inputStream.reader())
-            var content: String
-            try {
-                content = reader.readText()
-            } finally {
-                reader.close()
-            }
-            return content
+        fun coreReleases() : String {
+            return resourceLoader.getResource("releases.json").orElseThrow().readText()
         }
     }
 

--- a/guides/micronaut-http-client/micronaut-http-client.adoc
+++ b/guides/micronaut-http-client/micronaut-http-client.adoc
@@ -110,10 +110,11 @@ test:GithubControllerTest[]
 
 callout:spec-name[1]
 callout:mock-http-server[number=2,arg0=GitHub]
-<3> Sometimes, receiving just the object is not enough, and you need information about the response. In this case, instead of `retrieve` you should use the `exchange` method.
-callout:binding-json-array[4]
-<5> Use `status` to check the HTTP status code.
-callout:body-method[6]
+<3> Create a sample `releases.json` file in `src/test/resources` directory. To get some test data call github api with curl or provide a few entries yourself.
+<4> Sometimes, receiving just the object is not enough, and you need information about the response. In this case, instead of `retrieve` you should use the `exchange` method.
+callout:binding-json-array[5]
+<6> Use `status` to check the HTTP status code.
+callout:body-method[7]
 
 
 common:testApp.adoc[]


### PR DESCRIPTION
A couple small improvements in Http Client Guide

- Fix regular expression in GithubControllerTest. It works against the existing releases.json in the repo, however it fails against the latest releases from Github.
- Simplify reading `releases.json` in Kotlin version of the test, so that it's done with less code. Also throwing instead of returning Optional. In case of missing releases.json the test would fail either way, but with `orElseThrow` it highlights the line with releases.json, easier to troubleshoot.
- Mention in the guide the user needs to create releases.json themselves. Now it might not be clear right away