### PR TITLE
CC 4.0 License for writing and Apache 2.0 for code

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,396 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Micronaut Guides
 
-This is the main repository for the [Micronaut Guides](https://guides.micronaut.io). There is also an alternative [guides index](https://guides.micronaut.io/latest/)
+This is the main repository for the [Micronaut Guides](https://guides.micronaut.io). 
 
 ## Build the guides
 

--- a/assets/template.html
+++ b/assets/template.html
@@ -150,7 +150,7 @@
                 <div id="text-5" class="widget widget_text">
                     <div class="textwidget">
                         <p>
-                            <small>© 2023 MICRONAUT FOUNDATION. ALL RIGHTS RESERVED</small>
+                            <small>Guides are licensed under <a href="https://creativecommons.org/licenses/by/4.0/deed.en">CC BY 4.0</a> for the writing and media and <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache.2.0</a> for the code</small>
                         </p>
                     </div>
                 </div>

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideMetadata.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideMetadata.groovy
@@ -90,7 +90,7 @@ class GuideMetadata {
         List<String> getInvisibleFeatures() {
             List<String> result = new ArrayList<>()
             if (invisibleFeatures) {
-                result.addAll(result)
+                result.addAll(invisibleFeatures)
             }
             result.add(FEATURE_SPOTLESS)
             result

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideMetadata.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideMetadata.groovy
@@ -61,6 +61,7 @@ class GuideMetadata {
     @ToString(includeNames = true)
     @CompileStatic
     static class App {
+        boolean validateLicense = true
         private static final String FEATURE_SPOTLESS = "spotless"
         String framework
         TestFramework testFramework
@@ -88,12 +89,15 @@ class GuideMetadata {
         }
 
         List<String> getInvisibleFeatures() {
-            List<String> result = new ArrayList<>()
-            if (invisibleFeatures) {
-                result.addAll(invisibleFeatures)
+            if (validateLicense) {
+                List<String> result = new ArrayList<>()
+                if (invisibleFeatures) {
+                    result.addAll(invisibleFeatures)
+                }
+                result.add(FEATURE_SPOTLESS)
+                return result
             }
-            result.add(FEATURE_SPOTLESS)
-            result
+            return invisibleFeatures
         }
 
         List<String> getVisibleFeatures(Language language) {

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideMetadata.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideMetadata.groovy
@@ -45,7 +45,7 @@ class GuideMetadata {
             tagsList.addAll(this.tags)
         }
         for (App app : this.apps) {
-            for (String featureName : app.javaFeatures + app.kotlinFeatures + app.groovyFeatures + app.visibleFeatures + app.invisibleFeatures) {
+            for (String featureName : app.javaFeatures + app.kotlinFeatures + app.groovyFeatures + app.visibleFeatures) {
                 if (featureName.startsWith(MICRONAUT_PREFIX)) {
                     tagsList.add(featureName.substring(MICRONAUT_PREFIX.length()))
                 } else {
@@ -61,6 +61,7 @@ class GuideMetadata {
     @ToString(includeNames = true)
     @CompileStatic
     static class App {
+        private static final String FEATURE_SPOTLESS = "spotless"
         String framework
         TestFramework testFramework
         ApplicationType applicationType
@@ -75,15 +76,24 @@ class GuideMetadata {
 
         List<String> getFeatures(Language language) {
             if (language == Language.JAVA) {
-                return visibleFeatures + invisibleFeatures + javaFeatures
+                return visibleFeatures + getInvisibleFeatures() + javaFeatures
             }
             if (language == Language.KOTLIN) {
-                return visibleFeatures + invisibleFeatures + kotlinFeatures
+                return visibleFeatures + getInvisibleFeatures() + kotlinFeatures
             }
             if (language == Language.GROOVY) {
-                return visibleFeatures + invisibleFeatures + groovyFeatures
+                return visibleFeatures + getInvisibleFeatures() + groovyFeatures
             }
-            visibleFeatures + invisibleFeatures
+            visibleFeatures + getInvisibleFeatures()
+        }
+
+        List<String> getInvisibleFeatures() {
+            List<String> result = new ArrayList<>()
+            if (invisibleFeatures) {
+                result.addAll(result)
+            }
+            result.add(FEATURE_SPOTLESS)
+            result
         }
 
         List<String> getVisibleFeatures(Language language) {

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -275,7 +275,7 @@ class GuideProjectGenerator implements AutoCloseable {
     private static String licenseHeaderText() {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         URL resource = classLoader.getResource(LICENSEHEADER)
-        resource.text
+        resource.text.replace('$YEAR', "${LocalDate.now().year}")
     }
 
     private static void copyGuideSourceFiles(File inputDir, Path destinationPath,

--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -116,6 +116,7 @@ class GuideProjectGenerator implements AutoCloseable {
                 zipIncludes: config.zipIncludes ?: [],
                 apps: config.apps.collect { it ->
                     new App(
+                            validateLicense: it.validateLicense == null ? true : it.validateLicense,
                             framework: it.framework,
                             testFramework: it.testFramework?.toUpperCase(),
                             name: it.name,
@@ -424,6 +425,7 @@ class GuideProjectGenerator implements AutoCloseable {
         for (String name : inBoth) {
             App baseApp = baseApps[name]
             App guideApp = guideApps[name]
+            guideApp.validateLicense = baseApp.validateLicense
             guideApp.visibleFeatures.addAll baseApp.visibleFeatures
             guideApp.invisibleFeatures.addAll baseApp.invisibleFeatures
             guideApp.javaFeatures.addAll baseApp.javaFeatures

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -213,7 +213,7 @@ ${buildTool == MAVEN ? './mvnw -Pnative test' : './gradlew nativeTest'} || EXIT_
 """
 } else {
 bashScript += """\
-${buildTool == MAVEN ? './mvnw -q test' : './gradlew -q test' } || EXIT_STATUS=\$?
+${buildTool == MAVEN ? './mvnw -q test spotless:check' : './gradlew -q check' } || EXIT_STATUS=\$?
 echo "Stopping shared test resources service (if created)"
 ${buildTool == MAVEN ? './mvnw -q mn:stop-testresources-service' : './gradlew -q stopTestResourcesService'} > /dev/null 2>&1 || true
 """

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -152,7 +152,7 @@ kill_kotlin_daemon () {
                     def defaultApp = metadata.apps.find { it.name == DEFAULT_APP_NAME }
                     if (!nativeTest || supportsNativeTest(defaultApp, guidesOption)) {
                         def features = defaultApp.getFeatures(guidesOption.language)
-                        bashScript << scriptForFolder(folder, folder, stopIfFailure, buildTool, features.contains("kapt") && Runtime.version().feature() > 17 && buildTool == GRADLE, nativeTest)
+                        bashScript << scriptForFolder(folder, folder, stopIfFailure, buildTool, features.contains("kapt") && Runtime.version().feature() > 17 && buildTool == GRADLE, nativeTest, defaultApp.validateLicense)
                     }
                 } else {
                     bashScript << """\
@@ -161,7 +161,7 @@ cd $folder
                     for (GuideMetadata.App app : metadata.apps) {
                         if (!nativeTest || supportsNativeTest(app, guidesOption)) {
                             def features = app.getFeatures(guidesOption.language)
-                            bashScript << scriptForFolder(app.name, folder + '/' + app.name, stopIfFailure, buildTool, features.contains("kapt") && Runtime.version().feature() > 17 && buildTool == GRADLE, nativeTest)
+                            bashScript << scriptForFolder(app.name, folder + '/' + app.name, stopIfFailure, buildTool, features.contains("kapt") && Runtime.version().feature() > 17 && buildTool == GRADLE, nativeTest, app.validateLicense)
                         }
                     }
                     bashScript << """\
@@ -197,7 +197,8 @@ fi
                                           boolean stopIfFailure,
                                           BuildTool buildTool,
                                           boolean noDaemon,
-                                          boolean nativeTest) {
+                                          boolean nativeTest,
+                                          boolean validateLicense) {
         String testcopy = nativeTest ? "native tests" : "tests"
         String bashScript = """\
 cd $nestedFolder
@@ -212,8 +213,9 @@ bashScript += """\
 ${buildTool == MAVEN ? './mvnw -Pnative test' : './gradlew nativeTest'} || EXIT_STATUS=\$?
 """
 } else {
+String mavenCommand = validateLicense ? './mvnw -q test spotless:check' : './mvnw -q test'
 bashScript += """\
-${buildTool == MAVEN ? './mvnw -q test spotless:check' : './gradlew -q check' } || EXIT_STATUS=\$?
+${buildTool == MAVEN ? mavenCommand : './gradlew -q check' } || EXIT_STATUS=\$?
 echo "Stopping shared test resources service (if created)"
 ${buildTool == MAVEN ? './mvnw -q mn:stop-testresources-service' : './gradlew -q stopTestResourcesService'} > /dev/null 2>&1 || true
 """

--- a/buildSrc/src/main/java/io/micronaut/guides/spotless/Spotless.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/spotless/Spotless.java
@@ -1,0 +1,90 @@
+package io.micronaut.guides.spotless;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.BuildPlugin;
+import io.micronaut.starter.build.dependencies.Coordinate;
+import io.micronaut.starter.build.gradle.GradlePlugin;
+import io.micronaut.starter.build.maven.MavenPlugin;
+import io.micronaut.starter.feature.Category;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.template.BinaryTemplate;
+import io.micronaut.starter.template.RockerWritable;
+import io.micronaut.guides.spotless.templates.spotlessGradle;
+import io.micronaut.guides.spotless.templates.spotlessMaven;
+import io.micronaut.starter.template.Template;
+import jakarta.inject.Singleton;
+
+import javax.swing.text.html.Option;
+import java.util.Optional;
+
+@Singleton
+public class Spotless implements Feature {
+    @Override
+    public @NonNull String getName() {
+        return "spotless";
+    }
+
+    @Override
+    public String getCategory() {
+        return Category.DEV_TOOLS;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Spotless";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adds Spotless build plugins";
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        buildPlugin(generatorContext).ifPresent(generatorContext::addBuildPlugin);
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        generatorContext.addTemplate("LICENSEHEADER", new BinaryTemplate(Template.ROOT, "LICENSEHEADER", classLoader.getResource("LICENSEHEADER")));
+    }
+
+    private Optional<BuildPlugin> buildPlugin(GeneratorContext generatorContext) {
+        if (generatorContext.getBuildTool().isGradle()) {
+            return Optional.of(gradleBuildPlugin(generatorContext));
+        } else if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+            return Optional.of(mavenBuildPlugin(generatorContext));
+        }
+        return Optional.empty();
+    }
+
+    private MavenPlugin mavenBuildPlugin(GeneratorContext generatorContext) {
+        Coordinate coordinate = generatorContext.resolveCoordinate("spotless-maven-plugin");
+        return MavenPlugin.builder()
+                .artifactId("spotless-maven-plugin")
+                .extension(new RockerWritable(spotlessMaven.template(coordinate.getGroupId(),
+                        coordinate.getArtifactId(),
+                        coordinate.getVersion(),
+                        generatorContext.getLanguage())))
+                .build();
+    }
+
+    private GradlePlugin gradleBuildPlugin(GeneratorContext generatorContext) {
+        return GradlePlugin.builder()
+                .id("com.diffplug.spotless")
+                .lookupArtifactId("spotless-plugin-gradle")
+                .extension(new RockerWritable(spotlessGradle.template(generatorContext.getLanguage())))
+                .build();
+    }
+
+    @Override
+    public @Nullable String getThirdPartyDocumentation() {
+        return "https://github.com/diffplug/spotless";
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+}

--- a/buildSrc/src/main/java/io/micronaut/guides/spotless/Spotless.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/spotless/Spotless.java
@@ -2,6 +2,9 @@ package io.micronaut.guides.spotless;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.guides.feature.Geb;
+import io.micronaut.guides.spotless.templates.spotlessGradle;
+import io.micronaut.guides.spotless.templates.spotlessMaven;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.BuildPlugin;
@@ -10,15 +13,16 @@ import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.build.maven.MavenPlugin;
 import io.micronaut.starter.feature.Category;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.FeaturePhase;
 import io.micronaut.starter.options.BuildTool;
+import io.micronaut.starter.options.Language;
 import io.micronaut.starter.template.BinaryTemplate;
 import io.micronaut.starter.template.RockerWritable;
-import io.micronaut.guides.spotless.templates.spotlessGradle;
-import io.micronaut.guides.spotless.templates.spotlessMaven;
 import io.micronaut.starter.template.Template;
 import jakarta.inject.Singleton;
 
-import javax.swing.text.html.Option;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Singleton
@@ -36,6 +40,11 @@ public class Spotless implements Feature {
     @Override
     public String getTitle() {
         return "Spotless";
+    }
+
+    @Override
+    public int getOrder() {
+        return FeaturePhase.BUILD_PLUGIN.getOrder();
     }
 
     @Override
@@ -66,15 +75,25 @@ public class Spotless implements Feature {
                 .extension(new RockerWritable(spotlessMaven.template(coordinate.getGroupId(),
                         coordinate.getArtifactId(),
                         coordinate.getVersion(),
-                        generatorContext.getLanguage())))
+                        languages(generatorContext))))
                 .build();
     }
+
+    private List<Language> languages(GeneratorContext generatorContext) {
+        List<Language> languages = new ArrayList<>();
+        languages.add(generatorContext.getLanguage());
+        if (generatorContext.hasFeature(Geb.class)) {
+            languages.add(Language.GROOVY);
+        }
+        return languages;
+    }
+
 
     private GradlePlugin gradleBuildPlugin(GeneratorContext generatorContext) {
         return GradlePlugin.builder()
                 .id("com.diffplug.spotless")
                 .lookupArtifactId("spotless-plugin-gradle")
-                .extension(new RockerWritable(spotlessGradle.template(generatorContext.getLanguage())))
+                .extension(new RockerWritable(spotlessGradle.template(languages(generatorContext))))
                 .build();
     }
 

--- a/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessGradle.rocker.raw
+++ b/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessGradle.rocker.raw
@@ -1,3 +1,4 @@
+@option discardLogicWhitespace=true
 @import io.micronaut.starter.options.Language
 @import java.util.List
 @args (List<Language> languages)

--- a/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessGradle.rocker.raw
+++ b/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessGradle.rocker.raw
@@ -1,15 +1,18 @@
 @import io.micronaut.starter.options.Language
-@args (Language language)
+@import java.util.List
+@args (List<Language> languages)
 spotless {
-@if(language == Language.JAVA) {
+@if(languages.contains(Language.JAVA)) {
     java {
         licenseHeaderFile(file("LICENSEHEADER"))
     }
-} else if (language == Language.KOTLIN) {
+}
+@if(languages.contains(Language.KOTLIN)) {
     kotlin {
         licenseHeaderFile(file("LICENSEHEADER"))
     }
-} else if (language == Language.GROOVY) {
+}
+@if(languages.contains(Language.GROOVY)) {
     groovy {
         licenseHeaderFile(file("LICENSEHEADER"))
     }

--- a/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessGradle.rocker.raw
+++ b/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessGradle.rocker.raw
@@ -1,0 +1,17 @@
+@import io.micronaut.starter.options.Language
+@args (Language language)
+spotless {
+@if(language == Language.JAVA) {
+    java {
+        licenseHeaderFile(file("LICENSEHEADER"))
+    }
+} else if (language == Language.KOTLIN) {
+    kotlin {
+        licenseHeaderFile(file("LICENSEHEADER"))
+    }
+} else if (language == Language.GROOVY) {
+    groovy {
+        licenseHeaderFile(file("LICENSEHEADER"))
+    }
+}
+}

--- a/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessMaven.rocker.raw
+++ b/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessMaven.rocker.raw
@@ -1,3 +1,4 @@
+@option discardLogicWhitespace=true
 @import io.micronaut.starter.options.Language
 @import java.util.List
 @args(String groupId, String artifactId, String version, List<Language> languages)

--- a/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessMaven.rocker.raw
+++ b/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessMaven.rocker.raw
@@ -1,23 +1,26 @@
 @import io.micronaut.starter.options.Language
-@args(String groupId, String artifactId, String version, Language language)
+@import java.util.List
+@args(String groupId, String artifactId, String version, List<Language> languages)
 <plugin>
   <groupId>@groupId</groupId>
   <artifactId>@artifactId</artifactId>
   <version>@version</version>
   <configuration>
-@if(language == Language.JAVA) {
+@if(languages.contains(Language.JAVA)) {
     <java>
         <licenseHeader>
             <file>${project.basedir}/LICENSEHEADER</file>
         </licenseHeader>
     </java>
-} else if (language == Language.KOTLIN) {
+}
+@if(languages.contains(Language.KOTLIN)) {
     <kotlin>
         <licenseHeader>
             <file>${project.basedir}/LICENSEHEADER</file>
         </licenseHeader>
     </kotlin>
-} else if (language == Language.GROOVY) {
+}
+@if(languages.contains(Language.GROOVY)) {
     <groovy>
         <licenseHeader>
             <file>${project.basedir}/LICENSEHEADER</file>

--- a/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessMaven.rocker.raw
+++ b/buildSrc/src/main/java/io/micronaut/guides/spotless/templates/spotlessMaven.rocker.raw
@@ -1,0 +1,28 @@
+@import io.micronaut.starter.options.Language
+@args(String groupId, String artifactId, String version, Language language)
+<plugin>
+  <groupId>@groupId</groupId>
+  <artifactId>@artifactId</artifactId>
+  <version>@version</version>
+  <configuration>
+@if(language == Language.JAVA) {
+    <java>
+        <licenseHeader>
+            <file>${project.basedir}/LICENSEHEADER</file>
+        </licenseHeader>
+    </java>
+} else if (language == Language.KOTLIN) {
+    <kotlin>
+        <licenseHeader>
+            <file>${project.basedir}/LICENSEHEADER</file>
+        </licenseHeader>
+    </kotlin>
+} else if (language == Language.GROOVY) {
+    <groovy>
+        <licenseHeader>
+            <file>${project.basedir}/LICENSEHEADER</file>
+        </licenseHeader>
+    </groovy>
+}
+  </configuration>
+</plugin>

--- a/buildSrc/src/main/java/io/spring/start/GradleReplacement.java
+++ b/buildSrc/src/main/java/io/spring/start/GradleReplacement.java
@@ -1,15 +1,31 @@
 package io.spring.start;
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.build.Property;
+import io.micronaut.starter.feature.KotlinSymbolProcessing;
 import io.micronaut.starter.feature.build.gradle.Gradle;
 import io.micronaut.starter.build.RepositoryResolver;
 import io.micronaut.starter.build.gradle.GradleBuildCreator;
 import jakarta.inject.Singleton;
 import io.micronaut.starter.application.generator.GeneratorContext;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Replaces(Gradle.class)
 @Singleton
 public class GradleReplacement extends Gradle {
+    private static final Property PROPERTY_GRADLE_JVMARGS_4G = new Property() {
+        @Override
+        public String getKey() {
+            return "org.gradle.jvmargs";
+        }
 
+        @Override
+        public String getValue() {
+            return "-Xmx4G";
+        }
+    };
     public GradleReplacement(GradleBuildCreator dependencyResolver,
                   RepositoryResolver repositoryResolver) {
         super(dependencyResolver, repositoryResolver);
@@ -18,5 +34,15 @@ public class GradleReplacement extends Gradle {
     protected void generateNoneMicronautFrameworkBuild(GeneratorContext generatorContext) {
         super.generateNoneMicronautFrameworkBuild(generatorContext);
         addGradleInitFiles(generatorContext);
+    }
+
+    @NonNull
+    @Override
+    protected List<Property> gradleProperties(@NonNull GeneratorContext generatorContext) {
+        List<Property> properties = new ArrayList(generatorContext.getBuildProperties().getProperties().stream().filter((p) -> {
+            return p.getKey() == null || !p.getKey().equals("micronaut.runtime");
+        }).toList());
+        properties.add(PROPERTY_GRADLE_JVMARGS_4G);
+        return properties;
     }
 }

--- a/buildSrc/src/main/java/io/spring/start/GroovyGradlePlugin.java
+++ b/buildSrc/src/main/java/io/spring/start/GroovyGradlePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringBootDependencies.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringBootFramework.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootFramework.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringBootGradlePlugin.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootGradlePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringBootGroovy.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootGroovy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringBootJava.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootJava.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringBootKotlin.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootKotlin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringBootStarter.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootStarter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringBootStarterFeature.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootStarterFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringBootStarterWeb.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootStarterWeb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringDefaultFeature.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringDefaultFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/java/io/spring/start/SpringDependencyManagementGradlePlugin.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringDependencyManagementGradlePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/resources/LICENSEHEADER
+++ b/buildSrc/src/main/resources/LICENSEHEADER
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/buildSrc/src/main/resources/LICENSEHEADER
+++ b/buildSrc/src/main/resources/LICENSEHEADER
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/resources/LICENSEHEADER
+++ b/buildSrc/src/main/resources/LICENSEHEADER
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-$YEAR original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/resources/pom.xml
+++ b/buildSrc/src/main/resources/pom.xml
@@ -13,6 +13,16 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <version>2.41.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-plugin-gradle</artifactId>
+            <version>6.23.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
             <version>5.15.0</version>

--- a/cli/src/main/java/io/micronaut/guides/TweetsCommand.java
+++ b/cli/src/main/java/io/micronaut/guides/TweetsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors original authors
+ * Copyright 2017-2024 original authors original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cli/src/main/java/io/micronaut/guides/httpclient/BuildTool.java
+++ b/cli/src/main/java/io/micronaut/guides/httpclient/BuildTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors original authors
+ * Copyright 2017-2024 original authors original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cli/src/main/java/io/micronaut/guides/httpclient/Guide.java
+++ b/cli/src/main/java/io/micronaut/guides/httpclient/Guide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors original authors
+ * Copyright 2017-2024 original authors original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cli/src/main/java/io/micronaut/guides/httpclient/GuidesApi.java
+++ b/cli/src/main/java/io/micronaut/guides/httpclient/GuidesApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors original authors
+ * Copyright 2017-2024 original authors original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cli/src/main/java/io/micronaut/guides/httpclient/GuidesClient.java
+++ b/cli/src/main/java/io/micronaut/guides/httpclient/GuidesClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors original authors
+ * Copyright 2017-2024 original authors original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cli/src/main/java/io/micronaut/guides/httpclient/Language.java
+++ b/cli/src/main/java/io/micronaut/guides/httpclient/Language.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors original authors
+ * Copyright 2017-2024 original authors original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cli/src/main/java/io/micronaut/guides/httpclient/Option.java
+++ b/cli/src/main/java/io/micronaut/guides/httpclient/Option.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors original authors
+ * Copyright 2017-2024 original authors original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/guides/micronaut-error-handling/groovy/src/main/groovy/example/micronaut/BookController.groovy
+++ b/guides/micronaut-error-handling/groovy/src/main/groovy/example/micronaut/BookController.groovy
@@ -1,6 +1,9 @@
+package example.micronaut
+/*
 //tag::package[]
 package example.micronaut
 //end::package[]
+*/
 
 //tag::imports[]
 import groovy.transform.CompileStatic

--- a/guides/micronaut-error-handling/java/src/main/java/example/micronaut/BookController.java
+++ b/guides/micronaut-error-handling/java/src/main/java/example/micronaut/BookController.java
@@ -1,7 +1,9 @@
+package example.micronaut;
+/*
 //tag::package[]
 package example.micronaut;
 //end::package[]
-
+*/
 //tag::imports[]
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;

--- a/guides/micronaut-error-handling/kotlin/src/main/kotlin/example/micronaut/BookController.kt
+++ b/guides/micronaut-error-handling/kotlin/src/main/kotlin/example/micronaut/BookController.kt
@@ -1,6 +1,9 @@
+package example.micronaut
+/*
 //tag::package[]
 package example.micronaut
 //end::package[]
+*/
 
 //tag::imports[]
 import io.micronaut.http.HttpRequest

--- a/guides/micronaut-flyway/groovy/src/main/groovy/example/micronaut/Person.groovy
+++ b/guides/micronaut-flyway/groovy/src/main/groovy/example/micronaut/Person.groovy
@@ -1,6 +1,10 @@
-//tag::clazz1[]
 package example.micronaut
-
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::clazz1[]
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable

--- a/guides/micronaut-flyway/java/src/main/java/example/micronaut/Person.java
+++ b/guides/micronaut-flyway/java/src/main/java/example/micronaut/Person.java
@@ -1,6 +1,10 @@
-//tag::clazz1[]
 package example.micronaut;
-
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::clazz1[]
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.annotation.GeneratedValue;

--- a/guides/micronaut-flyway/kotlin/src/main/kotlin/example/micronaut/Person.kt
+++ b/guides/micronaut-flyway/kotlin/src/main/kotlin/example/micronaut/Person.kt
@@ -1,6 +1,10 @@
+package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
 //tag::clazz1[]
-package example.micronaut
-
 import io.micronaut.data.annotation.GeneratedValue
 import io.micronaut.data.annotation.Id
 import io.micronaut.data.annotation.MappedEntity

--- a/guides/micronaut-flyway/micronaut-flyway.adoc
+++ b/guides/micronaut-flyway/micronaut-flyway.adoc
@@ -31,7 +31,7 @@ https://guides.micronaut.io/latest/micronaut-intellij-idea-ide-setup.html[Setup 
 
 Create a `@MappedEntity` to save persons. Initially, consider name and age required. Use `int` primitive for the age.
 
-source:Person[tags=clazz1|ageint|clazz2]
+source:Person[tags=package|clazz1|ageint|clazz2]
 
 callout:mapped-entity[1]
 callout:mapped-entity-id[2]

--- a/guides/micronaut-jaxrs-jdbc/src/main/resources/application.yml
+++ b/guides/micronaut-jaxrs-jdbc/src/main/resources/application.yml
@@ -5,8 +5,9 @@ micronaut:
 #tag::datasource[]
 datasources:
   default:
+    db-type: mysql
     dialect: MYSQL
-    driverClassName: ${JDBC_DRIVER:com.mysql.cj.jdbc.Driver}
+    driver-class-name: com.mysql.cj.jdbc.Driver
 #end::datasource[]
 ---
 #tag::flyway[]

--- a/guides/micronaut-kotlin-extension-fns/kotlin/src/main/kotlin/example/micronaut/DadJokeController.kt
+++ b/guides/micronaut-kotlin-extension-fns/kotlin/src/main/kotlin/example/micronaut/DadJokeController.kt
@@ -1,5 +1,10 @@
-//tag::fileHead[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::fileHead[]
 
 import io.micronaut.http.MediaType.TEXT_PLAIN
 import io.micronaut.http.annotation.Controller

--- a/guides/micronaut-kotlin-extension-fns/micronaut-kotlin-extension-fns.adoc
+++ b/guides/micronaut-kotlin-extension-fns/micronaut-kotlin-extension-fns.adoc
@@ -94,7 +94,7 @@ Let's see how we can extend this client to suit our own use case.
 
 We'll create a controller to utilize the client's standard `GET` for a random joke.
 
-source:DadJokeController[tags=fileHead|start|standardGet|end]
+source:DadJokeController[tags=package|fileHead|start|standardGet|end]
 
 Now, say we have a particular way we want to use a client frequently, for example attaching common headers or filling in some parameters by default.
 

--- a/guides/micronaut-liquibase/groovy/src/main/groovy/example/micronaut/Person.groovy
+++ b/guides/micronaut-liquibase/groovy/src/main/groovy/example/micronaut/Person.groovy
@@ -1,5 +1,10 @@
-//tag::clazz1[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::clazz1[]
 
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.NonNull

--- a/guides/micronaut-liquibase/java/src/main/java/example/micronaut/Person.java
+++ b/guides/micronaut-liquibase/java/src/main/java/example/micronaut/Person.java
@@ -1,5 +1,10 @@
-//tag::clazz1[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::clazz1[]
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;

--- a/guides/micronaut-liquibase/kotlin/src/main/kotlin/example/micronaut/Person.kt
+++ b/guides/micronaut-liquibase/kotlin/src/main/kotlin/example/micronaut/Person.kt
@@ -1,5 +1,10 @@
-//tag::clazz1[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::clazz1[]
 
 import io.micronaut.data.annotation.GeneratedValue
 import io.micronaut.data.annotation.Id

--- a/guides/micronaut-liquibase/micronaut-liquibase.adoc
+++ b/guides/micronaut-liquibase/micronaut-liquibase.adoc
@@ -27,7 +27,7 @@ https://guides.micronaut.io/latest/micronaut-intellij-idea-ide-setup.html[Setup 
 
 Create a `@MappedEntity` to save persons. Initially, consider name and age required. Use `int` primitive for the age.
 
-source:Person[tags=clazz1|ageint|clazz2]
+source:Person[tags=pacakge|clazz1|ageint|clazz2]
 
 callout:mapped-entity[1]
 callout:mapped-entity-id[2]

--- a/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
 
+//tag::imports[]
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import org.reactivestreams.Publisher
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
@@ -1,5 +1,11 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+
+//tag::imports[]
 
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Consumes
@@ -8,7 +14,7 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8082") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
@@ -1,11 +1,17 @@
-//tag::packageandimports[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Recoverable;
 import org.reactivestreams.Publisher;
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookCatalogueClient.kt
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookCatalogueClient.kt
@@ -1,5 +1,11 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
@@ -7,7 +13,7 @@ import io.micronaut.retry.annotation.Recoverable
 import reactor.core.publisher.Flux
 import org.reactivestreams.Publisher
 
-//end::packageandimports[]
+//end::imports[]
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>
 @Recoverable(api = BookCatalogueOperations::class)

--- a/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Consumes
@@ -10,7 +15,7 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
 
-//end::packageandimports[]
+//end::imports[]
 //tag::harcoded[]
 @Client("http://localhost:8082") // <1>
 @Recoverable(api = BookInventoryOperations::class)

--- a/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import org.reactivestreams.Publisher
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Consumes
@@ -8,7 +13,7 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8082") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Recoverable;
 import org.reactivestreams.Publisher;
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookCatalogueClient.kt
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookCatalogueClient.kt
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
@@ -7,7 +12,7 @@ import io.micronaut.retry.annotation.Recoverable
 import reactor.core.publisher.Flux
 import org.reactivestreams.Publisher
 
-//end::packageandimports[]
+//end::imports[]
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>
 @Recoverable(api = BookCatalogueOperations::class)

--- a/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Consumes
@@ -10,7 +15,7 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
 
-//end::packageandimports[]
+//end::imports[]
 //tag::harcoded[]
 @Client("http://localhost:8082") // <1>
 @Recoverable(api = BookInventoryOperations::class)

--- a/guides/micronaut-microservices-distributed-tracing-xray/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
+++ b/guides/micronaut-microservices-distributed-tracing-xray/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Recoverable;
 import org.reactivestreams.Publisher;
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client(id = "bookcatalogue") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-zipkin-opentelemetry/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin-opentelemetry/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import org.reactivestreams.Publisher
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-zipkin-opentelemetry/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin-opentelemetry/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
@@ -1,5 +1,11 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
+
 
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Consumes
@@ -8,7 +14,7 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8082") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-zipkin-opentelemetry/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin-opentelemetry/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Recoverable;
 import org.reactivestreams.Publisher;
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-zipkin-opentelemetry/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin-opentelemetry/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Consumes
@@ -10,7 +15,7 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
 
-//end::packageandimports[]
+//end::imports[]
 //tag::harcoded[]
 @Client("http://localhost:8082") // <1>
 @Recoverable(api = BookInventoryOperations::class)

--- a/guides/micronaut-microservices-distributed-tracing-zipkin-opentelemetry/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/bookrecommendation/BookCatalogueClient.kt
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin-opentelemetry/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/bookrecommendation/BookCatalogueClient.kt
@@ -1,12 +1,17 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import org.reactivestreams.Publisher
 
-//end::packageandimports[]
+//end::imports[]
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>
 @Recoverable(api = BookCatalogueOperations::class)

--- a/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import org.reactivestreams.Publisher
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Consumes
@@ -8,7 +13,7 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8082") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Recoverable;
 import org.reactivestreams.Publisher;
-//end::packageandimports[]
+//end::imports[]
 
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>

--- a/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Consumes
@@ -10,7 +15,7 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
 
-//end::packageandimports[]
+//end::imports[]
 //tag::harcoded[]
 @Client("http://localhost:8082") // <1>
 @Recoverable(api = BookInventoryOperations::class)

--- a/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/bookrecommendation/BookCatalogueClient.kt
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/bookrecommendation/BookCatalogueClient.kt
@@ -1,12 +1,17 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import org.reactivestreams.Publisher
 
-//end::packageandimports[]
+//end::imports[]
 //tag::harcoded[]
 @Client("http://localhost:8081") // <1>
 @Recoverable(api = BookCatalogueOperations::class)

--- a/guides/micronaut-microservices-services-discover-consul/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
+++ b/guides/micronaut-microservices-services-discover-consul/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import org.reactivestreams.Publisher
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-consul/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
+++ b/guides/micronaut-microservices-services-discover-consul/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.http.annotation.Consumes
@@ -11,7 +16,7 @@ import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
 
 import static io.micronaut.http.MediaType.TEXT_PLAIN
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-consul/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
+++ b/guides/micronaut-microservices-services-discover-consul/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Recoverable;
 import org.reactivestreams.Publisher;
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-consul/bookrecommendation/java/src/main/java/example/micronaut/BookInventoryClient.java
+++ b/guides/micronaut-microservices-services-discover-consul/bookrecommendation/java/src/main/java/example/micronaut/BookInventoryClient.java
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.annotation.Consumes;
@@ -11,7 +16,7 @@ import reactor.core.publisher.Mono;
 import jakarta.validation.constraints.NotBlank;
 
 import static io.micronaut.http.MediaType.TEXT_PLAIN;
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-consul/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookCatalogueClient.kt
+++ b/guides/micronaut-microservices-services-discover-consul/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookCatalogueClient.kt
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import org.reactivestreams.Publisher
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-consul/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
+++ b/guides/micronaut-microservices-services-discover-consul/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.MediaType.TEXT_PLAIN
 import io.micronaut.http.annotation.Consumes
@@ -8,7 +13,7 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-consul/micronaut-microservices-services-discover-consul.adoc
+++ b/guides/micronaut-microservices-services-discover-consul/micronaut-microservices-services-discover-consul.adoc
@@ -229,7 +229,7 @@ Create an interface to map operations with `bookcatalogue`, and a Micronaut Decl
 
 source:BookCatalogueOperations[app=bookrecommendation]
 
-source:BookCatalogueClient[app=bookrecommendation,tags=packageandimports|harcoded|clazz]
+source:BookCatalogueClient[app=bookrecommendation,tags=package|imports|harcoded|clazz]
 
 callout:client[1]
 
@@ -241,7 +241,7 @@ Create an interface to map operations with `bookinventory`, and a Micronaut Decl
 
 source:BookInventoryOperations[app=bookrecommendation]
 
-source:BookInventoryClient[app=bookrecommendation,tags=packageandimports|harcoded|clazz]
+source:BookInventoryClient[app=bookrecommendation,tags=package|imports|harcoded|clazz]
 
 callout:client[1]
 
@@ -456,11 +456,11 @@ resource:application.yml[app=bookrecommendation,tag=consul]
 
 Modify `BookInventoryClient` and `BookCatalogueClient` to use the service id instead of a hardcoded URL.
 
-source:BookCatalogueClient[app=bookrecommendation,tags=packageandimports|consul|clazz]
+source:BookCatalogueClient[app=bookrecommendation,tags=package|imports|consul|clazz]
 
 <1> Use the configuration value `micronaut.application.name` used in `bookcatalogue` as service `id`.
 
-source:BookInventoryClient[app=bookrecommendation,tags=packageandimports|consul|clazz]
+source:BookInventoryClient[app=bookrecommendation,tags=package|imports|consul|clazz]
 
 <1> Use the configuration value `micronaut.application.name` used in `bookinventory` as service `id`.
 

--- a/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
+++ b/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookCatalogueClient.groovy
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import org.reactivestreams.Publisher
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
+++ b/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/groovy/src/main/groovy/example/micronaut/BookInventoryClient.groovy
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.http.annotation.Consumes
@@ -11,7 +16,7 @@ import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
 
 import static io.micronaut.http.MediaType.TEXT_PLAIN
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
+++ b/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/java/src/main/java/example/micronaut/BookCatalogueClient.java
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.retry.annotation.Recoverable;
 import org.reactivestreams.Publisher;
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/java/src/main/java/example/micronaut/BookInventoryClient.java
+++ b/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/java/src/main/java/example/micronaut/BookInventoryClient.java
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.annotation.Consumes;
@@ -11,7 +16,7 @@ import reactor.core.publisher.Mono;
 import jakarta.validation.constraints.NotBlank;
 
 import static io.micronaut.http.MediaType.TEXT_PLAIN;
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookCatalogueClient.kt
+++ b/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookCatalogueClient.kt
@@ -1,11 +1,16 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import org.reactivestreams.Publisher
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
+++ b/guides/micronaut-microservices-services-discover-eureka/bookrecommendation/kotlin/src/main/kotlin/example/micronaut/BookInventoryClient.kt
@@ -1,5 +1,10 @@
-//tag::packageandimports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.http.MediaType.TEXT_PLAIN
 import io.micronaut.http.annotation.Consumes
@@ -8,7 +13,7 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Recoverable
 import reactor.core.publisher.Mono
 import jakarta.validation.constraints.NotBlank
-//end::packageandimports[]
+//end::imports[]
 
 /*
 //tag::harcoded[]

--- a/guides/micronaut-microservices-services-discover-eureka/micronaut-microservices-services-discover-eureka.adoc
+++ b/guides/micronaut-microservices-services-discover-eureka/micronaut-microservices-services-discover-eureka.adoc
@@ -213,7 +213,7 @@ Create an interface to map operations with `bookcatalogue`, and a Micronaut Decl
 
 source:BookCatalogueOperations[app=bookrecommendation]
 
-source:BookCatalogueClient[app=bookrecommendation,tags=packageandimports|harcoded|clazz]
+source:BookCatalogueClient[app=bookrecommendation,tags=package|imports|harcoded|clazz]
 
 callout:client[1]
 
@@ -225,7 +225,7 @@ Create an interface to map operations with `bookinventory`, and a Micronaut Decl
 
 source:BookInventoryOperations[app=bookrecommendation]
 
-source:BookInventoryClient[app=bookrecommendation,tags=packageandimports|harcoded|clazz]
+source:BookInventoryClient[app=bookrecommendation,tags=package|imports|harcoded|clazz]
 
 callout:client[1]
 
@@ -435,11 +435,11 @@ resource:application.yml[app=bookrecommendation,tag=eureka]
 
 Modify `BookInventoryClient` and `BookCatalogueClient` to use the service id instead of a hardcoded URL.
 
-source:BookCatalogueClient[app=bookrecommendation,tags=packageandimports|eureka|clazz]
+source:BookCatalogueClient[app=bookrecommendation,tags=package|imports|eureka|clazz]
 
 <1> Use the configuration value `micronaut.application.name` used in `bookcatalogue` as service `id`.
 
-source:BookInventoryClient[app=bookrecommendation,tags=packageandimports|eureka|clazz]
+source:BookInventoryClient[app=bookrecommendation,tags=package|imports|eureka|clazz]
 
 <1> Use the configuration value `micronaut.application.name` used in `bookinventory` as service `id`.
 

--- a/guides/micronaut-oauth2-github/groovy/src/main/groovy/example/micronaut/GithubApiClient.groovy
+++ b/guides/micronaut-oauth2-github/groovy/src/main/groovy/example/micronaut/GithubApiClient.groovy
@@ -1,5 +1,10 @@
-//tag::clazz[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::clazz[]
 
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Nullable

--- a/guides/micronaut-oauth2-github/java/src/main/java/example/micronaut/GithubApiClient.java
+++ b/guides/micronaut-oauth2-github/java/src/main/java/example/micronaut/GithubApiClient.java
@@ -1,5 +1,10 @@
-//tag::clazz[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//end::package[]
+*/
+//tag::clazz[]
 
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpHeaders;

--- a/guides/micronaut-oauth2-github/kotlin/src/main/kotlin/example/micronaut/GithubApiClient.kt
+++ b/guides/micronaut-oauth2-github/kotlin/src/main/kotlin/example/micronaut/GithubApiClient.kt
@@ -1,5 +1,10 @@
-//tag::clazz[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//end::package[]
+*/
+//tag::clazz[]
 
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpHeaders

--- a/guides/micronaut-oauth2-github/micronaut-oauth2-github.adoc
+++ b/guides/micronaut-oauth2-github/micronaut-oauth2-github.adoc
@@ -82,7 +82,7 @@ source:GithubUser[]
 
 Then, create a Micronaut Declarative HTTP Client to consume https://developer.github.com/v3/[GitHub REST API v3]
 
-source:GithubApiClient[tag=clazz]
+source:GithubApiClient[tag=package,clazz]
 
 <1> GitHub encourages explicitly requesting version 3 via the Accept header. With `@Header`, you add the `Accept: application/vnd.github.v3+json` HTTP header to every request.
 <2> Add the id `githubv3` to the `@Client` annotation. Later, you will provide URL for this client id.

--- a/guides/micronaut-openapi-generator-client/java/src/test/java/example/micronaut/WeatherClientTest.java
+++ b/guides/micronaut-openapi-generator-client/java/src/test/java/example/micronaut/WeatherClientTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2003-2021 the original author or authors.
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/guides/micronaut-openapi-generator-client/metadata.json
+++ b/guides/micronaut-openapi-generator-client/metadata.json
@@ -10,6 +10,7 @@
   "publicationDate": "2022-05-31",
   "apps": [
     {
+      "validateLicense": false,
       "name": "default",
       "features": ["reactor", "validation", "http-client"],
       "excludeTest": ["Micronautguide"],

--- a/guides/micronaut-openapi-generator-server/java/src/main/java/example/micronaut/controller/BooksController.java
+++ b/guides/micronaut-openapi-generator-server/java/src/main/java/example/micronaut/controller/BooksController.java
@@ -1,4 +1,21 @@
 /*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut.controller;
+
+/*
  * Library
  * This is a library API
  *
@@ -9,9 +26,11 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
-
-// tag::header[]
+/*
+//tag::package[]
 package example.micronaut.controller;
+//tag::package[]
+*/
 //tag::import[]
 
 import example.micronaut.BookEntity;
@@ -27,9 +46,10 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import java.util.List;
 //end::import[]
 
+//tag::clazz[]
 @Controller
 public class BooksController implements BooksApi {
-//end::header[]
+//end::clazz[]
 
     //tag::inject[]
     private final BookRepository bookRepository; // <1>

--- a/guides/micronaut-openapi-generator-server/metadata.json
+++ b/guides/micronaut-openapi-generator-server/metadata.json
@@ -20,6 +20,7 @@
   "publicationDate": "2022-03-03",
   "apps": [
     {
+      "validateLicense": false,
       "name": "default",
       "features": [
         "validation",

--- a/guides/micronaut-scope-types/java/src/main/java/example/micronaut/singleton/Robot.java
+++ b/guides/micronaut-scope-types/java/src/main/java/example/micronaut/singleton/Robot.java
@@ -1,6 +1,9 @@
+package example.micronaut.singleton;
+/*
 //tag::pkg[]
 package example.micronaut.singleton;
 //end::pkg[]
+*/
 
 //tag::clazz[]
 import io.micronaut.core.annotation.NonNull;

--- a/guides/micronaut-scope-types/java/src/main/java/example/micronaut/singleton/RobotController.java
+++ b/guides/micronaut-scope-types/java/src/main/java/example/micronaut/singleton/RobotController.java
@@ -1,6 +1,9 @@
+package example.micronaut.singleton;
+/*
 //tag::pkg[]
 package example.micronaut.singleton;
 //end::pkg[]
+*/
 
 //tag::imports[]
 import io.micronaut.http.annotation.Controller;

--- a/guides/micronaut-scope-types/java/src/test/java/example/micronaut/PrototypeScopeTest.java
+++ b/guides/micronaut-scope-types/java/src/test/java/example/micronaut/PrototypeScopeTest.java
@@ -1,5 +1,10 @@
-//tag::imports[]
 package example.micronaut;
+/*
+//tag::pkg[]
+package example.micronaut;
+//end::pkg[]
+*/
+//tag::imports[]
 
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;

--- a/guides/micronaut-scope-types/java/src/test/java/example/micronaut/RefreshableScopeTest.java
+++ b/guides/micronaut-scope-types/java/src/test/java/example/micronaut/RefreshableScopeTest.java
@@ -1,5 +1,10 @@
-//tag::imports[]
 package example.micronaut;
+/*
+//tag::pkg[]
+package example.micronaut;
+//end::pkg[]
+*/
+//tag::imports[]
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.core.type.Argument;

--- a/guides/micronaut-scope-types/java/src/test/java/example/micronaut/RequestScopeTest.java
+++ b/guides/micronaut-scope-types/java/src/test/java/example/micronaut/RequestScopeTest.java
@@ -1,5 +1,10 @@
-//tag::imports[]
 package example.micronaut;
+/*
+//tag::pkg[]
+package example.micronaut;
+//end::pkg[]
+*/
+//tag::imports[]
 
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;

--- a/guides/micronaut-scope-types/java/src/test/java/example/micronaut/SingletonScopeTest.java
+++ b/guides/micronaut-scope-types/java/src/test/java/example/micronaut/SingletonScopeTest.java
@@ -1,5 +1,10 @@
-//tag::imports[]
 package example.micronaut;
+/*
+//tag::pkg[]
+package example.micronaut;
+//end::pkg[]
+*/
+//tag::imports[]
 
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;

--- a/guides/micronaut-scope-types/kotlin/src/main/kotlin/example/micronaut/singleton/Robot.kt
+++ b/guides/micronaut-scope-types/kotlin/src/main/kotlin/example/micronaut/singleton/Robot.kt
@@ -1,6 +1,9 @@
+package example.micronaut.singleton
+/*
 //tag::pkg[]
 package example.micronaut.singleton
 //end::pkg[]
+*/
 
 //tag::clazz[]
 import jakarta.inject.Singleton

--- a/guides/micronaut-scope-types/kotlin/src/main/kotlin/example/micronaut/singleton/RobotController.kt
+++ b/guides/micronaut-scope-types/kotlin/src/main/kotlin/example/micronaut/singleton/RobotController.kt
@@ -1,6 +1,9 @@
+package example.micronaut.singleton
+/*
 //tag::pkg[]
 package example.micronaut.singleton
 //end::pkg[]
+*/
 
 //tag::imports[]
 import io.micronaut.http.annotation.Controller

--- a/guides/micronaut-scope-types/kotlin/src/test/kotlin/example/micronaut/ContextTest.kt
+++ b/guides/micronaut-scope-types/kotlin/src/test/kotlin/example/micronaut/ContextTest.kt
@@ -1,4 +1,10 @@
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//tag::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.exceptions.BeanInstantiationException

--- a/guides/micronaut-scope-types/kotlin/src/test/kotlin/example/micronaut/PrototypeScopeTest.kt
+++ b/guides/micronaut-scope-types/kotlin/src/test/kotlin/example/micronaut/PrototypeScopeTest.kt
@@ -1,5 +1,10 @@
-//tag::imports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//tag::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
@@ -9,7 +14,6 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-
 
 @MicronautTest // <1>
 class PrototypeScopeTest(@Client("/") val httpClient: HttpClient) { // <2>

--- a/guides/micronaut-scope-types/kotlin/src/test/kotlin/example/micronaut/RefreshableScopeTest.kt
+++ b/guides/micronaut-scope-types/kotlin/src/test/kotlin/example/micronaut/RefreshableScopeTest.kt
@@ -1,5 +1,10 @@
-//tag::imports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//tag::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.core.type.Argument
@@ -11,7 +16,6 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-
 
 @Property(name = "endpoints.refresh.enabled", value = StringUtils.TRUE) // <1>
 @Property(name = "endpoints.refresh.sensitive", value = StringUtils.FALSE) // <2>

--- a/guides/micronaut-scope-types/kotlin/src/test/kotlin/example/micronaut/RequestScopeTest.kt
+++ b/guides/micronaut-scope-types/kotlin/src/test/kotlin/example/micronaut/RequestScopeTest.kt
@@ -1,5 +1,10 @@
-//tag::imports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//tag::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest

--- a/guides/micronaut-scope-types/kotlin/src/test/kotlin/example/micronaut/SingletonScopeTest.kt
+++ b/guides/micronaut-scope-types/kotlin/src/test/kotlin/example/micronaut/SingletonScopeTest.kt
@@ -1,5 +1,10 @@
-//tag::imports[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//tag::package[]
+*/
+//tag::imports[]
 
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest

--- a/guides/micronaut-scope-types/micronaut-scope-types.adoc
+++ b/guides/micronaut-scope-types/micronaut-scope-types.adoc
@@ -52,7 +52,7 @@ common:junit-params.adoc[]
 
 The following test verifies `@Singleton` behavior.
   
-test:SingletonScopeTest[tags=imports|testheader|test]
+test:SingletonScopeTest[tags=package|imports|testheader|test]
 callout:micronaut-test[1]
 callout:http-client[2]
 <3> The same instance fulfills both injection points at `RobotFather` and `RobotMother`. 
@@ -71,7 +71,7 @@ callout:prototype[1]
 
 The following test verifies the behavior of `Prototype` scope. 
 
-test:PrototypeScopeTest[tags=imports|testheader|test]
+test:PrototypeScopeTest[tags=package|imports|testheader|test]
 callout:micronaut-test[1]
 callout:http-client[2]
 <3> A new instance is created to fulfill each injection point. Two instances - one for `RobotFather` and another for `RobotMother`. 
@@ -89,7 +89,7 @@ callout:request-aware[2]
 
 The following test verifies the behavior of `@RequestScope` scope. 
 
-test:RequestScopeTest[tags=imports|test]
+test:RequestScopeTest[tags=package|imports|test]
 callout:micronaut-test[1]
 callout:http-client[2]
 <3> Both injection points, `RobotFather` and `RobotMother`, are fulfilled with the same instance of `Robot`. An instance associated with the HTTP Request. 
@@ -111,7 +111,7 @@ dependency:micronaut-management[]
 
 The following test enables the https://docs.micronaut.io/latest/guide/#refreshEndpoint[refresh endpoint] and verifies the behavior of `@Refreshable`
 
-test:RefreshableScopeTest[tags=imports|test]
+test:RefreshableScopeTest[tags=package|imports|test]
 callout:property[1]
 <2> The refresh endpoint is sensitive by default. To invoke it in the test, we set `endpoints.refresh.sensitive` to false.
 callout:micronaut-test[3]

--- a/guides/micronaut-security-jwt/groovy/src/main/groovy/example/micronaut/RefreshTokenEntity.groovy
+++ b/guides/micronaut-security-jwt/groovy/src/main/groovy/example/micronaut/RefreshTokenEntity.groovy
@@ -1,5 +1,10 @@
-//tag::clazzwithoutsettersandgetters[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//tag::package[]
+*/
+//tag::clazzwithoutsettersandgetters[]
 
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.NonNull

--- a/guides/micronaut-security-jwt/java/src/main/java/example/micronaut/RefreshTokenEntity.java
+++ b/guides/micronaut-security-jwt/java/src/main/java/example/micronaut/RefreshTokenEntity.java
@@ -1,5 +1,10 @@
-//tag::clazzwithoutsettersandgetters[]
 package example.micronaut;
+/*
+//tag::package[]
+package example.micronaut;
+//tag::package[]
+*/
+//tag::clazzwithoutsettersandgetters[]
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.data.annotation.DateCreated;

--- a/guides/micronaut-security-jwt/kotlin/src/main/kotlin/example/micronaut/RefreshTokenEntity.kt
+++ b/guides/micronaut-security-jwt/kotlin/src/main/kotlin/example/micronaut/RefreshTokenEntity.kt
@@ -1,5 +1,10 @@
-//tag::clazzwithoutsettersandgetters[]
 package example.micronaut
+/*
+//tag::package[]
+package example.micronaut
+//tag::package[]
+*/
+//tag::clazzwithoutsettersandgetters[]
 
 import io.micronaut.data.annotation.DateCreated
 import io.micronaut.data.annotation.GeneratedValue

--- a/guides/micronaut-security-jwt/micronaut-security-jwt.adoc
+++ b/guides/micronaut-security-jwt/micronaut-security-jwt.adoc
@@ -130,7 +130,7 @@ dependency:h2[groupId=com.h2database,scope=runtimeOnly,callout=4]
 
 Create an entity to save the issued Refresh Tokens.
 
-source:RefreshTokenEntity[tags=clazzwithoutsettersandgetters|endclass]
+source:RefreshTokenEntity[tags=package|clazzwithoutsettersandgetters|endclass]
 
 <1> Specifies the entity is mapped to the database
 <2> Specifies the ID of an entity

--- a/src/docs/common/snippets/common-license.adoc
+++ b/src/docs/common/snippets/common-license.adoc
@@ -1,0 +1,3 @@
+== License
+
+NOTE: All guides are released with an https://www.apache.org/licenses/LICENSE-2.0[Apache license 2.0 license] for the code and a https://creativecommons.org/licenses/by/4.0/deed.en[Creative Commons Attribution 4.0] license for the writing and media (images...).


### PR DESCRIPTION
Micronaut Guides was missing a License file. As discussed in the [Micronaut Foundation board of directors](https://micronaut.io/foundation/) mailing list, this PR adds a CC 4.0 License for writing and Apache 2.0 for code.

Moreover, it adds the [spotless plugin](https://github.com/diffplug/spotless) with an invisible feature to ensure the code contains the Apache 2.0 license.

I have created a separate PR, adding the license to the code in this repository.

This PR directly adds the license to the code from the starter generation.

The HTML does not show the Apache 2.0 License, but the downloadable sample application contains the license.

This PR includes the following copy at the of every guide:

> All guides are released with an Apache license 2.0 license for the code and a Creative Commons Attribution 4.0 license for the writing and media (images…​).

The site footer now says

> GUIDES ARE LICENSED UNDER CC BY 4.0 FOR THE WRITING AND MEDIA AND APACHE.2.0 FOR THE CODE

instead of: 

> © 2023 MICRONAUT FOUNDATION. ALL RIGHTS RESERVED