### PR TITLE
move graalvm as java and kotlin feature

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideAsciidocGenerator.groovy
@@ -246,9 +246,6 @@ class GuideAsciidocGenerator {
                                                String app) {
         App appEl = metadata.apps().find { it.name() == app }
         List<String> features = appEl ? GuideUtils.getAppVisibleFeatures(appEl, guidesOption.language) : []
-        if (guidesOption.language == GROOVY) {
-            features.remove 'graalvm'
-        }
         features
     }
 
@@ -605,10 +602,6 @@ class GuideAsciidocGenerator {
             excludedFeatureNames = []
         }
         featureNames.removeAll excludedFeatureNames
-
-        if (guidesOption.language == GROOVY) {
-            featureNames.remove 'graalvm'
-        }
         featureNames
     }
 

--- a/guides/creating-your-first-micronaut-app/metadata.json
+++ b/guides/creating-your-first-micronaut-app/metadata.json
@@ -9,7 +9,8 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm"]
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/hotwire-turbo-micronaut-chat/metadata.json
+++ b/guides/hotwire-turbo-micronaut-chat/metadata.json
@@ -9,12 +9,15 @@
   "apps": [
     {
       "name": "initial",
-      "features": ["yaml", "websocket", "views-thymeleaf", "data-jdbc", "flyway", "jdbc-hikari" ,"mysql", "graalvm", "junit-params", "serialization-jackson", "validation"]
+      "features": ["yaml", "websocket", "views-thymeleaf", "data-jdbc", "flyway", "jdbc-hikari" ,"mysql", "junit-params", "serialization-jackson", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "complete",
-      "features": ["yaml", "websocket", "views-thymeleaf","data-jdbc", "flyway", "jdbc-hikari" ,"mysql", "graalvm", "reactor", "junit-params", "serialization-jackson", "validation"],
-      "javaFeatures": [ "awaitility"]
+      "features": ["yaml", "websocket", "views-thymeleaf","data-jdbc", "flyway", "jdbc-hikari" ,"mysql", "reactor", "junit-params", "serialization-jackson", "validation"],
+      "kotlinFeatures": ["graalvm"],
+      "javaFeatures": [ "graalvm", "awaitility"]
     }
   ]
 }

--- a/guides/localized-message-source/metadata.json
+++ b/guides/localized-message-source/metadata.json
@@ -8,7 +8,8 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm"]
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-aws-secretsmanager/metadata.json
+++ b/guides/micronaut-aws-secretsmanager/metadata.json
@@ -10,8 +10,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "security-oauth2", "aws-secrets-manager"],
-      "javaFeatures": [ "localstack"]
+      "features": ["security-oauth2", "aws-secrets-manager"],
+      "javaFeatures": [ "graalvm", "localstack"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-azure-cloud/metadata.json
+++ b/guides/micronaut-azure-cloud/metadata.json
@@ -11,7 +11,8 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm"]
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-cache/metadata.json
+++ b/guides/micronaut-cache/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "graalvm","cache-caffeine","serialization-jackson"]
+      "features": ["yaml", "cache-caffeine","serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-configuration/metadata.json
+++ b/guides/micronaut-configuration/metadata.json
@@ -8,8 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "graalvm","serialization-jackson"],
-      "kotlinFeatures": ["kapt"]
+      "features": ["yaml", "serialization-jackson"],
+      "kotlinFeatures": ["graalvm", "kapt"],
+      "javaFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-cors/metadata.json
+++ b/guides/micronaut-cors/metadata.json
@@ -8,7 +8,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "graalvm"]
+      "features": ["yaml"]
     }
   ]
 }

