### PR TITLE
major: Switch to security-processor for Micronaut 5.0.0

### DIFF
--- a/guides/micronaut-token-propagation/micronaut-token-propagation.adoc
+++ b/guides/micronaut-token-propagation/micronaut-token-propagation.adoc
@@ -36,7 +36,7 @@ Add the security-jwt module to the configuration:
 
 :dependencies:
 
-dependency:micronaut-security-annotations[groupId=io.micronaut.security,scope=annotationProcessor]
+dependency:micronaut-security-processor[groupId=io.micronaut.security,scope=annotationProcessor]
 dependency:micronaut-security-jwt[groupId=io.micronaut.security]
 
 :dependencies:
@@ -116,7 +116,7 @@ Add the security-jwt module to the configuration:
 
 :dependencies:
 
-dependency:micronaut-security-annotations[groupId=io.micronaut.security,scope=annotationProcessor]
+dependency:micronaut-security-processor[groupId=io.micronaut.security,scope=annotationProcessor]
 dependency:micronaut-security-jwt[groupId=io.micronaut.security]
 
 :dependencies:


### PR DESCRIPTION
In https://github.com/micronaut-projects/micronaut-security/pull/1611 for Micronaut 5 we moved the JSR 250 annotation mappers to a new module.

This PR updates the guides that mention the micronaut-annotations annotation processor.