### PR TITLE
GraalVM Polyglot JS

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/GraalvmPolyglot.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/GraalvmPolyglot.java
@@ -1,0 +1,10 @@
+package io.micronaut.guides.feature;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class GraalvmPolyglot extends AbstractFeature {
+    protected GraalvmPolyglot() {
+        super("graalvm-polyglot", "polyglot");
+    }
+}

--- a/buildSrc/src/main/java/io/micronaut/guides/feature/GraalvmPolyglotJs.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/GraalvmPolyglotJs.java
@@ -1,0 +1,10 @@
+package io.micronaut.guides.feature;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class GraalvmPolyglotJs extends AbstractFeature {
+    protected GraalvmPolyglotJs() {
+        super("graalvm-polyglot-js", "js");
+    }
+}

--- a/buildSrc/src/main/resources/pom.xml
+++ b/buildSrc/src/main/resources/pom.xml
@@ -13,6 +13,16 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>org.graalvm.polyglot</groupId>
+            <artifactId>polyglot</artifactId>
+            <version>23.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.polyglot</groupId>
+            <artifactId>js</artifactId>
+            <version>23.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
             <version>5.15.0</version>

--- a/guides/micronaut-graalvm-polyglot-js/java/src/main/java/example/micronaut/HomeController.java
+++ b/guides/micronaut-graalvm-polyglot-js/java/src/main/java/example/micronaut/HomeController.java
@@ -1,0 +1,25 @@
+package com.example;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+
+@Controller
+public class HomeController {
+
+    @Produces(MediaType.TEXT_PLAIN)
+    @Get
+    HttpResponse<String> index() {
+        try (Context context = Context.create()) {
+            Value f = context.eval("js", "x => x + 1");
+            if (f.canExecute()) {
+                return HttpResponse.ok("" + f.execute(41).asInt());
+            }
+        }
+        return HttpResponse.serverError();
+    }
+}

--- a/guides/micronaut-graalvm-polyglot-js/java/src/test/java/example/micronaut/HomeControllerTest.java
+++ b/guides/micronaut-graalvm-polyglot-js/java/src/test/java/example/micronaut/HomeControllerTest.java
@@ -1,0 +1,22 @@
+package com.example;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+class HomeControllerTest {
+
+    @Test
+    void jsembedding(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpRequest<?> request = HttpRequest.GET("/").accept(MediaType.TEXT_PLAIN_TYPE);
+        assertEquals("42", client.retrieve(request));
+    }
+}

--- a/guides/micronaut-graalvm-polyglot-js/metadata.json
+++ b/guides/micronaut-graalvm-polyglot-js/metadata.json
@@ -1,0 +1,15 @@
+{
+  "title": "GraalVM Polyglot JS",
+  "intro": "GraalVM Polyglot JS.",
+  "authors": ["Sergio del Amo"],
+  "categories": ["GraalVM"],
+  "publicationDate": "2023-09-22",
+  "languages": ["java"],
+  "buildTools": ["gradle"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["graalvm-polyglot", "graalvm-polyglot-js"]
+    }
+  ]
+}


### PR DESCRIPTION
To generate guide locally:

`./gradlew micronautGraalvmPolyglotJsBuild`
Open HTML locally:

`open build/dist/index.html`

Code available:

`build/code/micronaut-graalvm-polyglot-js`

Related to: 

- [Truffle unchained Blog post](https://medium.com/graalvm/truffle-unchained-13887b77b62c)
• [Example Repository](https://github.com/graalvm/polyglot-embedding-demo)
• [Embedding Guide](https://www.graalvm.org/latest/reference-manual/embed-languages/)
• [23.1 Release Announcement](https://medium.com/graalvm/new-truffle-and-graalvm-languages-release-1e5c8cdaaff)
• [Module Migration for Language Implementations](https://github.com/oracle/graal/blob/master/truffle/docs/ModuleMigration.md)