### PR TITLE
remove graalvm sections for Graalpy guides

### DIFF
--- a/guides/micronaut-graalpy-python-package/micronaut-graalpy-python-package.adoc
+++ b/guides/micronaut-graalpy-python-package/micronaut-graalpy-python-package.adoc
@@ -68,28 +68,6 @@ Open `http://localhost:8080/pygal` in a web browser of your choice execute the e
 
 image::graalpy-pygal.png[]
 
-:exclude-for-languages:groovy
-
-== GraalVM Native Executable
-
-:leveloffset: +1
-
-=== Native Executable metadata
-The https://www.graalvm.org/[GraalVM] Native Image compilation requires metadata to properly run code that uses https://www.graalvm.org/latest/reference-manual/native-image/metadata/#dynamic-proxy[dynamic proxies].
-
-For the case that also a native executable has to be generated, create a proxy configuration file:
-resource:META-INF/native-image/proxy-config.json[]
-
-common:graal-with-plugins.adoc[]
-
-Open `http://localhost:8080/pygal` in a web browser of your choice to execute the endpoint exposed by the native executable. You should see a stacked bar chart.
-
-common:nativetest.adoc[]
-
-:exclude-for-languages:
-
-:leveloffset: -1
-
 == Next steps
 
 Read more about https://micronaut-projects.github.io/micronaut-test/latest/guide/[Micronaut testing].

--- a/guides/micronaut-graalpy/micronaut-graalpy.adoc
+++ b/guides/micronaut-graalpy/micronaut-graalpy.adoc
@@ -56,40 +56,6 @@ callout:http-request[3]
 common:testApp.adoc[]
 common:runapp.adoc[]
 
-:exclude-for-languages:groovy
-
-== GraalVM Native Executable
-
-:leveloffset: +1
-
-=== Native Executable metadata
-The https://www.graalvm.org/[GraalVM] Native Image compilation requires metadata to properly run code that uses https://www.graalvm.org/latest/reference-manual/native-image/metadata/#dynamic-proxy[dynamic proxies].
-
-For the case that also a native executable has to be generated, create a proxy configuration file:
-resource:META-INF/native-image/proxy-config.json[]
-
-common:graal-with-plugins.adoc[]
-
-=== Invoke the Native Executable
-
-You can execute the endpoint exposed by the native executable:
-
-[source, bash]
-----
-curl localhost:8080/hello
-----
-
-[source]
-----
-Hello World
-----
-
-common:nativetest.adoc[]
-
-:exclude-for-languages:
-
-:leveloffset: -1
-
 == Next steps
 
 Read more about https://micronaut-projects.github.io/micronaut-graal-languages/latest/guide/[Micronaut Graalpy] integration.


### PR DESCRIPTION
This pull-request removes GraalVM Native image sections fro Graalpy guides.

It seems Virtual threads are not supported on native image with Truffle JIT compilation. And it seems, Micronaut is not able to disable virtual threads completely. I tried having controllers NOT annotated with `@ExecuteOn(BLOCKING)` or with `micronaut.executors.blocking.virtual=false` but got the same issues. 

