### PR TITLE
docs: correct spelling for 'Controller'

### DIFF
--- a/guides/micronaut-produces-xml/micronaut-produces-xml.adoc
+++ b/guides/micronaut-produces-xml/micronaut-produces-xml.adoc
@@ -23,7 +23,7 @@ callout:introspected[1]
 <2> `@JacksonXmlRootElement` annotation defines the name of root element used for the root-level object when serialized.
 <3> `@JacksonXmlProperty` annotation provides XML-specific configuration for properties.
 
-=== Book Cotroller
+=== Book Controller
 Create a controller which returns a `Book` instance.
 
 source:BookController[]


### PR DESCRIPTION
## Summary of Issue
Part of section 4.3's title is misspelled in the guide for [Render XML in a Micronaut Controller](https://guides.micronaut.io/latest/micronaut-produces-xml.html). this exists in both the maven and gradle versions.

<details><summary>Screenshots</summary><br><ul>

![image](https://github.com/micronaut-projects/micronaut-guides/assets/62955101/4c78198e-e631-43b7-9596-95ebe08521ce)

![image](https://github.com/micronaut-projects/micronaut-guides/assets/62955101/654a8583-4638-4474-ac93-a8f0dd902c36)


</ul></details>

## Summary of Changes

Adding a single letter to a single file (`guides/micronaut-produces-xml/micronaut-produces-xml.adoc`) [fixes](https://github.com/micronaut-projects/micronaut-guides/pull/1466/commits/15956b457b0802b75ce93c56f71b8312dd003c68) this since these guides are generated w/ low duplication in mind. 

## Tests

I didn't add anything to any tests, but for the sake of due diligence I ran `gradlew MicronautProducesXmlBuild` per the main readme which was successful 

<details><summary>gradle output</summary>

```sh
------------------------------------------------------------------------------------------------------------------------
                        8.3s (4.4% of total time) in 97 GCs | Peak RSS: 10.63GB | CPU load: 9.94
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 /root/micronaut-guides/build/code/micronaut-produces-xml/micronaut-produces-xml-gradle-java/build/native/nativeTestCompile/default-tests (executable)
========================================================================================================================
Finished generating 'default-tests' in 3m 9s.
[native-image-plugin] Native Image written to: /root/micronaut-guides/build/code/micronaut-produces-xml/micronaut-produces-xml-gradle-java/build/native/nativeTestCompile

> Task :nativeTest
JUnit Platform on Native Image - report
----------------------------------------

01:35:32.012 [main] INFO  i.m.c.DefaultApplicationContext$RuntimeConfiguredEnvironment - Established active environments: [test]
01:35:32.048 [main] INFO  i.m.c.DefaultApplicationContext$RuntimeConfiguredEnvironment - Established active environments: [test]
01:35:32.063 [main] INFO  i.m.c.DefaultApplicationContext$RuntimeConfiguredEnvironment - Established active environments: [test]
example.micronaut.BookControllerTest > testXmlRendered(HttpClient) SUCCESSFUL

example.micronaut.DefaultTest > testItWorks() SUCCESSFUL

example.micronaut.HelloControllerTest > testHello() SUCCESSFUL


Test run finished after 73 ms
[         4 containers found      ]
[         0 containers skipped    ]
[         4 containers started    ]
[         0 containers aborted    ]
[         4 containers successful ]
[         0 containers failed     ]
[         3 tests found           ]
[         0 tests skipped         ]
[         3 tests started         ]
[         0 tests aborted         ]
[         3 tests successful      ]
[         0 tests failed          ]


BUILD SUCCESSFUL in 3m 11s
9 actionable tasks: 2 executed, 7 up-to-date

> Task :micronautProducesXmlRunTestScript
Running test script /root/micronaut-guides/build/code/micronaut-produces-xml/test.sh with environment [JAVA_HOME:/root/.sdkman/candidates/java/17.0.11-graal]
-------------------------------------------------
Executing 'micronaut-produces-xml-gradle-java' tests
Stopping shared test resources service (if created)
-------------------------------------------------
Executing 'micronaut-produces-xml-maven-java' tests
01:36:06.809 [main] INFO  i.m.c.DefaultApplicationContext$RuntimeConfiguredEnvironment - Established active environments: [test]
01:36:07.650 [main] INFO  i.m.c.DefaultApplicationContext$RuntimeConfiguredEnvironment - Established active environments: [test]
01:36:07.764 [main] INFO  i.m.c.DefaultApplicationContext$RuntimeConfiguredEnvironment - Established active environments: [test]
Stopping shared test resources service (if created)

> Task :asciidoctor
2024-05-30T01:36:20.340Z [main] WARN FilenoUtil : Native subprocess control requires open access to the JDK IO subsystem
Pass '--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED' to enable.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 4m 4s
21 actionable tasks: 6 executed, 1 from cache, 14 up-to-date
```

</details>