### PR TITLE
Title rename of streaming http client StreamedFile guide

### DIFF
--- a/guides/micronaut-streamed-file-and-reactor-streaming-http-client/metadata.json
+++ b/guides/micronaut-streamed-file-and-reactor-streaming-http-client/metadata.json
@@ -1,5 +1,5 @@
 {
-  "title": "Download a big file with StreamingHttpClient",
+  "title": "How to use blocking I/O to stream a file from a URL",
   "intro": "Learn how to stream responses with ReactorStreamingHttpClient, and how to use it in combination with StreamedFile.",
   "authors": ["Sergio del Amo"],
   "tags": [],


### PR DESCRIPTION
Change title until [the PR which removes the usage of StreamedFile](https://github.com/micronaut-projects/micronaut-guides/pull/1400) can be merged. 