```
% java --version
java 21.0.4 2024-07-16 LTS
Java(TM) SE Runtime Environment Oracle GraalVM 21.0.4+8.1 (build 21.0.4+8-LTS-jvmci-23.1-b41)
Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21.0.4+8.1 (build 21.0.4+8-LTS-jvmci-23.1-b41, mixed mode, sharing)
%./gradlew micronautGraalpyBuild
 cd build/code/micronaut-graalpy/micronaut-graalpy-maven-java
./mvnw package -Dpackaging=native-image
…
..
:
    5 native libraries: -framework CoreServices, -framework Foundation, dl, pthread, z

Error: Unsupported features in 2 methods
Detailed message:
Error: Error loading a referenced type: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported constructor jdk.internal.vm.Continuation.<init>(ContinuationScope, Runnable) is reachable: The declaring class of this element has been substituted, but this element is not present in the substitution class
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
Error encountered while parsing com.oracle.svm.core.code.FactoryMethodHolder.VirtualThread$VThreadContinuation_constructor_9b18764f800ca30fcd3432637d994dc67606e296(generated:0)
Parsing context:
   at java.lang.VirtualThread.<init>(VirtualThread.java:179)
   at com.oracle.svm.core.code.FactoryMethodHolder.VirtualThread_constructor_777a70ab45041e41aa8999a243277cc51a61143b(generated:0)
   at java.lang.ThreadBuilders$VirtualThreadFactory.newThread(ThreadBuilders.java:392)
   at ch.qos.logback.core.util.ExecutorServiceUtil$1.newThread(ExecutorServiceUtil.java:55)
   at java.util.concurrent.ThreadPoolExecutor$Worker.<init>(ThreadPoolExecutor.java:637)
   at com.oracle.svm.core.code.FactoryMethodHolder.ThreadPoolExecutor$Worker_constructor_cf4cc25806c8b3cd6b3398e442b1841849aa4298(generated:0)
   at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:928)
   at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1364)
   at jdk.internal.logger.BootstrapLogger$BootstrapExecutors.submit(BootstrapLogger.java:148)
   at jdk.internal.logger.BootstrapLogger$LogEvent.log(BootstrapLogger.java:454)
   at jdk.internal.logger.BootstrapLogger.flush(BootstrapLogger.java:551)
   at jdk.internal.logger.BootstrapLogger$LogEvent.log(BootstrapLogger.java:530)
   at jdk.internal.logger.BootstrapLogger$BootstrapExecutors.flush(BootstrapLogger.java:217)
   at jdk.internal.logger.BootstrapLogger.checkBootstrapping(BootstrapLogger.java:573)
   at jdk.internal.logger.BootstrapLogger.log(BootstrapLogger.java:656)
   at jdk.internal.logger.AbstractLoggerWrapper.log(AbstractLoggerWrapper.java:73)
   at sun.util.locale.provider.LocaleServiceProviderPool.getLocalizedObjectImpl(LocaleServiceProviderPool.java:289)
   at java.util.Currency.getSymbol(Currency.java:552)
   at java.text.DecimalFormatSymbols.initializeCurrency(DecimalFormatSymbols.java:891)
   at java.text.DecimalFormatSymbols.getInternationalCurrencySymbol(DecimalFormatSymbols.java:439)
   at java.text.DecimalFormat.expandAffix(DecimalFormat.java:3040)
   at java.text.DecimalFormat.expandAffixes(DecimalFormat.java:2998)
   at java.text.DecimalFormat.applyPattern(DecimalFormat.java:3674)
   at java.text.DecimalFormat.<init>(DecimalFormat.java:497)
   at com.oracle.svm.core.code.FactoryMethodHolder.DecimalFormat_constructor_d46d9d38931ba4d94da6fea9b9ca99b4e460b36b(generated:0)
   at java.util.Scanner.useLocale(Scanner.java:1295)
   at java.util.Scanner.<init>(Scanner.java:547)
   at java.util.Scanner.<init>(Scanner.java:558)
   at java.util.Scanner.<init>(Scanner.java:685)
   at java.util.Scanner.<init>(Scanner.java:679)
   at com.oracle.svm.core.code.FactoryMethodHolder.Scanner_constructor_23030a7591b0b0d34a34fc7893d1cf4c08309d72(generated:0)
   at java.net.InetAddress$HostsFileResolver.lookupByName(InetAddress.java:1334)
   at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1828)
   at java.net.InetAddress$NameServiceAddresses.get(InetAddress.java:1139)
   at java.net.InetAddress.getAllByName0(InetAddress.java:1818)
   at java.net.InetAddress.getAllByName(InetAddress.java:1688)
   at java.net.InetAddress.getByName(InetAddress.java:1568)
   at java.net.URL.getHostAddress(URL.java:995)
   at java.net.URLStreamHandler.getHostAddress(URLStreamHandler.java:447)
   at java.net.URLStreamHandler.hostsEqual(URLStreamHandler.java:460)
   at java.net.URLStreamHandler.sameFile(URLStreamHandler.java:431)
   at java.net.URLStreamHandler.equals(URLStreamHandler.java:352)
   at java.net.URL.equals(URL.java:1144)
   at java.util.HashMap.putVal(HashMap.java:654)
   at java.util.HashMap.put(HashMap.java:618)
   at com.oracle.svm.core.jdk.SystemPropertiesSupport.initializeLazyValue(SystemPropertiesSupport.java:238)
   at com.oracle.svm.core.jdk.SystemPropertiesSupport.getProperty(SystemPropertiesSupport.java:180)
   at com.oracle.svm.core.jdk.Target_java_lang_System.getProperty(JavaLangSubstitutions.java:478)
   at static root method.(Unknown Source)

Error: Error loading a referenced type: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported method jdk.internal.vm.Continuation.run() is reachable: The declaring class of this element has been substituted, but this element is not present in the substitution class
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
Error encountered while parsing java.lang.VirtualThread$$Lambda/0x0000007002c74f98.run(Unknown Source)
Parsing context:
   at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1423)
   at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
   at java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:667)
   at java.util.stream.ForEachOps$ForEachOp.evaluateParallel(ForEachOps.java:160)
   at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateParallel(ForEachOps.java:174)
   at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
   at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
   at java.lang.reflect.Executable.sharedToString(Executable.java:123)
   at java.lang.reflect.Method.toString(Method.java:416)
   at root method.(Unknown Source)

…
.
``