### PR TITLE
fix cli command for guides with junit-params

### DIFF
--- a/src/docs/common/snippets/common-build-lang-arguments.adoc
+++ b/src/docs/common/snippets/common-build-lang-arguments.adoc
@@ -1,1 +1,1 @@
-NOTE: If you don't specify the `--build` argument, Gradle is used as the build tool. +++<br/>+++ If you don't specify the `--lang` argument, Java is used as the language.
+NOTE: If you don't specify the `--build` argument, Gradle is used as the build tool. +++<br/>+++ If you don't specify the `--lang` argument, Java is used as the language.+++<br/>+++ If you don't specify the `--test` argument, JUnit is used for Java and Kotlin, and Spock is used for Groovy.

--- a/src/docs/common/snippets/common-create-app-features.adoc
+++ b/src/docs/common/snippets/common-create-app-features.adoc
@@ -7,7 +7,8 @@ common:cli-or-launch.adoc[]
 mn @cli-command@ example.micronaut.micronautguide \
     --features=@features@ \
     --build=@build@ \
-    --lang=@lang@
+    --lang=@lang@ \
+    --test=@testFramework@
 ----
 
 common:build-lang-arguments.adoc[]


### PR DESCRIPTION
Trying to execute this guide and getting an error
https://guides.micronaut.io/latest/micronaut-custom-validation-annotation-gradle-java.html

```
| Error junit-params requires JUnit.
```

Looks like specifying test framework is mandatory when adding junit-params as feature. It makes the cli command for generating the project invalid in a couple of places.

This PR adds a template for cli when the test framework needs to be specified explicitly.

How it looks like after the change:
<img width="960" alt="image" src="https://github.com/micronaut-projects/micronaut-guides/assets/138369917/03bd67b0-64c0-4859-82ad-5d40bdffff91">
