### PR TITLE
Add Kotlin version for "TESTING REST API INTEGRATIONS USING TESTCONTAINERS WITH WIREMOCK OR MOCKSERVER" guide

### DIFF
--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/kotlin/example/micronaut/Album.kt
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/kotlin/example/micronaut/Album.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable // <1>
+data class Album(val albumId: Long, val photos: List<Photo>?)

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/kotlin/example/micronaut/AlbumController.kt
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/kotlin/example/micronaut/AlbumController.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+
+@Controller("/api") // <1>
+class AlbumController(private val photoServiceClient: PhotoServiceClient) { // <2>
+
+    @ExecuteOn(TaskExecutors.BLOCKING) // <3>
+    @Get("/albums/{albumId}") // <4>
+    fun getAlbumById(@PathVariable albumId: Long): Album { // <5>
+        return Album(albumId, photoServiceClient.getPhotos(albumId))
+    }
+}

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/kotlin/example/micronaut/Application.kt
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/kotlin/example/micronaut/Application.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.runtime.Micronaut.*
+
+fun main(args: Array<String>) {
+    run(*args)
+}

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/kotlin/example/micronaut/Photo.kt
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/kotlin/example/micronaut/Photo.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable // <1>
+data class Photo(val id: Long, val title: String, val url: String, val thumbnailUrl: String)

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/kotlin/example/micronaut/PhotoServiceClient.kt
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/kotlin/example/micronaut/PhotoServiceClient.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.client.annotation.Client
+
+@Client(id = "photosapi")
+interface PhotoServiceClient {
+
+    @Get("/albums/{albumId}/photos")
+    fun getPhotos(@PathVariable albumId: Long): List<Photo>
+}

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/resources/application.properties
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+micronaut.http.services.photosapi.url=https://jsonplaceholder.typicode.com

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/kotlin/example/micronaut/AlbumControllerMockServerTest.kt
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/kotlin/example/micronaut/AlbumControllerMockServerTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import io.restassured.http.ContentType
+import io.restassured.specification.RequestSpecification
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockserver.client.MockServerClient
+import org.mockserver.model.Header
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+import org.mockserver.model.JsonBody.json
+import org.mockserver.verify.VerificationTimes
+import org.testcontainers.containers.MockServerContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+@MicronautTest // <1>
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
+@Testcontainers(disabledWithoutDocker = true) // <3>
+class AlbumControllerMockServerTest : TestPropertyProvider {  // <4>
+
+    companion object {
+        @Container
+        @JvmField
+        var mockServerContainer: MockServerContainer = MockServerContainer(
+            DockerImageName.parse("mockserver/mockserver:5.15.0")
+        )
+
+        lateinit var mockServerClient: MockServerClient
+    }
+
+    override fun getProperties(): Map<String, String> { // <4>
+        mockServerContainer.start()
+        mockServerClient = MockServerClient(
+            mockServerContainer.host,
+            mockServerContainer.serverPort
+        )
+        return mapOf("micronaut.http.services.photosapi.url" to mockServerContainer.endpoint) // <5>
+    }
+
+    @BeforeEach
+    fun setUp() {
+        mockServerClient.reset()
+    }
+
+    @Test
+    fun shouldGetAlbumById(spec: RequestSpecification) { // <6>
+        val albumId = 1L
+
+        mockServerClient
+            .`when`(request().withMethod("GET").withPath("/albums/$albumId/photos"))
+            .respond(
+                response()
+                    .withStatusCode(200)
+                    .withHeaders(Header("Content-Type", "application/json; charset=utf-8"))
+                    .withBody(
+                        json(
+                            """
+                            [
+                                 {
+                                     "id": 1,
+                                     "title": "accusamus beatae ad facilis cum similique qui sunt",
+                                     "url": "https://via.placeholder.com/600/92c952",
+                                     "thumbnailUrl": "https://via.placeholder.com/150/92c952"
+                                 },
+                                 {
+                                     "id": 2,
+                                     "title": "reprehenderit est deserunt velit ipsam",
+                                     "url": "https://via.placeholder.com/600/771796",
+                                     "thumbnailUrl": "https://via.placeholder.com/150/771796"
+                                 }
+                             ]
+                            """
+                        )
+                    )
+            )
+
+        spec // <7>
+            .contentType(ContentType.JSON)
+            .`when`()
+            .get("/api/albums/{albumId}", albumId)
+            .then()
+            .statusCode(200)
+            .body("albumId", `is`(albumId.toInt()))
+            .body("photos", hasSize<Int>(2))
+
+        verifyMockServerRequest("GET", "/albums/$albumId/photos", 1)
+    }
+
+    private fun verifyMockServerRequest(method: String, path: String, times: Int) {
+        mockServerClient.verify(
+            request().withMethod(method).withPath(path),
+            VerificationTimes.exactly(times)
+        )
+    }
+}

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/kotlin/example/micronaut/AlbumControllerTest.kt
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/kotlin/example/micronaut/AlbumControllerTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.MediaType
+import io.micronaut.runtime.server.EmbeddedServer
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers(disabledWithoutDocker = true) // <1>
+class AlbumControllerTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension // <2>
+        var wireMock: WireMockExtension = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build()
+    }
+
+    private fun getProperties(): Map<String, Any> {
+        return mapOf("micronaut.http.services.photosapi.url" to wireMock.baseUrl()) // <3>
+    }
+
+    @Test
+    fun shouldGetAlbumById() { // <4>
+        ApplicationContext.run(EmbeddedServer::class.java, getProperties()).use { server ->
+            RestAssured.port = server.port // <5>
+            val albumId = 1L
+            wireMock.stubFor( // <6>
+                WireMock.get(WireMock.urlMatching("/albums/$albumId/photos"))
+                    .willReturn(
+                        WireMock.aResponse()
+                            .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                            .withBody(
+                                """
+                                [
+                                     {
+                                         "id": 1,
+                                         "title": "accusamus beatae ad facilis cum similique qui sunt",
+                                         "url": "https://via.placeholder.com/600/92c952",
+                                         "thumbnailUrl": "https://via.placeholder.com/150/92c952"
+                                     },
+                                     {
+                                         "id": 2,
+                                         "title": "reprehenderit est deserunt velit ipsam",
+                                         "url": "https://via.placeholder.com/600/771796",
+                                         "thumbnailUrl": "https://via.placeholder.com/150/771796"
+                                     }
+                                 ]
+                                """
+                            )
+                    )
+            )
+
+            RestAssured.given().contentType(ContentType.JSON)
+                .`when`()
+                .get("/api/albums/{albumId}", albumId)
+                .then()
+                .statusCode(200)
+                .body("albumId", `is`(albumId.toInt()))
+                .body("photos", hasSize<Int>(2))
+        }
+    }
+
+    @Test  // <7>
+    fun shouldReturnServerErrorWhenPhotoServiceCallFailed() {
+        ApplicationContext.run(EmbeddedServer::class.java, getProperties()).use { server ->
+            RestAssured.port = server.port // <5>
+            val albumId = 2L
+            wireMock.stubFor(
+                WireMock.get(WireMock.urlMatching("/albums/$albumId/photos"))
+                    .willReturn(WireMock.aResponse().withStatus(500))
+            )
+
+            RestAssured.given().contentType(ContentType.JSON)
+                .`when`()
+                .get("/api/albums/{albumId}", albumId)
+                .then()
+                .statusCode(500)
+        }
+    }
+}

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/kotlin/example/micronaut/AlbumControllerTestcontainersTests.kt
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/kotlin/example/micronaut/AlbumControllerTestcontainersTests.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Test
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.wiremock.integrations.testcontainers.WireMockContainer
+
+@Testcontainers(disabledWithoutDocker = true) // <1>
+class AlbumControllerTestcontainersTests {
+
+    companion object {
+        @Container // <2>
+        @JvmField
+        var wiremockServer: WireMockContainer = WireMockContainer("wiremock/wiremock:2.35.0")
+            .withMapping("photos-by-album", AlbumControllerTestcontainersTests::class.java, "mocks-config.json") // <3>
+            .withFileFromResource(
+                "album-photos-response.json",
+                AlbumControllerTestcontainersTests::class.java,
+                "album-photos-response.json"
+            )
+    }
+
+    private fun getProperties(): Map<String, Any> { // <4>
+        return mapOf("micronaut.http.services.photosapi.url" to wiremockServer.baseUrl) // <5>
+    }
+
+    @Test
+    fun shouldGetAlbumById() {
+        val albumId = 1L
+        ApplicationContext.run(EmbeddedServer::class.java, getProperties()).use { server ->
+            RestAssured.port = server.port
+
+            RestAssured.given().contentType(ContentType.JSON)
+                .`when`()
+                .get("/api/albums/{albumId}", albumId)
+                .then()
+                .statusCode(200)
+                .body("albumId", `is`(albumId.toInt()))
+                .body("photos", hasSize<Int>(2))
+        }
+    }
+
+    @Test
+    fun shouldReturnServerErrorWhenPhotoServiceCallFailed() {
+        val albumId = 2L
+        ApplicationContext.run(EmbeddedServer::class.java, getProperties()).use { server ->
+            RestAssured.port = server.port
+            RestAssured.given().contentType(ContentType.JSON)
+                .`when`()
+                .get("/api/albums/{albumId}", albumId)
+                .then()
+                .statusCode(500)
+        }
+    }
+
+    @Test
+    fun shouldReturnEmptyPhotos() {
+        val albumId = 3L
+        ApplicationContext.run(EmbeddedServer::class.java, getProperties()).use { server ->
+            RestAssured.port = server.port
+            RestAssured.given().contentType(ContentType.JSON)
+                .`when`()
+                .get("/api/albums/{albumId}", albumId)
+                .then()
+                .statusCode(200)
+                .body("albumId", `is`(albumId.toInt()))
+                .body("photos", nullValue())
+        }
+    }
+}

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/kotlin/example/micronaut/AlbumControllerWireMockMappingTests.kt
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/kotlin/example/micronaut/AlbumControllerWireMockMappingTests.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers(disabledWithoutDocker = true) // <1>
+class AlbumControllerWireMockMappingTests {
+
+    companion object {
+        //tag::registerExtension[]
+        @JvmField
+        @RegisterExtension
+        var wireMockServer: WireMockExtension = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort().usingFilesUnderClasspath("wiremock"))
+            .build()
+        //end::registerExtension[]
+    }
+
+    private fun getProperties(): Map<String, Any> {
+        return mapOf("micronaut.http.services.photosapi.url" to wireMockServer.baseUrl()) //
+    }
+
+    //tag::shouldGetAlbumById[]
+    @Test
+    fun shouldGetAlbumById() {
+        val albumId = 1L
+        ApplicationContext.run(EmbeddedServer::class.java, getProperties()).use { server ->
+            RestAssured.port = server.port
+
+            RestAssured.given().contentType(ContentType.JSON)
+                .`when`()
+                .get("/api/albums/{albumId}", albumId)
+                .then()
+                .statusCode(200)
+                .body("albumId", `is`(albumId.toInt()))
+                .body("photos", hasSize<Int>(2))
+        }
+    }
+    //end::shouldGetAlbumById[]
+
+    @Test
+    fun shouldReturnServerErrorWhenPhotoServiceCallFailed() {
+        val albumId = 2L
+        ApplicationContext.run(EmbeddedServer::class.java, getProperties()).use { server ->
+            RestAssured.port = server.port
+
+            RestAssured.given().contentType(ContentType.JSON)
+                .`when`()
+                .get("/api/albums/{albumId}", albumId)
+                .then()
+                .statusCode(500)
+        }
+    }
+
+    @Test
+    fun shouldReturnEmptyPhotos() {
+        val albumId = 3L
+        ApplicationContext.run(EmbeddedServer::class.java, getProperties()).use { server ->
+            RestAssured.port = server.port
+
+            RestAssured.given().contentType(ContentType.JSON)
+                .`when`()
+                .get("/api/albums/{albumId}", albumId)
+                .then()
+                .statusCode(200)
+                .body("albumId", `is`(albumId.toInt()))
+                .body("photos", nullValue())
+        }
+    }
+}

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/resources/example/micronaut/AlbumControllerTestcontainersTests/album-photos-response.json
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/resources/example/micronaut/AlbumControllerTestcontainersTests/album-photos-response.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "title": "accusamus beatae ad facilis cum similique qui sunt",
+    "url": "https://via.placeholder.com/600/92c952",
+    "thumbnailUrl": "https://via.placeholder.com/150/92c952"
+  },
+  {
+    "id": 2,
+    "title": "reprehenderit est deserunt velit ipsam",
+    "url": "https://via.placeholder.com/600/771796",
+    "thumbnailUrl": "https://via.placeholder.com/150/771796"
+  }
+]

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/resources/example/micronaut/AlbumControllerTestcontainersTests/mocks-config.json
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/resources/example/micronaut/AlbumControllerTestcontainersTests/mocks-config.json
@@ -1,0 +1,42 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "urlPattern": "/albums/([0-9]+)/photos"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "album-photos-response.json"
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPattern": "/albums/2/photos"
+      },
+      "response": {
+        "status": 500,
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPattern": "/albums/3/photos"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": []
+      }
+    }
+  ]
+}

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/resources/wiremock/__files/album-photos-resp-200.json
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/resources/wiremock/__files/album-photos-resp-200.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "title": "accusamus beatae ad facilis cum similique qui sunt",
+    "url": "https://via.placeholder.com/600/92c952",
+    "thumbnailUrl": "https://via.placeholder.com/150/92c952"
+  },
+  {
+    "id": 2,
+    "title": "reprehenderit est deserunt velit ipsam",
+    "url": "https://via.placeholder.com/600/771796",
+    "thumbnailUrl": "https://via.placeholder.com/150/771796"
+  }
+]

--- a/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/resources/wiremock/mappings/get-album-photos.json
+++ b/guides/testing-rest-api-integrations-using-mockserver/kotlin/src/test/resources/wiremock/mappings/get-album-photos.json
@@ -1,0 +1,42 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "urlPattern": "/albums/([0-9]+)/photos"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "album-photos-resp-200.json"
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPattern": "/albums/2/photos"
+      },
+      "response": {
+        "status": 500,
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "urlPattern": "/albums/3/photos"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": []
+      }
+    }
+  ]
+}

--- a/guides/testing-rest-api-integrations-using-mockserver/metadata.json
+++ b/guides/testing-rest-api-integrations-using-mockserver/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["testcontainers"],
   "categories": ["Testing"],
   "publicationDate": "2023-09-13",
-  "languages": ["java"],
+  "languages": ["java", "kotlin"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
This PR adds a Kotlin version of the "TESTING REST API INTEGRATIONS USING TESTCONTAINERS WITH WIREMOCK OR MOCKSERVER" guide

This pull request revisits and reimplements the work originally started in #1511

Fixes #1341