### PR TITLE
[GR-60327] Extend Graal guide with steps how to pass additional arguments to `native-image` build process. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ common:next.adoc[]
 
 TODO or a personalised guide for the guide:
 
-== Next steps
+== Next Steps
 
 TODO: link to the documentation modules you used in the guide
 

--- a/buildSrc/src/test/resources/adding-commit-info-gradle-java-expected.html
+++ b/buildSrc/src/test/resources/adding-commit-info-gradle-java-expected.html
@@ -1044,7 +1044,7 @@ configured in <code>resource-config.json</code>:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="next-steps">13. Next steps</h2>
+<h2 id="next-steps">13. Next Steps</h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Explore more features with <a href="https://micronaut.io/guides/">Micronaut Guides</a>.</p>

--- a/buildSrc/src/test/resources/adding-commit-info-gradle-java-expected.html
+++ b/buildSrc/src/test/resources/adding-commit-info-gradle-java-expected.html
@@ -543,11 +543,11 @@ table.CodeRay td.code{padding:0 0 0 .75em}
 <li><a href="#running-the-application">11. Running the Application</a></li>
 <li><a href="#generate-a-micronaut-application-native-executable-with-graalvm">12. Generate a Micronaut Application Native Executable with GraalVM</a>
 <ul class="sectlevel2">
-<li><a href="#graalvm-installation">12.1. GraalVM installation</a></li>
-<li><a href="#native-executable-generation">12.2. Native executable generation</a></li>
+<li><a href="#graalvm-installation">12.1. GraalVM Installation</a></li>
+<li><a href="#native-executable-generation">12.2. Native Executable Generation</a></li>
 </ul>
 </li>
-<li><a href="#next-steps">13. Next steps</a></li>
+<li><a href="#next-steps">13. Next Steps</a></li>
 <li><a href="#help-with-the-micronaut-framework">14. Help with the Micronaut Framework</a></li>
 <li><a href="#license">15. License</a></li>
 </ul>
@@ -893,10 +893,10 @@ git commit -am &quot;Initial project&quot;</code></pre>
 <h2 id="generate-a-micronaut-application-native-executable-with-graalvm">12. Generate a Micronaut Application Native Executable with GraalVM</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>We will use <a href="https://www.graalvm.org/">GraalVM</a>, the polyglot embeddable virtual machine, to generate a native executable of our Micronaut application.</p>
+<p>We will use <a href="https://www.graalvm.org/">GraalVM</a>, an advanced JDK with ahead-of-time Native Image compilation, to generate a native executable of this Micronaut application.</p>
 </div>
 <div class="paragraph">
-<p>Compiling native executables ahead of time with GraalVM improves startup time and reduces the memory footprint of JVM-based applications.</p>
+<p>Compiling Micronaut applications ahead of time with GraalVM significantly improves startup time and reduces the memory footprint of JVM-based applications.</p>
 </div>
 <div class="admonitionblock note">
 <table>
@@ -911,24 +911,24 @@ Only Java and Kotlin projects support using GraalVM&#8217;s <code>native-image</
 </table>
 </div>
 <div class="sect2">
-<h3 id="graalvm-installation">12.1. GraalVM installation</h3>
+<h3 id="graalvm-installation">12.1. GraalVM Installation</h3>
 <div class="paragraph">
-<p>The easiest way to install <a href="https://www.graalvm.org">GraalVM</a> on Linux or Mac is to use <a href="https://sdkman.io/">SDKMan.io</a>.</p>
+<p>The easiest way to install <a href="https://www.graalvm.org">GraalVM</a> on Linux or Mac is to use <a href="https://sdkman.io/">SDKMAN!</a>.</p>
 </div>
 <div class="listingblock">
-<div class="title">Java 17</div>
+<div class="title">Java 21</div>
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="bash">sdk install java 17.0.12-graal</code></pre>
+<pre class="CodeRay highlight"><code data-lang="bash">sdk install java 21.0.5-graal</code></pre>
 </div>
 </div>
 <div class="listingblock">
-<div class="title">Java 17</div>
+<div class="title">Java 21</div>
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="bash">sdk use java 17.0.12-graal</code></pre>
+<pre class="CodeRay highlight"><code data-lang="bash">sdk use java 21.0.5-graal</code></pre>
 </div>
 </div>
 <div class="paragraph">
-<p>For installation on Windows, or for manual installation on Linux or Mac, see the <a href="https://www.graalvm.org/latest/docs/getting-started/">GraalVM Getting Started</a> documentation.</p>
+<p>For installation on Windows, or for a manual installation on Linux or Mac, see the <a href="https://www.graalvm.org/latest/docs/getting-started/">GraalVM Getting Started</a> documentation.</p>
 </div>
 <div class="paragraph">
 <p>The previous command installs Oracle GraalVM, which is free to use in production and free to redistribute, at no cost, under the <a href="https://www.oracle.com/downloads/licenses/graal-free-license.html">GraalVM Free Terms and Conditions</a>.</p>
@@ -937,20 +937,20 @@ Only Java and Kotlin projects support using GraalVM&#8217;s <code>native-image</
 <p>Alternatively, you can use the <a href="https://github.com/graalvm/graalvm-ce-builds/releases/">GraalVM Community Edition</a>:</p>
 </div>
 <div class="listingblock">
-<div class="title">Java 17</div>
+<div class="title">Java 21</div>
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="bash">sdk install java 17.0.9-graalce</code></pre>
+<pre class="CodeRay highlight"><code data-lang="bash">sdk install java 21.0.5-graalce</code></pre>
 </div>
 </div>
 <div class="listingblock">
-<div class="title">Java 17</div>
+<div class="title">Java 21</div>
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="bash">sdk use java 17.0.9-graalce</code></pre>
+<pre class="CodeRay highlight"><code data-lang="bash">sdk use java 21.0.5-graalce</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="native-executable-generation">12.2. Native executable generation</h3>
+<h3 id="native-executable-generation">12.2. Native Executable Generation</h3>
 <div class="paragraph">
 <p>To generate a native executable using Gradle, run:</p>
 </div>
