### PR TITLE
Re-enable tests for 4.4.1

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/openapi/AbstractOpenApiGeneratorFeature.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/openapi/AbstractOpenApiGeneratorFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2021 the original author or authors.
+ * Copyright 2003-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,12 @@
 package io.micronaut.guides.feature.openapi;
 
 import com.fizzed.rocker.RockerModel;
-import io.micronaut.core.version.SemanticVersion;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.PomDependencyVersionResolver;
 import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.template.RockerWritable;
-import io.micronaut.starter.util.VersionInfo;
 
 import java.util.Map;
 
@@ -62,10 +60,6 @@ public abstract class AbstractOpenApiGeneratorFeature implements Feature {
                     .extension(new RockerWritable(provideGradleModel()))
                     .build());
         } else {
-            if (!SemanticVersion.isAtLeast(VersionInfo.getMicronautVersion(), "4.4.1")) {
-                // temporary fix for openapi generator (until Micronaut 4.4.1 is out)
-                generatorContext.getBuildProperties().put("micronaut-maven-plugin.version", "4.5.3");
-            }
             generatorContext.getBuildProperties().putAll(provideMavenProperties());
         }
     }

--- a/guides/micronaut-object-storage-aws/metadata.json
+++ b/guides/micronaut-object-storage-aws/metadata.json
@@ -8,8 +8,6 @@
   "publicationDate": "2022-09-20",
   "languages": ["java"],
   "env": { "AWS_ACCESS_KEY_ID": "XXX", "AWS_SECRET_ACCESS_KEY": "YYY", "AWS_REGION": "us-east-1" },
-  "skipGradleTests": true,
-  "skipMavenTests": true,
   "apps": [
     {
       "name": "default",

--- a/guides/micronaut-object-storage-gcp/metadata.json
+++ b/guides/micronaut-object-storage-gcp/metadata.json
@@ -7,8 +7,6 @@
   "categories": ["Google Cloud", "Object Storage"],
   "publicationDate": "2022-10-07",
   "languages": ["java"],
-  "skipGradleTests": true,
-  "skipMavenTests": true,
   "apps": [
     {
       "name": "default",

--- a/guides/micronaut-object-storage-oracle-cloud/metadata.json
+++ b/guides/micronaut-object-storage-oracle-cloud/metadata.json
@@ -7,8 +7,6 @@
   "categories": ["Oracle Cloud", "Object Storage"],
   "publicationDate": "2022-09-26",
   "languages": ["java"],
-  "skipGradleTests": true,
-  "skipMavenTests": true,
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
For 4.4.0 we had to disable some tests and hard-code a maven plugin version.

Now we're on 4.4.1 we can revert these changes

See: https://github.com/micronaut-projects/micronaut-guides/pull/1449/files