### PR TITLE
corrections to micronaut-k8s guide

### DIFF
--- a/guides/micronaut-k8s/micronaut-k8s.adoc
+++ b/guides/micronaut-k8s/micronaut-k8s.adoc
@@ -47,7 +47,7 @@ mn @users:cli-command@          \
 
 common:build-lang-arguments.adoc[]
 
-If you use Micronaut Launch, select Micronaut Application as application type and add the `discovery-kubernetes`, `management`, `security`, `serialization-jackson`, `kubernetes` and `graalvm` features.
+If you use Micronaut Launch, select Micronaut Application as application type and add the `yaml`, `discovery-kubernetes`, `management`, `security`, `serialization-jackson`, `kubernetes` and `graalvm` features.
 
 The previous command creates a directory named _users_ containing Micronaut application with a package named `example.micronaut`.
 
@@ -209,7 +209,7 @@ example.micronaut.orders
 
 common:build-lang-arguments.adoc[]
 
-If you use Micronaut Launch, select Micronaut Application as application type and add the `discovery-kubernetes`, `management`, `security`, `serialization-jackson`, `kubernetes` and `graalvm` features.
+If you use Micronaut Launch, select Micronaut Application as application type and add the `yaml`, `discovery-kubernetes`, `management`, `security`, `serialization-jackson`, `kubernetes` and `graalvm` features.
 
 The previous command creates a directory named _orders_ containing a Micronaut application with a package named `example.micronaut`.
 
@@ -397,7 +397,7 @@ mn @api:cli-command@         \
 
 common:build-lang-arguments.adoc[]
 
-If you use Micronaut Launch, select Micronaut Application as application type and add the `discovery-kubernetes`, `management`, `kubernetes`, `serialization-jackson`, `mockito` and `graalvm` features.
+If you use Micronaut Launch, select Micronaut Application as application type and add the `yaml`, `discovery-kubernetes`, `management`, `kubernetes`, `serialization-jackson`, `mockito`, `graalvm` and `http-client` features.
 
 The previous command creates a directory named _api_ containing a Micronaut application with a package named `example.micronaut`.
 
@@ -454,7 +454,7 @@ callout:serdeable[1]
 
 Create a package named `clients` where you will put the HTTP Clients to call the `users` and `orders` microservices.
 
-Create a `UserClient` for the `users` microservice.
+Create a `UsersClient` for the `users` microservice.
 source:clients/UsersClient[app=api]
 callout:client[1]
 
@@ -595,7 +595,7 @@ external:micronaut-k8s/verify.adoc[]
 
 == Kubernetes and the Micronaut framework
 
-In this chapter we will first create the necessary Kubernetes resources for our microservices that will make them work properly then we will configure, build container images and deploy each of the microservices that we created on the local Kubernetes cluster.
+In this chapter we will first create the necessary Kubernetes resources for our microservices that will make them work properly then we will configure build container images and deploy each of the microservices that we created on the local Kubernetes cluster.
 
 Create a filed named _auth.yml_  that will service role for microservices that have secret configurations.
 


### PR DESCRIPTION
Some corrections to the micronaut-kubernetes guide:

- add 'yaml' to the list of Micronaut Launch features, as yaml files are used in the guide (the list of features for Micronaut CLI also contains 'yaml')
- add 'http-client' to the list of Micronaut Launch features for 'api' service (the list of features for Micronaut CLI also contains 'http-client', there is an error in the guide if 'http-client' is not included)