### PR TITLE
major: Update EclipseStore guide after processor module extraction

### DIFF
--- a/guides/micronaut-eclipsestore-persitence/micronaut-eclipsestore-persitence.adoc
+++ b/guides/micronaut-eclipsestore-persitence/micronaut-eclipsestore-persitence.adoc
@@ -15,9 +15,11 @@ The `eclipsestore` features adds the following dependencies:
 :dependencies:
 
 :exclude-for-languages:groovy
-dependency:micronaut-eclipsestore-annotations[groupId=io.micronaut.eclipsestore,scope=annotationProcessor]
+dependency:micronaut-eclipsestore-processor[groupId=io.micronaut.eclipsestore,scope=annotationProcessor]
 :exclude-for-languages:
-dependency:micronaut-eclipsestore-annotations[groupId=io.micronaut.eclipsestore]
+:exclude-for-languages:java,kotlin
+dependency:micronaut-eclipsestore-processor[groupId=io.micronaut.eclipsestore,scope=compileOnly]
+:exclude-for-languages:
 dependency:micronaut-eclipsestore[groupId=io.micronaut.eclipsestore]
 
 :dependencies:


### PR DESCRIPTION
The next Major of Micronaut has this change https://github.com/micronaut-projects/micronaut-eclipsestore/pull/15

This updates the guide to be correct