### PR TITLE
Add GraalVM Native Image and Truffle compilation sections for GraalPy guides

### DIFF
--- a/guides/micronaut-graalpy-python-package/micronaut-graalpy-python-package.adoc
+++ b/guides/micronaut-graalpy-python-package/micronaut-graalpy-python-package.adoc
@@ -72,7 +72,7 @@ image::graalpy-pygal.png[]
 
 common:graalpy-graalvm.adoc[]
 
-Open `http://localhost:8080/pygal` in a web browser of your choice to execute the
+Open http://localhost:8080/pygal[http://localhost:8080/pygal] in your web browser to execute the endpoint exposed by the native executable. You should see a stacked bar chart.
 endpoint exposed by the native executable. You should see a stacked bar chart.
 
 == Next Steps

--- a/guides/micronaut-graalpy-python-package/micronaut-graalpy-python-package.adoc
+++ b/guides/micronaut-graalpy-python-package/micronaut-graalpy-python-package.adoc
@@ -70,6 +70,11 @@ Open `http://localhost:8080/pygal` in a web browser of your choice execute the e
 
 image::graalpy-pygal.png[]
 
+common:graalpy-graalvm.adoc[]
+
+Open `http://localhost:8080/pygal` in a web browser of your choice to execute the
+endpoint exposed by the native executable. You should see a stacked bar chart.
+
 == Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-test/latest/guide/[Micronaut testing].

--- a/guides/micronaut-graalpy/micronaut-graalpy.adoc
+++ b/guides/micronaut-graalpy/micronaut-graalpy.adoc
@@ -56,6 +56,20 @@ callout:http-request[]
 common:testApp.adoc[]
 common:runapp.adoc[]
 
+common:graalpy-graalvm.adoc[]
+
+You can execute the endpoint exposed by the native executable:
+
+[source, bash]
+----
+curl localhost:8080/hello
+----
+
+[source]
+----
+Hello World
+----
+
 == Next Steps
 
 Read more about https://micronaut-projects.github.io/micronaut-graal-languages/latest/guide/[Micronaut Graalpy] integration.

--- a/src/docs/common/snippets/common-graal-with-plugins-multi.adoc
+++ b/src/docs/common/snippets/common-graal-with-plugins-multi.adoc
@@ -64,7 +64,7 @@ It is possible to customize the name of the native executable or pass additional
     <version>0.10.3</version>
     <configuration>
         <!-- <1> -->
-        <imageName>mn-graalvm-application</imageName> <1>
+        <imageName>mn-graalvm-application</imageName>
         <buildArgs>
 	      <!-- <2> -->
           <buildArg>-Ob</buildArg>

--- a/src/docs/common/snippets/common-graalpy-graalvm.adoc
+++ b/src/docs/common/snippets/common-graalpy-graalvm.adoc
@@ -28,7 +28,6 @@ sdk install java 23-graalce
 === GraalVM JDK Compatibility
 
 To enable runtime compilation, you must use versions of GraalPy and the Polyglot API dependencies that are compatible with the specified GraalVM JDK version. If you see errors like the following:
-dependencies compatible with given GraalVM JDK version. If you see errors like this:
 
 [source, bash]
 ----
@@ -48,12 +47,11 @@ org.graalvm.python:graalpy-maven-plugin
 == Generate a Micronaut Application Native Executable with GraalVM
 
 Starting with GraalVM for JDK 23, Micronaut applications that use GraalPy or any Truffle language can be compiled into native executables using GraalVM Native Image.
-can be compiled to native executable using GraalVM Native Image.
 
 Compiling Micronaut applications ahead of time with GraalVM significantly improves startup time and reduces
 the memory footprint of JVM-based applications.
 
-=== GraalVM Native Image Metadata
+=== Native Image Configuration
 GraalVM Native Image compilation requires metadata to correctly run code that uses https://www.graalvm.org/latest/reference-manual/native-image/metadata/#dynamic-proxy[dynamic proxies].
 
 Create a proxy configuration file:

