### PR TITLE
Rename isbn field for openapi-generator-server guide

### DIFF
--- a/guides/micronaut-openapi-generator-server/java/src/main/java/example/micronaut/controller/BooksController.java
+++ b/guides/micronaut-openapi-generator-server/java/src/main/java/example/micronaut/controller/BooksController.java
@@ -50,7 +50,7 @@ public class BooksController implements BooksApi {
         bookRepository.save(bookInfo.getName(), // <3>
                 bookInfo.getAvailability(),
                 bookInfo.getAuthor(),
-                bookInfo.getISBN());
+                bookInfo.getIsbn());
     }
     //end::addBook[]
 
@@ -68,7 +68,7 @@ public class BooksController implements BooksApi {
 
     private BookInfo map(BookEntity entity) {
         var book = new BookInfo(entity.name(), entity.availability());
-        book.setISBN(entity.isbn());
+        book.setIsbn(entity.isbn());
         book.setAuthor(entity.author());
         return book;
     }

--- a/guides/micronaut-openapi-generator-server/java/src/main/resources/library-definition.yml
+++ b/guides/micronaut-openapi-generator-server/java/src/main/resources/library-definition.yml
@@ -72,7 +72,7 @@ components:
         name: {type: string}
         availability: {$ref: "#/components/schemas/BookAvailability"} # <3>
         author: {type: string, minLength: 3}
-        ISBN: {type: string, pattern: "[0-9]{13}"}
+        isbn: {type: string, pattern: "[0-9]{13}"}
       required: ["name", "availability"]
     BookAvailability: # <4>
       type: string

--- a/guides/micronaut-openapi-generator-server/java/src/test/java/example/micronaut/controller/BooksControllerTest.java
+++ b/guides/micronaut-openapi-generator-server/java/src/test/java/example/micronaut/controller/BooksControllerTest.java
@@ -40,7 +40,7 @@ public class BooksControllerTest {
     void addBookClientApiTest() {
         var body = new BookInfo("Building Microservices", BookAvailability.AVAILABLE);
         body.setAuthor("Sam Newman");
-        body.setISBN("9781492034025");
+        body.setIsbn("9781492034025");
         var response = client.toBlocking()
                 .exchange(HttpRequest.POST("/add", body)); // <3>
         assertEquals(HttpStatus.OK, response.status()); // <4>

--- a/guides/micronaut-openapi-generator-server/java/src/test/java/example/micronaut/model/BookInfoTest.java
+++ b/guides/micronaut-openapi-generator-server/java/src/test/java/example/micronaut/model/BookInfoTest.java
@@ -84,15 +84,15 @@ public class BookInfoTest {
     @Test
     public void ISBNTest() {
         BookInfo bookInfo = new BookInfo("Alice's Adventures in Wonderland", BookAvailability.AVAILABLE)
-                .ISBN(null);
+                .isbn(null);
         assertTrue(validator.validate(bookInfo).isEmpty());
 
         bookInfo = new BookInfo("Alice's Adventures in Wonderland", BookAvailability.AVAILABLE)
-                .ISBN("9783161484100");
+                .isbn("9783161484100");
         assertTrue(validator.validate(bookInfo).isEmpty()); // <3>
 
         bookInfo = new BookInfo("Alice's Adventures in Wonderland", BookAvailability.AVAILABLE)
-                .ISBN("9783161 84100");
+                .isbn("9783161 84100");
         assertFalse(validator.validate(bookInfo).isEmpty()); // <4>
     }
     //end::otherProperties[]
@@ -106,7 +106,7 @@ public class BookInfoTest {
     public void bookInfoJsonSerialization() {
         BookInfo requiredBookInfo = new BookInfo("Alice's Adventures in Wonderland", BookAvailability.AVAILABLE)
                 .author("Lewis Carroll")
-                .ISBN("9783161484100");
+                .isbn("9783161484100");
 
         BookInfo bookInfo = httpClient.toBlocking().retrieve(HttpRequest.GET("/bookinfo"), BookInfo.class); // <5>
         assertEquals(requiredBookInfo, bookInfo);
@@ -120,7 +120,7 @@ public class BookInfoTest {
         BookInfo index() { // <4>
             return new BookInfo("Alice's Adventures in Wonderland", BookAvailability.AVAILABLE)
                     .author("Lewis Carroll")
-                    .ISBN("9783161484100");
+                    .isbn("9783161484100");
         }
     }
     //end::jsonSerialization[]


### PR DESCRIPTION
All caps generation with Gradle had an issue https://github.com/micronaut-projects/micronaut-openapi/pull/1472

Whilst that should fix it, this PR renames the guide again works for both build tools and 4.3.5-SNAPSHOT