@@ -972,7 +972,7 @@ Only Java and Kotlin projects support using GraalVM&#8217;s <code>native-image</
     binaries {
         main {
             imageName.set(<span class="string"><span class="delimiter">'</span><span class="content">mn-graalvm-application</span><span class="delimiter">'</span></span>) <i class="conum" data-value="1"></i><b>(1)</b>
-            buildArgs.add(<span class="string"><span class="delimiter">'</span><span class="content">--verbose</span><span class="delimiter">'</span></span>) <i class="conum" data-value="2"></i><b>(2)</b>
+            buildArgs.add(<span class="string"><span class="delimiter">'</span><span class="content">-Ob</span><span class="delimiter">'</span></span>) <i class="conum" data-value="2"></i><b>(2)</b>
         }
     }
 }</code></pre>
@@ -986,7 +986,7 @@ Only Java and Kotlin projects support using GraalVM&#8217;s <code>native-image</
 </tr>
 <tr>
 <td><i class="conum" data-value="2"></i><b>2</b></td>
-<td>It is possible to pass extra arguments to build the native executable</td>
+<td>It is possible to pass extra build arguments to <code>native-image</code>. For example, <code>-Ob</code> enables the quick build mode.</td>
 </tr>
 </table>
 </div>

--- a/buildSrc/src/test/resources/adding-commit-info-gradle-java.adoc
+++ b/buildSrc/src/test/resources/adding-commit-info-gradle-java.adoc
@@ -203,53 +203,50 @@ To run the application, use the `./gradlew run` command, which starts the applic
 
 == Generate a Micronaut Application Native Executable with GraalVM
 
-We will use https://www.graalvm.org/[GraalVM], the polyglot embeddable virtual machine, to generate a native executable of our Micronaut application.
+We will use https://www.graalvm.org/[GraalVM], an advanced JDK with ahead-of-time Native Image compilation, to generate a native executable of this Micronaut application.
 
-Compiling native executables ahead of time with GraalVM improves startup time and reduces the memory footprint of JVM-based applications.
+Compiling Micronaut applications ahead of time with GraalVM significantly improves startup time and reduces the memory footprint of JVM-based applications.
 
 NOTE: Only Java and Kotlin projects support using GraalVM's `native-image` tool. Groovy relies heavily on reflection, which is only partially supported by GraalVM.
 
-=== GraalVM installation
+=== GraalVM Installation
 
 // Start: src/docs/common/snippets/common-install-graalvm-sdkman.adoc
-The easiest way to install https://www.graalvm.org[GraalVM] on Linux or Mac is to use https://sdkman.io/[SDKMan.io].
+The easiest way to install https://www.graalvm.org[GraalVM] on Linux or Mac is to use https://sdkman.io/[SDKMAN!].
 
 [source, bash]
-.Java 17
+.Java 21
 ----
-sdk install java 17.0.12-graal
+sdk install java 21.0.5-graal
 ----
 
 [source, bash]
-.Java 17
+.Java 21
 ----
-sdk use java 17.0.12-graal
+sdk use java 21.0.5-graal
 ----
 
 For installation on Windows, or for manual installation on Linux or Mac, see the https://www.graalvm.org/latest/docs/getting-started/[GraalVM Getting Started] documentation.
-
 
 The previous command installs Oracle GraalVM, which is free to use in production and free to redistribute, at no cost, under the https://www.oracle.com/downloads/licenses/graal-free-license.html[GraalVM Free Terms and Conditions].
 
 Alternatively, you can use the https://github.com/graalvm/graalvm-ce-builds/releases/[GraalVM Community Edition]:
 
 [source, bash]
-.Java 17
+.Java 21
 ----
-sdk install java 17.0.9-graalce
+sdk install java 21.0.5-graalce
 ----
 
 [source, bash]
-.Java 17
+.Java 21
 ----
-sdk use java 17.0.9-graalce
+sdk use java 21.0.5-graalce
 ----
-
 
 // End: src/docs/common/snippets/common-install-graalvm-sdkman.adoc
 
-=== Native executable generation
-
+=== Native Executable Generation
 
 To generate a native executable using Gradle, run:
 
@@ -269,18 +266,15 @@ graalvmNative {
     binaries {
         main {
             imageName.set('mn-graalvm-application') // <1>
-            buildArgs.add('--verbose') // <2>
+            buildArgs.add('-Ob') // <2>
         }
     }
 }
 ----
 <1> The native executable name will now be `mn-graalvm-application`
-<2> It is possible to pass extra arguments to build the native executable
-
-
+<2> It is possible to pass extra build arguments to `native-image`. For example, `-Ob` enables the quick build mode.
 
 // End: src/docs/common/snippets/common-graal-with-plugins.adoc
-
 
 Annotate the `Application` class with `@Introspected`. This won't be necessary in a real world application because there
 will be Micronaut beans defined (something annotated with `@Singleton`, `@Controller`,...), but for this case we need to

--- a/buildSrc/src/test/resources/adding-commit-info-gradle-java.adoc
+++ b/buildSrc/src/test/resources/adding-commit-info-gradle-java.adoc
@@ -226,7 +226,7 @@ sdk install java 21.0.5-graal
 sdk use java 21.0.5-graal
 ----
 
-For installation on Windows, or for manual installation on Linux or Mac, see the https://www.graalvm.org/latest/docs/getting-started/[GraalVM Getting Started] documentation.
+For installation on Windows, or for a manual installation on Linux or Mac, see the https://www.graalvm.org/latest/docs/getting-started/[GraalVM Getting Started] documentation.
 
 The previous command installs Oracle GraalVM, which is free to use in production and free to redistribute, at no cost, under the https://www.oracle.com/downloads/licenses/graal-free-license.html[GraalVM Free Terms and Conditions].
 

--- a/buildSrc/src/test/resources/adding-commit-info-gradle-java.adoc
+++ b/buildSrc/src/test/resources/adding-commit-info-gradle-java.adoc
@@ -310,7 +310,7 @@ curl localhost:8080/info
 
 
 // Start: src/docs/common/snippets/common-next.adoc
-== Next steps
+== Next Steps
 
 Explore more features with https://micronaut.io/guides/[Micronaut Guides].
 // End: src/docs/common/snippets/common-next.adoc

--- a/buildSrc/src/test/resources/guides/creating-your-first-micronaut-app/creating-your-first-micronaut-app.adoc
+++ b/buildSrc/src/test/resources/guides/creating-your-first-micronaut-app/creating-your-first-micronaut-app.adoc
@@ -38,7 +38,7 @@ Hello World
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-test/latest/guide/[Micronaut testing].
 