--- a/src/docs/common/snippets/common-graalpy-graalvm.adoc
+++ b/src/docs/common/snippets/common-graalpy-graalvm.adoc
@@ -1,0 +1,71 @@
+:exclude-for-languages:groovy
+
+== Python Runtime Compilation
+
+With GraalVM JDK, the Python code executed using the GraalPy engine will be just-in-time compiled.
+With other JDKs, the Python code will be interpreted, which negatively impacts its performance.
+
+The easiest way to install https://www.graalvm.org[GraalVM] on Linux or Mac is to use https://sdkman.io/[SDKMan.io].
+
+[source, bash]
+.Java 23
+----
+sdk install java 23-graal
+----
+
+For installation on Windows, or for a manual installation on Linux or Mac, see the https://www.graalvm.org/latest/docs/getting-started/[GraalVM Getting Started] documentation.
+
+The previous command installs Oracle GraalVM, which is free to use in production and free to redistribute, at no cost, under the https://www.oracle.com/downloads/licenses/graal-free-license.html[GraalVM Free Terms and Conditions].
+
+Alternatively, you can use the https://github.com/graalvm/graalvm-ce-builds/releases/[GraalVM Community Edition]:
+
+[source, bash]
+.Java 23
+----
+sdk install java 23-graalce
+----
+
+=== GraalVM JDK Compatibility
+
+In order to support runtime compilation, one must use versions of GraalPy and the Polyglot API
+dependencies compatible with given GraalVM JDK version. If you see errors like this:
+
+[source, bash]
+----
+Your Java runtime '23.0.1+11-jvmci-b01' with compiler version '24.1.1' is incompatible with polyglot version '24.1.0'.
+----
+
+You need to override the versions of the following dependencies according to the error message:
+
+[source, text]
+----
+org.graalvm.polyglot:polyglot
+org.graalvm.python:python
+org.graalvm.python:python-embedding
+org.graalvm.python:graalpy-maven-plugin
+----
+
+== Generate a Micronaut Application Native Executable with GraalVM
+
+Starting from the GraalVM for JDK 23, Micronaut applications using GraalPy, or any Truffle language in general,
+can be compiled to native executable using GraalVM Native Image.
+
+Compiling Micronaut applications ahead of time with GraalVM significantly improves startup time and reduces
+the memory footprint of JVM-based applications.
+
+=== Native Executable metadata
+The https://www.graalvm.org/[GraalVM] Native Image compilation requires metadata to properly run code that uses https://www.graalvm.org/latest/reference-manual/native-image/metadata/#dynamic-proxy[dynamic proxies].
+
+Create a proxy configuration file:
+resource:META-INF/native-image/proxy-config.json[]
+
+=== Native Executable Generation
+
+To generate a native executable using Maven, run:
+
+[source, bash]
+----
+./mvnw package -Dpackaging=native-image
+----
+
+The native executable is created in the `target` directory and can be run with `target/micronautguide`.

--- a/src/docs/common/snippets/common-graalpy-graalvm.adoc
+++ b/src/docs/common/snippets/common-graalpy-graalvm.adoc
@@ -53,7 +53,7 @@ can be compiled to native executable using GraalVM Native Image.
 Compiling Micronaut applications ahead of time with GraalVM significantly improves startup time and reduces
 the memory footprint of JVM-based applications.
 
-=== Native Executable metadata
+=== GraalVM Native Image Metadata
 GraalVM Native Image compilation requires metadata to correctly run code that uses https://www.graalvm.org/latest/reference-manual/native-image/metadata/#dynamic-proxy[dynamic proxies].
 
 Create a proxy configuration file:

--- a/src/docs/common/snippets/common-graalpy-graalvm.adoc
+++ b/src/docs/common/snippets/common-graalpy-graalvm.adoc
@@ -2,8 +2,8 @@
 
 == Python Runtime Compilation
 
-With GraalVM JDK, the Python code executed using the GraalPy engine will be just-in-time compiled.
-With other JDKs, the Python code will be interpreted, which negatively impacts its performance.
+When using the GraalVM JDK, Python code executed with the GraalPy engine is just-in-time compiled.
+With other JDKs, the Python code is interpreted, resulting in reduced performance.
 
 The easiest way to install https://www.graalvm.org[GraalVM] on Linux or Mac is to use https://sdkman.io/[SDKMan.io].
 
@@ -27,7 +27,7 @@ sdk install java 23-graalce
 
 === GraalVM JDK Compatibility
 
-In order to support runtime compilation, one must use versions of GraalPy and the Polyglot API
+To enable runtime compilation, you must use versions of GraalPy and the Polyglot API dependencies that are compatible with the specified GraalVM JDK version. If you see errors like the following:
 dependencies compatible with given GraalVM JDK version. If you see errors like this:
 
 [source, bash]
@@ -47,14 +47,14 @@ org.graalvm.python:graalpy-maven-plugin
 
 == Generate a Micronaut Application Native Executable with GraalVM
 
-Starting from the GraalVM for JDK 23, Micronaut applications using GraalPy, or any Truffle language in general,
+Starting with GraalVM for JDK 23, Micronaut applications that use GraalPy or any Truffle language can be compiled into native executables using GraalVM Native Image.
 can be compiled to native executable using GraalVM Native Image.
 
 Compiling Micronaut applications ahead of time with GraalVM significantly improves startup time and reduces
 the memory footprint of JVM-based applications.
 
 === Native Executable metadata
-The https://www.graalvm.org/[GraalVM] Native Image compilation requires metadata to properly run code that uses https://www.graalvm.org/latest/reference-manual/native-image/metadata/#dynamic-proxy[dynamic proxies].
+GraalVM Native Image compilation requires metadata to correctly run code that uses https://www.graalvm.org/latest/reference-manual/native-image/metadata/#dynamic-proxy[dynamic proxies].
 
 Create a proxy configuration file:
 resource:META-INF/native-image/proxy-config.json[]
@@ -68,4 +68,4 @@ To generate a native executable using Maven, run:
 ./mvnw package -Dpackaging=native-image
 ----
 
-The native executable is created in the `target` directory and can be run with `target/micronautguide`.
+The native executable is created in the _target_ directory and can be run with `./target/micronautguide`.


### PR DESCRIPTION
From GraalVM JDK 23, Micronaut apps with GraalPy can be also compiled with GraalVM Native Image.

We also noticed that this guide is broken for some reason: https://guides.micronaut.io/latest/micronaut-graalpy-python-package.html. Any ideas why that could be?