--- a/guides/micronaut-cors/metadata.json
+++ b/guides/micronaut-cors/metadata.json
@@ -8,7 +8,8 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml"]
+      "features": ["yaml"],
+      "javaFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-creating-first-graal-app/metadata.json
+++ b/guides/micronaut-creating-first-graal-app/metadata.json
@@ -9,7 +9,8 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm"]
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-data-access-mybatis/metadata.json
+++ b/guides/micronaut-data-access-mybatis/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "flyway", "jdbc-hikari", "mybatis", "serialization-jackson", "validation"]
+      "features": ["flyway", "jdbc-hikari", "mybatis", "serialization-jackson", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-data-hibernate-reactive/metadata.json
+++ b/guides/micronaut-data-hibernate-reactive/metadata.json
@@ -10,7 +10,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "mysql", "graalvm", "data-hibernate-reactive", "reactor", "serialization-jackson", "awaitility", "validation"]
+      "features": ["yaml", "mysql", "data-hibernate-reactive", "reactor", "serialization-jackson", "awaitility", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-data-jdbc-repository/metadata.json
+++ b/guides/micronaut-data-jdbc-repository/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["data-jdbc", "flyway", "jdbc-hikari" ,"mysql", "graalvm", "serialization-jackson","validation"]
+      "features": ["data-jdbc", "flyway", "jdbc-hikari" ,"mysql", "serialization-jackson","validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-data-one-to-many/metadata.json
+++ b/guides/micronaut-data-one-to-many/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm","data-jdbc","liquibase","h2"]
+      "features": ["data-jdbc","liquibase","h2"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-data-r2dbc-repository/metadata.json
+++ b/guides/micronaut-data-r2dbc-repository/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["data-r2dbc", "flyway", "mysql", "test-resources", "graalvm", "jdbc-hikari", "serialization-jackson"]
+      "features": ["data-r2dbc", "flyway", "mysql", "test-resources", "jdbc-hikari", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-docker-image/metadata.json
+++ b/guides/micronaut-docker-image/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm","crac","micronaut-aot"]
+      "features": ["crac","micronaut-aot"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-email-amazon-ses/metadata.json
+++ b/guides/micronaut-email-amazon-ses/metadata.json
@@ -11,7 +11,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "email-amazon-ses", "aws-v2-sdk", "validation"]
+      "features": ["email-amazon-ses", "aws-v2-sdk", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-email-sendgrid/metadata.json
+++ b/guides/micronaut-email-sendgrid/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "email-sendgrid","validation"]
+      "features": ["email-sendgrid","validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-error-handling/metadata.json
+++ b/guides/micronaut-error-handling/metadata.json
@@ -10,7 +10,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "views-velocity", "geb", "serialization-jackson", "validation"]
+      "features": ["views-velocity", "geb", "serialization-jackson", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-file-download-excel/metadata.json
+++ b/guides/micronaut-file-download-excel/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "spreadsheet-builder", "views-thymeleaf","validation"]
+      "features": ["spreadsheet-builder", "views-thymeleaf","validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-flyway/metadata.json
+++ b/guides/micronaut-flyway/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm","data-jdbc","flyway","mysql", "management","jackson-databind","validation"]
+      "features": ["data-jdbc","flyway","mysql", "management","jackson-databind","validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-graalvm-native-image-google-cloud-platform-cloud-run/metadata.json
+++ b/guides/micronaut-graalvm-native-image-google-cloud-platform-cloud-run/metadata.json
@@ -11,7 +11,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["docker-push-native-gcr", "graalvm"]
+      "features": ["docker-push-native-gcr"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-graphql-todo/metadata.json
+++ b/guides/micronaut-graphql-todo/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graphql", "data-jdbc", "flyway", "postgres", "graalvm", "validation"]
+      "features": ["graphql", "data-jdbc", "flyway", "postgres", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-graphql/metadata.json
+++ b/guides/micronaut-graphql/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "graphql", "jackson-databind"]
+      "features": ["graphql", "jackson-databind"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-health-endpoint/metadata.json
+++ b/guides/micronaut-health-endpoint/metadata.json
@@ -10,7 +10,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["management", "graalvm"]
+      "features": ["management"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-http-client/metadata.json
+++ b/guides/micronaut-http-client/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["http-client", "graalvm"]
+      "features": ["http-client"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-java-records/metadata.json
+++ b/guides/micronaut-java-records/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "graalvm", "data-jdbc","liquibase","postgres","serialization-jackson", "validation"]
+      "features": ["yaml", "data-jdbc","liquibase","postgres","serialization-jackson", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-jaxrs-jdbc/metadata.json
+++ b/guides/micronaut-jaxrs-jdbc/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["jax-rs", "data-jdbc", "mysql", "flyway", "graalvm", "serialization-jackson", "validation"]
+      "features": ["jax-rs", "data-jdbc", "mysql", "flyway", "serialization-jackson", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-k8s/metadata.json
+++ b/guides/micronaut-k8s/metadata.json
@@ -9,17 +9,21 @@
   "apps": [
     {
       "name": "users",
-      "features": ["yaml","discovery-kubernetes", "management", "security", "kubernetes", "serialization-jackson", "graalvm","validation"]
+      "features": ["yaml","discovery-kubernetes", "management", "security", "kubernetes", "serialization-jackson", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "orders",
-      "features": ["yaml","discovery-kubernetes", "management", "security", "kubernetes", "serialization-jackson", "graalvm","validation"]
+      "features": ["yaml","discovery-kubernetes", "management", "security", "kubernetes", "serialization-jackson", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "api",
-      "features": ["yaml","discovery-kubernetes", "management", "kubernetes", "serialization-jackson", "graalvm", "http-client"],
-      "javaFeatures": ["mockito"],
-      "kotlinFeatures": ["mockito", "kapt"]
+      "features": ["yaml","discovery-kubernetes", "management", "kubernetes", "serialization-jackson", "http-client"],
+      "javaFeatures": ["mockito", "graalvm"],
+      "kotlinFeatures": ["mockito", "kapt", "graalvm"]
     }
   ]
 }

--- a/guides/micronaut-kafka/metadata.json
+++ b/guides/micronaut-kafka/metadata.json
@@ -9,13 +9,15 @@
   "apps": [
     {
       "name": "books",
-      "features": ["yaml", "graalvm", "kafka", "reactor"],
-      "javaFeatures": [ "awaitility"],
-      "kotlinFeatures": ["awaitility"]
+      "features": ["yaml", "kafka", "reactor"],
+      "javaFeatures": ["awaitility", "graalvm"],
+      "kotlinFeatures": ["awaitility", "graalvm"]
     },
     {
       "name": "analytics",
-      "features": ["yaml", "graalvm", "kafka"]
+      "features": ["yaml", "kafka"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-kotlin-extension-fns/metadata.json
+++ b/guides/micronaut-kotlin-extension-fns/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["kotlin-extension-functions", "reactor", "graalvm", "http-client"]
+      "features": ["kotlin-extension-functions", "reactor", "http-client"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-liquibase/metadata.json
+++ b/guides/micronaut-liquibase/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm","data-jdbc","liquibase","postgres","management","validation"]
+      "features": ["data-jdbc","liquibase","postgres","management","validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-metrics/metadata.json
+++ b/guides/micronaut-metrics/metadata.json
@@ -7,6 +7,8 @@
   "publicationDate": "2022-08-01",
   "apps": [{
     "name": "default",
-    "features": ["micrometer-annotation", "data-jdbc", "flyway", "graalvm","validation","http-client"]
+    "features": ["micrometer-annotation", "data-jdbc", "flyway", "validation","http-client"],
+    "javaFeatures": ["graalvm"],
+    "kotlinFeatures": ["graalvm"]
   }]
 }

--- a/guides/micronaut-microservices-distributed-tracing-zipkin/metadata.json
+++ b/guides/micronaut-microservices-distributed-tracing-zipkin/metadata.json
@@ -8,15 +8,21 @@
   "apps": [
     {
       "name": "bookcatalogue",
-      "features": ["yaml", "tracing-zipkin", "management", "graalvm", "validation"]
+      "features": ["yaml", "tracing-zipkin", "management", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookinventory",
-      "features": ["yaml", "tracing-zipkin", "management", "graalvm", "validation"]
+      "features": ["yaml", "tracing-zipkin", "management", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookrecommendation",
-      "features": ["yaml", "tracing-zipkin", "management", "graalvm", "reactor", "validation", "retry", "http-client"]
+      "features": ["yaml", "tracing-zipkin", "management", "reactor", "validation", "retry", "http-client"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-microservices-services-discover-consul/metadata.json
+++ b/guides/micronaut-microservices-services-discover-consul/metadata.json
@@ -8,15 +8,21 @@
   "apps": [
     {
       "name": "bookcatalogue",
-      "features": ["yaml","discovery-consul", "management", "graalvm", "serialization-jackson"]
+      "features": ["yaml","discovery-consul", "management", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookinventory",
-      "features": ["yaml","discovery-consul", "management", "graalvm", "serialization-jackson"]
+      "features": ["yaml","discovery-consul", "management", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookrecommendation",
-      "features": ["yaml","discovery-consul", "management", "graalvm", "reactor", "serialization-jackson","http-client","retry"]
+      "features": ["yaml","discovery-consul", "management", "reactor", "serialization-jackson","http-client","retry"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-microservices-services-discover-eureka/metadata.json
+++ b/guides/micronaut-microservices-services-discover-eureka/metadata.json
@@ -8,15 +8,21 @@
   "apps": [
     {
       "name": "bookcatalogue",
-      "features": ["yaml","discovery-eureka", "graalvm", "serialization-jackson"]
+      "features": ["yaml","discovery-eureka", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookinventory",
-      "features": ["yaml","discovery-eureka", "graalvm", "serialization-jackson"]
+      "features": ["yaml","discovery-eureka", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookrecommendation",
-      "features": ["yaml","discovery-eureka", "graalvm", "reactor", "serialization-jackson","http-client","retry"]
+      "features": ["yaml","discovery-eureka", "reactor", "serialization-jackson","http-client","retry"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-mongodb-asynchronous/metadata.json
+++ b/guides/micronaut-mongodb-asynchronous/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml","mongo-reactive","reactor", "graalvm","serialization-bson", "serialization-jackson"]
+      "features": ["yaml","mongo-reactive","reactor", "serialization-bson", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-mongodb-synchronous/metadata.json
+++ b/guides/micronaut-mongodb-synchronous/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "mongo-sync", "graalvm", "serialization-bson", "serialization-jackson"]
+      "features": ["yaml", "mongo-sync", "serialization-bson", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-mqtt/metadata.json
+++ b/guides/micronaut-mqtt/metadata.json
@@ -9,16 +9,16 @@
     {
       "applicationType": "messaging",
       "name": "app",
-      "features": ["yaml","graalvm", "mqtt"],
-      "javaFeatures": [ "awaitility"],
-      "kotlinFeatures": [ "awaitility"]
+      "features": ["yaml", "mqtt"],
+      "javaFeatures": [ "graalvm", "awaitility"],
+      "kotlinFeatures": [ "graalvm", "awaitility"]
     },
     {
       "applicationType": "cli",
       "name": "cli",
-      "features": ["yaml","graalvm", "mqtt"],
-      "javaFeatures": [ "awaitility"],
-      "kotlinFeatures": [ "awaitility", "kapt"]
+      "features": ["yaml", "mqtt"],
+      "javaFeatures": [ "graalvm", "awaitility"],
+      "kotlinFeatures": [ "graalvm", "awaitility", "kapt"]
     }
   ]
 }

--- a/guides/micronaut-oauth2-auth0/metadata.json
+++ b/guides/micronaut-oauth2-auth0/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml","graalvm", "views-thymeleaf", "security-jwt", "security-oauth2"]
+      "features": ["yaml", "views-thymeleaf", "security-jwt", "security-oauth2"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oauth2-client-credentials-auth0/metadata.json
+++ b/guides/micronaut-oauth2-client-credentials-auth0/metadata.json
@@ -8,15 +8,21 @@
   "apps": [
     {
       "name": "bookcatalogue",
-      "features": ["yaml","security-jwt", "security-oauth2", "management", "graalvm", "serialization-jackson"]
+      "features": ["yaml","security-jwt", "security-oauth2", "management", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookinventory",
-      "features": ["yaml","security-jwt", "security-oauth2", "management", "graalvm", "serialization-jackson"]
+      "features": ["yaml","security-jwt", "security-oauth2", "management", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookrecommendation",
-      "features": ["yaml","security-jwt", "security-oauth2", "management", "graalvm", "reactor", "serialization-jackson","retry","http-client"]
+      "features": ["yaml","security-jwt", "security-oauth2", "management", "reactor", "serialization-jackson","retry","http-client"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oauth2-client-credentials-cognito/metadata.json
+++ b/guides/micronaut-oauth2-client-credentials-cognito/metadata.json
@@ -9,15 +9,21 @@
   "apps": [
     {
       "name": "bookcatalogue",
-      "features": ["yaml","security-jwt", "security-oauth2", "management", "graalvm", "serialization-jackson"]
+      "features": ["yaml","security-jwt", "security-oauth2", "management", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookinventory",
-      "features": ["yaml","security-jwt", "security-oauth2", "management", "graalvm", "serialization-jackson"]
+      "features": ["yaml","security-jwt", "security-oauth2", "management", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookrecommendation",
-      "features": ["yaml","security-jwt", "security-oauth2", "management", "graalvm", "reactor", "serialization-jackson","retry","http-client"]
+      "features": ["yaml","security-jwt", "security-oauth2", "management", "reactor", "serialization-jackson","retry","http-client"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oauth2-cognito/metadata.json
+++ b/guides/micronaut-oauth2-cognito/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml","graalvm", "views-thymeleaf", "security-jwt", "security-oauth2"]
+      "features": ["yaml", "views-thymeleaf", "security-jwt", "security-oauth2"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oauth2-github/metadata.json
+++ b/guides/micronaut-oauth2-github/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml","views-thymeleaf", "security-oauth2", "security-jwt", "reactor", "graalvm", "serialization-jackson","http-client"]
+      "features": ["yaml","views-thymeleaf", "security-oauth2", "security-jwt", "reactor", "serialization-jackson","http-client"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oauth2-keycloak/metadata.json
+++ b/guides/micronaut-oauth2-keycloak/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml","graalvm", "views-thymeleaf", "security-jwt", "security-oauth2"]
+      "features": ["yaml", "views-thymeleaf", "security-jwt", "security-oauth2"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oauth2-linkedin/metadata.json
+++ b/guides/micronaut-oauth2-linkedin/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml","security-oauth2", "security-jwt", "views-thymeleaf", "reactor", "graalvm", "serialization-jackson","http-client"]
+      "features": ["yaml","security-oauth2", "security-jwt", "views-thymeleaf", "reactor", "serialization-jackson","http-client"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oauth2-oidc-google/metadata.json
+++ b/guides/micronaut-oauth2-oidc-google/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml","graalvm", "views-thymeleaf", "security-jwt", "security-oauth2"]
+      "features": ["yaml", "views-thymeleaf", "security-jwt", "security-oauth2"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oauth2-oidc-strava/metadata.json
+++ b/guides/micronaut-oauth2-oidc-strava/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml","graalvm", "views-thymeleaf", "security-jwt", "security-oauth2"]
+      "features": ["yaml", "views-thymeleaf", "security-jwt", "security-oauth2"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oauth2-okta/metadata.json
+++ b/guides/micronaut-oauth2-okta/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "views-thymeleaf", "security-jwt", "security-oauth2"]
+      "features": ["views-thymeleaf", "security-jwt", "security-oauth2"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-object-storage-aws/metadata.json
+++ b/guides/micronaut-object-storage-aws/metadata.json
@@ -12,7 +12,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["object-storage-aws", "graalvm"],
+      "features": ["object-storage-aws"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"],
       "invisibleFeatures": ["localstack"]
     }
   ]

--- a/guides/micronaut-object-storage-gcp/metadata.json
+++ b/guides/micronaut-object-storage-gcp/metadata.json
@@ -11,7 +11,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["object-storage-gcp", "graalvm"],
+      "features": ["object-storage-gcp"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"],
       "invisibleFeatures": ["testcontainers"]
     }
   ]

--- a/guides/micronaut-object-storage-oracle-cloud/metadata.json
+++ b/guides/micronaut-object-storage-oracle-cloud/metadata.json
@@ -11,7 +11,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["object-storage-oracle-cloud", "graalvm"],
+      "features": ["object-storage-oracle-cloud"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"],
       "invisibleFeatures": ["testcontainers"]
     }
   ]

--- a/guides/micronaut-openapi-generator-server/metadata.json
+++ b/guides/micronaut-openapi-generator-server/metadata.json
@@ -29,13 +29,14 @@
         "data-jdbc",
         "flyway",
         "jdbc-hikari",
-        "postgres",
-        "graalvm"
+        "postgres"
       ],
       "invisibleFeatures": [
         "openapi-generator-server",
         "swagger-annotations"
-      ]
+      ],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oracle-autonomous-db/metadata.json
+++ b/guides/micronaut-oracle-autonomous-db/metadata.json
@@ -12,6 +12,8 @@
     {
       "excludeTest": ["DefaultTest"],
       "name": "default",
-      "features": ["data-jdbc", "flyway", "graalvm", "http-client", "oracle-cloud-atp"]
+      "features": ["data-jdbc", "flyway", "http-client", "oracle-cloud-atp"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
   }]
 }

--- a/guides/micronaut-oracle-cloud-streaming/metadata.json
+++ b/guides/micronaut-oracle-cloud-streaming/metadata.json
@@ -10,15 +10,15 @@
   "apps": [
     {
       "name": "chess-game",
-      "features": ["yaml","graalvm", "kafka", "reactor", "testcontainers", "testcontainers-kafka", "validation"],
-      "javaFeatures": [ "awaitility"],
-      "kotlinFeatures": [ "awaitility"]
+      "features": ["yaml", "kafka", "reactor", "testcontainers", "testcontainers-kafka", "validation"],
+      "javaFeatures": [ "graalvm", "awaitility"],
+      "kotlinFeatures": [ "graalvm", "awaitility"]
     },
     {
       "name": "chess-listener",
-      "features": ["yaml","graalvm", "kafka", "data-jdbc", "flyway", "oracle-cloud-atp", "reactor", "testcontainers", "testcontainers-kafka", "testcontainers-oracle-xe"],
-      "javaFeatures": [ "awaitility"],
-      "kotlinFeatures": [ "awaitility"]
+      "features": ["yaml", "kafka", "data-jdbc", "flyway", "oracle-cloud-atp", "reactor", "testcontainers", "testcontainers-kafka", "testcontainers-oracle-xe"],
+      "javaFeatures": [ "graalvm", "awaitility"],
+      "kotlinFeatures": [ "graalvm", "awaitility"]
     }
   ]
 }

--- a/guides/micronaut-oracle-cloud/metadata.json
+++ b/guides/micronaut-oracle-cloud/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm"]
+      "features": [],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oracle-function-http/metadata.json
+++ b/guides/micronaut-oracle-function-http/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "oracle-function", "oracle-cloud-sdk", "oci-java-sdk-core"]
+      "features": ["oracle-function", "oracle-cloud-sdk", "oci-java-sdk-core"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-oracle-function/metadata.json
+++ b/guides/micronaut-oracle-function/metadata.json
@@ -11,7 +11,9 @@
     {
       "applicationType": "function",
       "name": "default",
-      "features": ["graalvm", "oracle-function"]
+      "features": ["oracle-function"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-rabbitmq-rpc/metadata.json
+++ b/guides/micronaut-rabbitmq-rpc/metadata.json
@@ -8,15 +8,21 @@
   "apps": [
     {
       "name": "bookcatalogue",
-      "features": ["yaml", "rabbitmq", "graalvm", "serialization-jackson"]
+      "features": ["yaml", "rabbitmq", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookinventory",
-      "features": ["yaml", "rabbitmq", "graalvm", "serialization-jackson","validation"]
+      "features": ["yaml", "rabbitmq", "serialization-jackson","validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "bookrecommendation",
-      "features": ["yaml", "rabbitmq", "graalvm", "reactor", "serialization-jackson"]
+      "features": ["yaml", "rabbitmq", "reactor", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-rabbitmq/metadata.json
+++ b/guides/micronaut-rabbitmq/metadata.json
@@ -8,12 +8,15 @@
   "apps": [
     {
       "name": "books",
-      "features": ["yaml", "graalvm", "rabbitmq", "mockito", "reactor", "serialization-jackson"],
-      "kotlinFeatures": ["kapt"]
+      "features": ["yaml", "rabbitmq", "mockito", "reactor", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm", "kapt"]
     },
     {
       "name": "analytics",
-      "features": ["yaml", "graalvm", "rabbitmq", "serialization-jackson"]
+      "features": ["yaml", "rabbitmq", "serialization-jackson"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-rest-assured/metadata.json
+++ b/guides/micronaut-rest-assured/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm", "micronaut-test-rest-assured"]
+      "features": ["micronaut-test-rest-assured"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-scheduled/metadata.json
+++ b/guides/micronaut-scheduled/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["graalvm"]
+      "features": [],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-security-api-key/metadata.json
+++ b/guides/micronaut-security-api-key/metadata.json
@@ -10,7 +10,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "security", "graalvm"]
+      "features": ["yaml", "security"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-security-basicauth/metadata.json
+++ b/guides/micronaut-security-basicauth/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["security", "graalvm"]
+      "features": ["security"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-security-jwt-cookie/metadata.json
+++ b/guides/micronaut-security-jwt-cookie/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "security-jwt", "graalvm", "views-velocity", "geb"]
+      "features": ["yaml", "security-jwt", "views-velocity", "geb"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-security-jwt/metadata.json
+++ b/guides/micronaut-security-jwt/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["security-jwt", "data-jdbc", "reactor", "graalvm", "validation"]
+      "features": ["security-jwt", "data-jdbc", "reactor", "validation"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-security-keys-jwks/metadata.json
+++ b/guides/micronaut-security-keys-jwks/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "security-jwt", "graalvm", "management"]
+      "features": ["yaml", "security-jwt", "management"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-security-session/metadata.json
+++ b/guides/micronaut-security-session/metadata.json
@@ -9,7 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "security-session", "graalvm", "views-velocity", "geb", "reactor"]
+      "features": ["yaml", "security-session", "views-velocity", "geb", "reactor"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-security-x509/metadata.json
+++ b/guides/micronaut-security-x509/metadata.json
@@ -20,7 +20,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "security", "graalvm", "reactor"]
+      "features": ["yaml", "security", "reactor"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm/metadata.json
+++ b/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm/metadata.json
@@ -12,7 +12,9 @@
     {
       "applicationType": "function",
       "name": "default",
-      "features": ["graalvm","aws-lambda"]
+      "features": ["aws-lambda"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-token-propagation/metadata.json
+++ b/guides/micronaut-token-propagation/metadata.json
@@ -8,19 +8,27 @@
   "apps": [
     {
       "name": "intermediate-gateway",
-      "features": ["yaml", "graalvm", "security-jwt",  "reactor", "management", "http-client"]
+      "features": ["yaml", "security-jwt",  "reactor", "management", "http-client"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "intermediate-userecho",
-      "features": ["yaml", "graalvm", "security-jwt", "reactor", "management"]
+      "features": ["yaml", "security-jwt", "reactor", "management"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "gateway",
-      "features": ["yaml", "graalvm", "security-jwt", "reactor",  "management", "http-client"]
+      "features": ["yaml", "security-jwt", "reactor",  "management", "http-client"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     },
     {
       "name": "userecho",
-      "features": ["yaml", "graalvm", "security-jwt", "reactor", "management"]
+      "features": ["yaml", "security-jwt", "reactor", "management"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-views-thymeleaf/metadata.json
+++ b/guides/micronaut-views-thymeleaf/metadata.json
@@ -8,7 +8,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["views-thymeleaf", "http-client", "graalvm"]
+      "features": ["views-thymeleaf", "http-client"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/micronaut-websocket/metadata.json
+++ b/guides/micronaut-websocket/metadata.json
@@ -9,8 +9,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["yaml", "websocket", "validation", "graalvm", "reactor"],
-      "javaFeatures": [ "awaitility"]
+      "features": ["yaml", "websocket", "validation", "reactor"],
+      "javaFeatures": ["awaitility", "graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/mn-application-aws-lambda-graalvm/metadata.json
+++ b/guides/mn-application-aws-lambda-graalvm/metadata.json
@@ -11,7 +11,9 @@
   "apps": [
     {
       "name": "default",
-      "features": ["aws-lambda", "graalvm"]
+      "features": ["aws-lambda"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }

--- a/guides/mn-serverless-function-aws-lambda-graalvm/metadata.json
+++ b/guides/mn-serverless-function-aws-lambda-graalvm/metadata.json
@@ -2,7 +2,7 @@
   "title": "Deploy a Micronaut function as a GraalVM Native Executable to AWS Lambda",
   "intro": "Learn how to distribute a Micronaut function built as a GraalVM Native executable to AWS Lambda Custom Runtime",
   "authors": ["Sergio del Amo"],
-  "tags": ["lambda", "function", "graalvm"],
+  "tags": ["lambda", "function"],
   "cloud": "AWS",
   "categories": ["AWS Lambda", "GraalVM"],
   "languages": ["java", "kotlin"],
@@ -13,7 +13,9 @@
     {
       "applicationType": "function",
       "name": "default",
-      "features": ["graalvm","aws-lambda"]
+      "features": ["aws-lambda"],
+      "javaFeatures": ["graalvm"],
+      "kotlinFeatures": ["graalvm"]
     }
   ]
 }


### PR DESCRIPTION
I have moved the `graalvm` feature to `javaFeatures` and `kotlinFeatures`. This way, we don't have to do a workaround in the java/groovy code to remove unsupported features by Groovy. 