--- a/guides/creating-your-first-micronaut-app/creating-your-first-micronaut-app.adoc
+++ b/guides/creating-your-first-micronaut-app/creating-your-first-micronaut-app.adoc
@@ -38,7 +38,7 @@ Hello World
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-test/latest/guide/[Micronaut testing].
 

--- a/guides/micronaut-aws-parameter-store/micronaut-aws-parameter-store.adoc
+++ b/guides/micronaut-aws-parameter-store/micronaut-aws-parameter-store.adoc
@@ -231,7 +231,7 @@ Run the application, and you should be able to execute this curl request and see
 curl -i localhost:8080/vat
 ----
 
-== Next steps
+== Next Steps
 
 Read about Micronaut https://micronaut-projects.github.io/micronaut-aws/latest/guide/#parametersStore[AWS Parameter Store] integration.
 

--- a/guides/micronaut-azure-http-functions/micronaut-azure-http-functions.adoc
+++ b/guides/micronaut-azure-http-functions/micronaut-azure-http-functions.adoc
@@ -187,7 +187,7 @@ HTTP/1.1 200 OK
 Example Response
 ----
 
-== Next steps
+== Next Steps
 
 Read more about:
 

--- a/guides/micronaut-cache/micronaut-cache.adoc
+++ b/guides/micronaut-cache/micronaut-cache.adoc
@@ -88,7 +88,7 @@ curl localhost:8080/NOVEMBER
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read about Micronaut https://docs.micronaut.io/latest/guide/#caching[Cache Advice].
 Moreover, check the https://micronaut-projects.github.io/micronaut-cache/latest/guide/[Micronaut Cache] project for more information.

--- a/guides/micronaut-cli-jwkgen/micronaut-cli-jwkgen.adoc
+++ b/guides/micronaut-cli-jwkgen/micronaut-cli-jwkgen.adoc
@@ -107,7 +107,7 @@ Generates a Json Web Key (JWT) with RS256 algorithm.
 
 common:graal-with-plugins.adoc[]
 
-== Next steps
+== Next Steps
 
 Read https://picocli.info[Picocli] documentation.
 

--- a/guides/micronaut-cloud-database-azure/micronaut-cloud-database-azure.adoc
+++ b/guides/micronaut-cloud-database-azure/micronaut-cloud-database-azure.adoc
@@ -179,7 +179,7 @@ When you are finished using the database, you can https://docs.microsoft.com/en-
 az group delete -n $AZURE_RESOURCE_GROUP
 ----
 
-== Next steps
+== Next Steps
 
 external:micronaut-cloud-database-base/end.adoc[]
 

--- a/guides/micronaut-cloud-database-oracle/micronaut-cloud-database-oracle.adoc
+++ b/guides/micronaut-cloud-database-oracle/micronaut-cloud-database-oracle.adoc
@@ -477,7 +477,7 @@ and run this to list the genres:
 curl <public IP address>:8080/genres/list
 ----
 
-== Next steps
+== Next Steps
 
 When you are finished using the database you can https://docs.oracle.com/en-us/iaas/tools/oci-cli/latest/oci_cli_docs/cmdref/mysql/db-system/delete.html[delete it using the CLI]. Run
 

--- a/guides/micronaut-configuration/micronaut-configuration.adoc
+++ b/guides/micronaut-configuration/micronaut-configuration.adoc
@@ -129,7 +129,7 @@ curl http://localhost:8080/my/team
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Visit https://docs.micronaut.io/latest/guide/#config[Micronaut Application Configuration] to learn more.
 

--- a/guides/micronaut-crac-google-cloud-platform-cloud-run/micronaut-crac-google-cloud-platform-cloud-run.adoc
+++ b/guides/micronaut-crac-google-cloud-platform-cloud-run/micronaut-crac-google-cloud-platform-cloud-run.adoc
@@ -95,7 +95,7 @@ common:gcloud-run-services-delete[]
 
 common:gcloud-delete-project[]
 
-== Next steps
+== Next Steps
 
 Read more about:
 

--- a/guides/micronaut-creating-first-graal-app/micronaut-creating-first-graal-app.adoc
+++ b/guides/micronaut-creating-first-graal-app/micronaut-creating-first-graal-app.adoc
@@ -39,13 +39,13 @@ callout:get[arg0=index,arg1=/random]
 
 common:graal-with-plugins.adoc[]
 
-=== Creating native executable inside Docker
+=== Creating a Native Executable Inside Docker
 
 The output following this approach is a Docker image that runs the native executable of your application. You don't need to install any additional dependencies.
 
 :exclude-for-build:maven
 
-.Building GraalVM native executable
+.Building a GraalVM native executable with Gradle
 [source,bash]
 ----
 ./gradlew dockerBuildNative
@@ -55,7 +55,7 @@ The output following this approach is a Docker image that runs the native execut
 
 :exclude-for-build:gradle
 
-.Building GraalVM native executable with Maven
+.Building a GraalVM native executable with Maven
 [source,bash]
 ----
 ./mvnw package -Dpackaging=docker-native
@@ -65,7 +65,7 @@ The output following this approach is a Docker image that runs the native execut
 
 :exclude-for-languages:
 
-=== Running the native executable
+=== Running the Native Executable
 
 Execute the application by either running the executable or starting the Docker container.
 
@@ -77,7 +77,7 @@ Execute the application by either running the executable or starting the Docker 
 
 We can see that the application starts in only 12ms.
 
-=== Sending a request
+=== Sending a Request
 
 Start the application either using Docker or the native executable. You can run a few cURL requests to test the application:
 
@@ -109,7 +109,7 @@ sys     0m0.004s
 
 == Next steps
 
-Read more about https://docs.micronaut.io/latest/guide/#graal[GraalVM Support] inside the Micronaut framework.
+Read more about https://docs.micronaut.io/latest/guide/#graal[Micronaut support for GraalVM].
 
 Take a look at the https://github.com/micronaut-projects/micronaut-gradle-plugin[Micronaut Gradle plugin] and https://micronaut-projects.github.io/micronaut-maven-plugin/latest/[Micronaut Maven Plugin] documentation.
 

--- a/guides/micronaut-creating-first-graal-app/micronaut-creating-first-graal-app.adoc
+++ b/guides/micronaut-creating-first-graal-app/micronaut-creating-first-graal-app.adoc
@@ -107,7 +107,7 @@ user    0m0.005s
 sys     0m0.004s
 ----
 
