### PR TITLE
Fix the exit code check in native test scripts

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -194,7 +194,7 @@ echo "Executing '$folder' $testcopy"
 """
 if (nativeTest) {
 bashScript += """\
-${buildTool == MAVEN ? './mvnw -Pnative test' : './gradlew nativeTest'} || EXIT_STATUS=\\\$?
+${buildTool == MAVEN ? './mvnw -Pnative test' : './gradlew nativeTest'} || EXIT_STATUS=\$?
 """
 } else {
 bashScript += """\


### PR DESCRIPTION
We had it double escaped, which meant we ended up with `EXIT_STATUS=\$?`

This doesn't work in bash, it needs to be `EXIT_STATUS=$?`