### PR TITLE
Fix guide generation when tests skipped

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -335,7 +335,7 @@ class GuideProjectGenerator implements AutoCloseable {
         List<GuidesOption> guidesOptionList = []
 
         for (BuildTool buildTool : BuildTool.values()) {
-            if (buildTools.contains(buildTool.toString()) && !guideMetadata.shouldSkip(buildTool)) {
+            if (buildTools.contains(buildTool.toString())) {
                 for (Language language : Language.values()) {
                     if (guideMetadata.shouldSkip(buildTool, language)) {
                         LOG.info("Skipping index guide for $buildTool and $language")

--- a/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/TestScriptGenerator.groovy
@@ -142,6 +142,9 @@ kill_kotlin_daemon () {
                 String folder = GuideProjectGenerator.folderName(metadata.slug, guidesOption)
                 BuildTool buildTool = folder.contains(MAVEN.toString()) ? MAVEN : GRADLE
                 if (metadata.apps.any { it.name == DEFAULT_APP_NAME } ) {
+                    if (metadata.shouldSkip(buildTool)) {
+                        continue
+                    }
                     def defaultApp = metadata.apps.find { it.name == DEFAULT_APP_NAME }
                     if (!nativeTest || supportsNativeTest(defaultApp, guidesOption)) {
                         def features = defaultApp.getFeatures(guidesOption.language)


### PR DESCRIPTION
In https://github.com/micronaut-projects/micronaut-guides/pull/1459 we added the ability to totally skip a build tool/language.

This broke guides which are generated but their tests are skipped (as they require resource we don't have on CI).

Fixes #1462