-== Next steps
+== Next Steps
 
 Read more about https://docs.micronaut.io/latest/guide/#graal[Micronaut support for GraalVM].
 

--- a/guides/micronaut-data-hibernate-reactive/micronaut-data-hibernate-reactive.adoc
+++ b/guides/micronaut-data-hibernate-reactive/micronaut-data-hibernate-reactive.adoc
@@ -147,7 +147,7 @@ curl -X "POST" "http://localhost:8080/genres" \
      -d $'{ "name": "music" }'
 ----
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-data/latest/guide/#hibernateReactive[Micronaut Data Hibernate Reactive].
 

--- a/guides/micronaut-data-jdbc-repository/micronaut-data-jdbc-repository.adoc
+++ b/guides/micronaut-data-jdbc-repository/micronaut-data-jdbc-repository.adoc
@@ -130,7 +130,7 @@ curl localhost:8080/genres/list
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-data/latest/guide/[Micronaut Data].
 

--- a/guides/micronaut-data-r2dbc-repository/micronaut-data-r2dbc-repository.adoc
+++ b/guides/micronaut-data-r2dbc-repository/micronaut-data-r2dbc-repository.adoc
@@ -133,7 +133,7 @@ curl localhost:8080/genres/list
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about:
 

--- a/guides/micronaut-dependency-injection-types/micronaut-dependency-injection-types.adoc
+++ b/guides/micronaut-dependency-injection-types/micronaut-dependency-injection-types.adoc
@@ -69,9 +69,9 @@ Constructor injection helps you easily identify if your bean depends on too many
 **Testing**
 
 Constructor injection simplifies writing both unit and integration tests. The constructor forces us to provide valid objects for all dependencies. 
-Thus, it decreases the chance of a NullPointerException occurrence during testing. 
+Thus, it decreases the chance of a NullPointerException occurrence during testing.
 
-== Next steps
+== Next Steps
 
 Read more about https://docs.micronaut.io/latest/guide/#ioc[Micronaut Inversion of Control] capabilities.
 

--- a/guides/micronaut-google-cloud-compute/micronaut-google-cloud-compute.adoc
+++ b/guides/micronaut-google-cloud-compute/micronaut-google-cloud-compute.adoc
@@ -145,7 +145,7 @@ gcloud compute instances stop guide-micronaut-jdbc-compute
 
 common:gcp-project-cleanup.adoc[]
 
-== Next steps
+== Next Steps
 
 Read more about:
 

--- a/guides/micronaut-google-cloud-platform-cloud-run/micronaut-google-cloud-platform-cloud-run.adoc
+++ b/guides/micronaut-google-cloud-platform-cloud-run/micronaut-google-cloud-platform-cloud-run.adoc
@@ -75,7 +75,7 @@ common:gcloud-run-services-delete[]
 
 common:gcloud-delete-project[]
 
-== Next steps
+== Next Steps
 
 You will probably want to deploy to Google Cloud Run from your CI server. https://launch.micronaut.io[Micronaut Launch] contains feature https://micronaut.io/launch?type=DEFAULT&name=demo&package=com.example&javaVersion=JDK_21&lang=JAVA&build=GRADLE&test=JUNIT&features=github-workflow-google-cloud-run&version=3.0.3[github-workflow-google-cloud-run], which adds a https://github.com/features/actions[GitHub Actions] Workflow that deploys an application to Google Cloud Run from Google Container Registry.
 

--- a/guides/micronaut-graalpy-python-package/micronaut-graalpy-python-package.adoc
+++ b/guides/micronaut-graalpy-python-package/micronaut-graalpy-python-package.adoc
@@ -70,7 +70,7 @@ Open `http://localhost:8080/pygal` in a web browser of your choice execute the e
 
 image::graalpy-pygal.png[]
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-test/latest/guide/[Micronaut testing].
 

--- a/guides/micronaut-graalpy/micronaut-graalpy.adoc
+++ b/guides/micronaut-graalpy/micronaut-graalpy.adoc
@@ -56,7 +56,7 @@ callout:http-request[]
 common:testApp.adoc[]
 common:runapp.adoc[]
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-graal-languages/latest/guide/[Micronaut Graalpy] integration.
 

--- a/guides/micronaut-graalvm-native-image-google-cloud-platform-cloud-run/micronaut-graalvm-native-image-google-cloud-platform-cloud-run.adoc
+++ b/guides/micronaut-graalvm-native-image-google-cloud-platform-cloud-run/micronaut-graalvm-native-image-google-cloud-platform-cloud-run.adoc
@@ -79,7 +79,7 @@ common:gcloud-run-services-delete[]
 
 common:gcloud-delete-project[]
 
-== Next steps
+== Next Steps
 
 You will probably want to deploy to Google Cloud Run from your CI server. https://launch.micronaut.io[Micronaut Launch] contains feature https://micronaut.io/launch?type=DEFAULT&features=github-workflow-google-cloud-run-graalvm[github-workflow-google-cloud-run-graalvm], which adds a https://github.com/features/actions[GitHub Actions] Workflow that deploys a GraalVM Native executable of a Micronaut application to Google Cloud Run from Google Container Registry.
 

--- a/guides/micronaut-graalvm-reflection/micronaut-graalvm-reflection.adoc
+++ b/guides/micronaut-graalvm-reflection/micronaut-graalvm-reflection.adoc
@@ -196,7 +196,7 @@ callout:reflective-access[]
 
 If you execute the <<native-tests, Native Tests>> again, they will pass.
 
-== Next steps
+== Next Steps
 
 Learn more about:
 

--- a/guides/micronaut-graphql-todo/micronaut-graphql-todo.adoc
+++ b/guides/micronaut-graphql-todo/micronaut-graphql-todo.adoc
@@ -327,7 +327,7 @@ execute the queries.
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Take a look at the https://micronaut-projects.github.io/micronaut-graphql/latest/guide/[Micronaut GraphQL documentation].
 

--- a/guides/micronaut-graphql/micronaut-graphql.adoc
+++ b/guides/micronaut-graphql/micronaut-graphql.adoc
@@ -194,7 +194,7 @@ execute the queries.
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Take a look at the https://micronaut-projects.github.io/micronaut-graphql/latest/guide/[Micronaut GraphQL documentation].
 

--- a/guides/micronaut-health-endpoint/micronaut-health-endpoint.adoc
+++ b/guides/micronaut-health-endpoint/micronaut-health-endpoint.adoc
@@ -77,7 +77,7 @@ curl localhost:8080/health
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Visit https://docs.micronaut.io/latest/guide/#management[Micronaut Management & Monitoring] to learn more.
 

--- a/guides/micronaut-hibernate-reactive/micronaut-hibernate-reactive.adoc
+++ b/guides/micronaut-hibernate-reactive/micronaut-hibernate-reactive.adoc
@@ -163,7 +163,7 @@ curl -X "POST" "http://localhost:8080/genres" \
      -d $'{ "name": "music" }'
 ----
 
-== Next steps
+== Next Steps
 
 Read more about https://docs.micronaut.io/latest/guide/#dataAccess[Configurations for Data Access] section in the Micronaut documentation.
 

--- a/guides/micronaut-http-client/micronaut-http-client.adoc
+++ b/guides/micronaut-http-client/micronaut-http-client.adoc
@@ -201,7 +201,7 @@ If you run again the tests, you will see the that the Filter is invoked and HTTP
 
 common:graal-with-plugins.adoc[]
 
-== Next steps
+== Next Steps
 
 Visit https://docs.micronaut.io/latest/guide/#httpClient[Micronaut HTTP Client documentation] to learn more.
 

--- a/guides/micronaut-jaxrs-jdbc/micronaut-jaxrs-jdbc.adoc
+++ b/guides/micronaut-jaxrs-jdbc/micronaut-jaxrs-jdbc.adoc
@@ -162,7 +162,7 @@ HTTP/1.1 200 OK
 
 common:application-prod-datasource.adoc[]
 
-== Next steps
+== Next Steps
 
 Read more about:
 

--- a/guides/micronaut-jpa-hibernate/micronaut-jpa-hibernate.adoc
+++ b/guides/micronaut-jpa-hibernate/micronaut-jpa-hibernate.adoc
@@ -194,7 +194,7 @@ curl -X "POST" "http://localhost:8080/genres" \
      -d $'{ "name": "music" }'
 ----
 
-== Next steps
+== Next Steps
 
 Read more about https://docs.micronaut.io/latest/guide/#dataAccess[Configurations for Data Access] section in the Micronaut documentation.
 

--- a/guides/micronaut-json-schema/micronaut-json-schema.adoc
+++ b/guides/micronaut-json-schema/micronaut-json-schema.adoc
@@ -57,6 +57,6 @@ common:json-assert.adoc[]
 
 common:testApp.adoc[]
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-json-schema/latest/guide/[Micronaut JSON Schema] and https://json-schema.org[JSON Schema].

--- a/guides/micronaut-k8s/micronaut-k8s.adoc
+++ b/guides/micronaut-k8s/micronaut-k8s.adoc
@@ -766,7 +766,7 @@ To delete all resources that were created in this guide run next command.
 kubectl delete namespaces micronaut-k8s
 ----
 
-== Next steps
+== Next Steps
 
 Read more about https://kubernetes.io/docs/home/[Kubernetes].
 

--- a/guides/micronaut-kafka/micronaut-kafka.adoc
+++ b/guides/micronaut-kafka/micronaut-kafka.adoc
@@ -426,7 +426,7 @@ Start the native executables for the two microservices and run the same `curl` r
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-kafka/latest/guide/[Kafka support] in Micronaut framework.
 

--- a/guides/micronaut-kotlin-extension-fns/micronaut-kotlin-extension-fns.adoc
+++ b/guides/micronaut-kotlin-extension-fns/micronaut-kotlin-extension-fns.adoc
@@ -152,7 +152,7 @@ curl localhost:8080/dadJokes/dogJokes`
 
 Hopefully it brings a smile to your day!
 
-== Next steps
+== Next Steps
 
 See all the useful libraries for Micronaut Kotlin developers in the https://micronaut-projects.github.io/micronaut-kotlin/latest/guide/#extensionFunctions[Micronaut Kotlin documentation].
 

--- a/guides/micronaut-metrics/end.adoc
+++ b/guides/micronaut-metrics/end.adoc
@@ -1,3 +1,3 @@
-== Next steps
+== Next Steps
 
 In combination with the `/metrics` endpoint, you often want to register a specific type of reporter. See the https://micronaut-projects.github.io/micronaut-micrometer/latest/guide/[Micronaut Micrometer documentation] to learn about the supported libraries for reporting metrics.

--- a/guides/micronaut-microservices-distributed-tracing-xray/micronaut-microservices-distributed-tracing-xray.adoc
+++ b/guides/micronaut-microservices-distributed-tracing-xray/micronaut-microservices-distributed-tracing-xray.adoc
@@ -192,7 +192,7 @@ In the previous image, you can see that:
 
 Moreover, you can see the requests to `bookinventory` are made in parallel.
 
-== Next steps
+== Next Steps
 
 As you have seen in this guide, you get distributed tracing up and running fast with the Micronaut framework without any annotations.
 

--- a/guides/micronaut-microservices-services-discover-consul/micronaut-microservices-services-discover-consul.adoc
+++ b/guides/micronaut-microservices-services-discover-consul/micronaut-microservices-services-discover-consul.adoc
@@ -540,7 +540,7 @@ Start the native executables for the three microservices and run the same `curl`
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about https://docs.micronaut.io/latest/guide/#distributedConfigurationConsul[Consul support] in the Micronaut framework.
 

--- a/guides/micronaut-microservices-services-discover-eureka/micronaut-microservices-services-discover-eureka.adoc
+++ b/guides/micronaut-microservices-services-discover-eureka/micronaut-microservices-services-discover-eureka.adoc
@@ -570,7 +570,7 @@ Start the native executables for the three microservices and run the same `curl`
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about https://docs.micronaut.io/latest/guide/#serviceDiscoveryEureka[Eureka Support] in the Micronaut framework.
 

--- a/guides/micronaut-mqtt/micronaut-mqtt.adoc
+++ b/guides/micronaut-mqtt/micronaut-mqtt.adoc
@@ -155,7 +155,7 @@ Generate GraalVM native executables for both the CLI and the messaging applicati
 :exclude-for-languages:
 
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-mqtt/latest/guide/[Micronaut MQTT].
 

--- a/guides/micronaut-oauth2-auth0/micronaut-oauth2-auth0.adoc
+++ b/guides/micronaut-oauth2-auth0/micronaut-oauth2-auth0.adoc
@@ -111,7 +111,7 @@ After you execute the native executable, navigate to localhost:8080 and authenti
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth[Micronaut OAuth 2.0 documentation] to learn more.
 

--- a/guides/micronaut-oauth2-client-credentials-auth0/micronaut-oauth2-client-credentials-auth0.adoc
+++ b/guides/micronaut-oauth2-client-credentials-auth0/micronaut-oauth2-client-credentials-auth0.adoc
@@ -231,7 +231,7 @@ curl http://localhost:8080/books
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth[Micronaut OAuth 2.0 Documentation] to learn more.
 

--- a/guides/micronaut-oauth2-client-credentials-cognito/micronaut-oauth2-client-credentials-cognito.adoc
+++ b/guides/micronaut-oauth2-client-credentials-cognito/micronaut-oauth2-client-credentials-cognito.adoc
@@ -231,7 +231,7 @@ curl http://localhost:8080/books
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth[Micronaut OAuth 2.0 Documentation] to learn more.
 

--- a/guides/micronaut-oauth2-cognito/micronaut-oauth2-cognito.adoc
+++ b/guides/micronaut-oauth2-cognito/micronaut-oauth2-cognito.adoc
@@ -105,7 +105,7 @@ aws cognito-idp delete-user-pool-client --client-id $OAUTH_CLIENT_ID --user-pool
 aws cognito-idp delete-user-pool --user-pool-id $COGNITO_POOL_ID
 ----
 
-== Next steps
+== Next Steps
 
 Read https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth[Micronaut OAuth 2.0 documentation] to learn more.
 

--- a/guides/micronaut-oauth2-github/micronaut-oauth2-github.adoc
+++ b/guides/micronaut-oauth2-github/micronaut-oauth2-github.adoc
@@ -144,7 +144,7 @@ Visit localhost:8080 and authenticate with GitHub
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth[Micronaut OAuth 2.0 documentation] to learn more.
 

--- a/guides/micronaut-oauth2-keycloak/micronaut-oauth2-keycloak.adoc
+++ b/guides/micronaut-oauth2-keycloak/micronaut-oauth2-keycloak.adoc
@@ -135,7 +135,7 @@ After you execute the native image, navigate to localhost:8081 and authenticate 
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth[Micronaut OAuth 2.0 documentation] to learn more.
 

--- a/guides/micronaut-oauth2-linkedin/micronaut-oauth2-linkedin.adoc
+++ b/guides/micronaut-oauth2-linkedin/micronaut-oauth2-linkedin.adoc
@@ -131,7 +131,7 @@ Visit localhost:8080 and authenticate with LinkedIn
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth[Micronaut OAuth 2.0 documentation^] to learn more.
 

--- a/guides/micronaut-oauth2-oidc-google/micronaut-oauth2-oidc-google.adoc
+++ b/guides/micronaut-oauth2-oidc-google/micronaut-oauth2-oidc-google.adoc
@@ -124,7 +124,7 @@ After you execute the native executable, navigate to localhost:8080 and authenti
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth[Micronaut OAuth 2.0 documentation] to learn more.
 

--- a/guides/micronaut-oauth2-oidc-strava/micronaut-oauth2-oidc-strava.adoc
+++ b/guides/micronaut-oauth2-oidc-strava/micronaut-oauth2-oidc-strava.adoc
@@ -124,7 +124,7 @@ After you execute the native executable, navigate to localhost:8080 and authenti
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth[Micronaut OAuth 2.0 documentation] to learn more.
 

--- a/guides/micronaut-oauth2-okta/micronaut-oauth2-okta.adoc
+++ b/guides/micronaut-oauth2-okta/micronaut-oauth2-okta.adoc
@@ -97,7 +97,7 @@ After you execute the native executable, navigate to localhost:8080 and authenti
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read https://micronaut-projects.github.io/micronaut-security/latest/guide/#oauth[Micronaut OAuth 2.0 documentation] to learn more.
 

--- a/guides/micronaut-openapi-generator-server/micronaut-openapi-generator-server.adoc
+++ b/guides/micronaut-openapi-generator-server/micronaut-openapi-generator-server.adoc
@@ -486,7 +486,7 @@ All the tests should run successfully.
 
 common:graal-with-plugins.adoc[]
 
-== Next steps
+== Next Steps
 
 === Learn More
 

--- a/guides/micronaut-oracle-cloud-streaming/micronaut-oracle-cloud-streaming.adoc
+++ b/guides/micronaut-oracle-cloud-streaming/micronaut-oracle-cloud-streaming.adoc
@@ -737,7 +737,7 @@ Now you can scp each native executable to a Compute instance with no Java instal
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-kafka/latest/guide/[Kafka support] in the Micronaut framework.
 

--- a/guides/micronaut-oracle-email-delivery/micronaut-oracle-email-delivery.adoc
+++ b/guides/micronaut-oracle-email-delivery/micronaut-oracle-email-delivery.adoc
@@ -337,7 +337,7 @@ curl -X POST \
 common:graal-with-plugins.adoc[]
 
 
-== Next steps
+== Next Steps
 
 Read more about the https://micronaut-projects.github.io/micronaut-email/latest/guide/[Micronaut Email] project.
 

--- a/guides/micronaut-rabbitmq/micronaut-rabbitmq.adoc
+++ b/guides/micronaut-rabbitmq/micronaut-rabbitmq.adoc
@@ -419,6 +419,6 @@ Start the native executables for the two microservices and run the same `curl` r
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-rabbitmq/latest/guide/[RabbitMQ support] in the Micronaut framework.

--- a/guides/micronaut-security-api-key/micronaut-security-api-key.adoc
+++ b/guides/micronaut-security-api-key/micronaut-security-api-key.adoc
@@ -119,7 +119,7 @@ curl -i --header "Accept: text/plain" --header "X-API-KEY: FOOBAR" localhost:808
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 See the https://micronaut-projects.github.io/micronaut-security/latest/guide/[Micronaut security documentation] to learn more.
 

--- a/guides/micronaut-security-basicauth/micronaut-security-basicauth.adoc
+++ b/guides/micronaut-security-basicauth/micronaut-security-basicauth.adoc
@@ -102,7 +102,7 @@ curl "http://localhost:8080" -u 'sherlock:password'
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 See the https://micronaut-projects.github.io/micronaut-security/latest/guide/[Micronaut security documentation] to learn more.
 

--- a/guides/micronaut-security-jwt/micronaut-security-jwt.adoc
+++ b/guides/micronaut-security-jwt/micronaut-security-jwt.adoc
@@ -230,7 +230,7 @@ Send the same `curl` request as before to test that the native executable applic
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Learn more about JWT Authentication in the https://micronaut-projects.github.io/micronaut-security/latest/guide/#jwt[official documentation].
 

--- a/guides/micronaut-spring-boot/micronaut-spring-boot.adoc
+++ b/guides/micronaut-spring-boot/micronaut-spring-boot.adoc
@@ -164,7 +164,7 @@ Execute the API:
 
 If you wait 30 seconds, you will see a log statement from `GreetingJob`.
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-spring/latest/guide/[Micronaut Spring].
 

--- a/guides/micronaut-token-propagation/micronaut-token-propagation.adoc
+++ b/guides/micronaut-token-propagation/micronaut-token-propagation.adoc
@@ -245,7 +245,7 @@ After creating the native executables for both microservices, start them and sen
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-security/latest/guide/#tokenPropagation[Token Propagation] and https://micronaut-projects.github.io/micronaut-security/latest/guide/[Micronaut Security].
 

--- a/guides/micronaut-websocket/micronaut-websocket.adoc
+++ b/guides/micronaut-websocket/micronaut-websocket.adoc
@@ -81,7 +81,7 @@ open your browser and visit http://localhost:8080/&num;/java/Joe[http://localhos
 
 :exclude-for-languages:
 
-== Next steps
+== Next Steps
 
 Read more about:
 

--- a/guides/spring-boot-micronaut-data/spring-boot-micronaut-data.adoc
+++ b/guides/spring-boot-micronaut-data/spring-boot-micronaut-data.adoc
@@ -84,7 +84,7 @@ callout:autowired[arg0=BookRepository]
 
 common:testAppSpringBoot.adoc[]
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-spring/latest/guide/[Micronaut Spring] and https://micronaut-projects.github.io/micronaut-data/latest/guide/[Micronaut Data].
 

--- a/guides/spring-boot-to-micronaut-application-class/spring-boot-to-micronaut-application-class.adoc
+++ b/guides/spring-boot-to-micronaut-application-class/spring-boot-to-micronaut-application-class.adoc
@@ -18,7 +18,7 @@ source:Application[app=micronautframework]
 
 Except for the `@SpringBootApplication` annotation, both classes are almost identical. :-]
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-spring/latest/guide/[Micronaut Spring].
 

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/spring-boot-to-micronaut-at-configuration-at-bean-at-factory.adoc
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/spring-boot-to-micronaut-at-configuration-at-bean-at-factory.adoc
@@ -59,7 +59,7 @@ callout:injection[arg0=Greeter]
 This guide illustrate that the APIs `@Configuration` and `@Factory` of both frameworks are almost identical.
 
 
-== Next steps
+== Next Steps
 
 Read more https://guides.micronaut.io/latest/tag-spring_boot_to_micronaut.html[Spring Boot to Micronaut] guides.
 

--- a/guides/spring-boot-to-micronaut-at-singleton-at-component/spring-boot-to-micronaut-at-singleton-at-component.adoc
+++ b/guides/spring-boot-to-micronaut-at-singleton-at-component/spring-boot-to-micronaut-at-singleton-at-component.adoc
@@ -58,7 +58,7 @@ NOTE: Micronaut Framework generates the necessary information to fulfill the inj
 
 WARNING: Spring relies on classpath scanning to find classes annotated with @Component. In the Spring Boot application, `HelloGreeter` is detected because the application contains an `Application` with the `@SpringBootApplication` annotation. The `@SpringBootApplication` annotation applies the `@ComponentScan` annotation, which tells Spring to scan the package where the `Application` class is located and its sub-packages
 
-== Next steps
+== Next Steps
 
 Read more https://guides.micronaut.io/latest/tag-spring_boot_to_micronaut.html[Spring Boot to Micronaut] guides.
 

--- a/guides/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder.adoc
+++ b/guides/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder.adoc
@@ -19,7 +19,7 @@ As you can see in the following code snippet, the API is similar. You should be 
 
 test:UriBuilderTest[app=micronautframework]
 
-== Next steps
+== Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-spring/latest/guide/[Micronaut Spring].
 

--- a/src/docs/common/snippets/common-graal-with-plugins-multi.adoc
+++ b/src/docs/common/snippets/common-graal-with-plugins-multi.adoc
@@ -2,13 +2,13 @@
 
 == Generate Micronaut Application Native Executables with GraalVM
 
-We will use https://www.graalvm.org/[GraalVM], the polyglot embeddable virtual machine, to generate Native executables of our Micronaut applications.
+We will use https://www.graalvm.org/[GraalVM], an advanced JDK with ahead-of-time Native Image compilation, to generate a native executable of this Micronaut application.
 
-Compiling native executables ahead-of-time with GraalVM improves startup time and reduces the memory footprint of JVM-based applications.
+Compiling Micronaut applications ahead of time with GraalVM significantly improves startup time and reduces the memory footprint of JVM-based applications.
 
 NOTE: Only Java and Kotlin projects support using GraalVM's `native-image` tool. Groovy relies heavily on reflection, which is only partially supported by GraalVM.
 
-=== Native Executable generation
+=== Native Executable Generation
 
 common:install-graalvm-sdkman.adoc[]
 
@@ -32,19 +32,19 @@ graalvmNative {
     binaries {
         main {
             imageName.set('mn-graalvm-application') // <1>
-            buildArgs.add('--verbose') // <2>
+            buildArgs.add('-Ob') // <2>
         }
     }
 }
 ----
 <1> The native executable name will now be `mn-graalvm-application`
-<2> It is possible to pass extra arguments to build the native executable
+<2> It is possible to pass extra build arguments to `native-image`. For example, `-Ob` enables the quick build mode.
 
 :exclude-for-build:
 
 :exclude-for-build:gradle
 
-To generate native executables for each application using Maven run:
+To generate native executables for each application using Maven, run:
 
 [source, bash]
 ----
@@ -52,6 +52,28 @@ To generate native executables for each application using Maven run:
 ----
 
 The native executable is created in the `target` directory and can be run with `target/micronautguide`.
+
+It is possible to customize the name of the native executable or pass additional build arguments using the https://graalvm.github.io/native-build-tools/latest/maven-plugin.html[Maven plugin for GraalVM Native Image building]. Declare the plugin as following:
+
+.pom.xml
+[source,xml]
+----
+<plugin>
+    <groupId>org.graalvm.buildtools</groupId>
+    <artifactId>native-maven-plugin</artifactId>
+    <version>0.10.3</version>
+    <configuration>
+        <!-- <1> -->
+        <imageName>mn-graalvm-application</imageName> <1>
+        <buildArgs>
+	      <!-- <2> -->
+          <buildArg>-Ob</buildArg>
+        </buildArgs>
+    </configuration>
+</plugin>
+----
+<1> The native executable name will now be `mn-graalvm-application`.
+<2> It is possible to pass extra build arguments to `native-image`. For example, `-Ob` enables the quick build mode.
 
 :exclude-for-build:
 

--- a/src/docs/common/snippets/common-graal-with-plugins.adoc
+++ b/src/docs/common/snippets/common-graal-with-plugins.adoc
@@ -2,17 +2,17 @@
 
 == Generate a Micronaut Application Native Executable with GraalVM
 
-We will use https://www.graalvm.org/[GraalVM], the polyglot embeddable virtual machine, to generate a native executable of our Micronaut application.
+We will use https://www.graalvm.org/[GraalVM], an advanced JDK with ahead-of-time Native Image compilation, to generate a native executable of this Micronaut application.
 
-Compiling native executables ahead of time with GraalVM improves startup time and reduces the memory footprint of JVM-based applications.
+Compiling Micronaut applications ahead of time with GraalVM significantly improves startup time and reduces the memory footprint of JVM-based applications.
 
 NOTE: Only Java and Kotlin projects support using GraalVM's `native-image` tool. Groovy relies heavily on reflection, which is only partially supported by GraalVM.
 
-=== GraalVM installation
+=== GraalVM Installation
 
 common:install-graalvm-sdkman.adoc[]
 
-=== Native executable generation
+=== Native Executable Generation
 
 :exclude-for-build:maven
 
@@ -34,13 +34,13 @@ graalvmNative {
     binaries {
         main {
             imageName.set('mn-graalvm-application') // <1>
-            buildArgs.add('--verbose') // <2>
+            buildArgs.add('-Ob') // <2>
         }
     }
 }
 ----
 <1> The native executable name will now be `mn-graalvm-application`
-<2> It is possible to pass extra arguments to build the native executable
+<2> It is possible to pass extra build arguments to `native-image`. For example, `-Ob` enables the quick build mode.
 
 :exclude-for-build:
 
@@ -54,6 +54,28 @@ To generate a native executable using Maven, run:
 ----
 
 The native executable is created in the `target` directory and can be run with `target/micronautguide`.
+
+It is possible to customize the name of the native executable or pass additional build arguments using the https://graalvm.github.io/native-build-tools/latest/maven-plugin.html[Maven plugin for GraalVM Native Image building]. Declare the plugin as following:
+
+.pom.xml
+[source,xml]
+----
+<plugin>
+    <groupId>org.graalvm.buildtools</groupId>
+    <artifactId>native-maven-plugin</artifactId>
+    <version>0.10.3</version>
+    <configuration>
+        <!-- <1> -->
+        <imageName>mn-graalvm-application</imageName> <1>
+        <buildArgs>
+	      <!-- <2> -->
+          <buildArg>-Ob</buildArg>
+        </buildArgs>
+    </configuration>
+</plugin>
+----
+<1> The native executable name will now be `mn-graalvm-application`.
+<2> It is possible to pass extra build arguments to `native-image`. For example, `-Ob` enables the quick build mode.
 
 :exclude-for-build:
 

--- a/src/docs/common/snippets/common-install-graal-function.adoc
+++ b/src/docs/common/snippets/common-install-graal-function.adoc
@@ -1,6 +1,6 @@
-We will use https://www.graalvm.org/[GraalVM], the polyglot embeddable virtual machine, to generate a Native executable of our function.
+We will use https://www.graalvm.org/[GraalVM], an advanced JDK with ahead-of-time Native Image compilation, to generate a native executable of this Micronaut application.
 
-Compiling native executables ahead-of-time with GraalVM improves startup time and reduces the memory footprint of JVM-based applications and functions.
+Compiling Micronaut applications ahead of time with GraalVM significantly improves startup time and reduces the memory footprint of JVM-based applications.
 
 NOTE: Only Java and Kotlin projects support using GraalVM's `native-image` tool. Groovy relies heavily on reflection, which is only partially supported by GraalVM.
 

--- a/src/docs/common/snippets/common-install-graalvm-sdkman.adoc
+++ b/src/docs/common/snippets/common-install-graalvm-sdkman.adoc
@@ -6,7 +6,7 @@ The easiest way to install https://www.graalvm.org[GraalVM] on Linux or Mac is t
 sdk install java 21.0.5-graal
 ----
 
-For installation on Windows, or for manual installation on Linux or Mac, see the https://www.graalvm.org/latest/docs/getting-started/[GraalVM Getting Started] documentation.
+For installation on Windows, or for a manual installation on Linux or Mac, see the https://www.graalvm.org/latest/docs/getting-started/[GraalVM Getting Started] documentation.
 
 The previous command installs Oracle GraalVM, which is free to use in production and free to redistribute, at no cost, under the https://www.oracle.com/downloads/licenses/graal-free-license.html[GraalVM Free Terms and Conditions].
 

--- a/src/docs/common/snippets/common-next.adoc
+++ b/src/docs/common/snippets/common-next.adoc
@@ -1,3 +1,3 @@
-== Next steps
+== Next Steps
 
 Explore more features with https://micronaut.io/guides/[Micronaut Guides].


### PR DESCRIPTION
1. There is no information, for Maven users, how to pass additional arguments to `native-image` build process. 
You can do that with Maven plugin for Native Image building: https://graalvm.github.io/native-build-tools/latest/maven-plugin.html#configuration-options 

2. Review GraalVM-related content.