### PR TITLE
Fix broken code listing in OpenAPI Server Generation guide

### DIFF
--- a/guides/micronaut-openapi-generator-server/java/src/main/java/example/micronaut/controller/BooksController.java
+++ b/guides/micronaut-openapi-generator-server/java/src/main/java/example/micronaut/controller/BooksController.java
@@ -14,7 +14,7 @@ package example.micronaut.controller;
 /*
 //tag::package[]
 package example.micronaut.controller;
-//tag::package[]
+//end::package[]
 */
 //tag::import[]
 

--- a/guides/micronaut-openapi-generator-server/micronaut-openapi-generator-server.adoc
+++ b/guides/micronaut-openapi-generator-server/micronaut-openapi-generator-server.adoc
@@ -340,7 +340,7 @@ Micronaut OpenAPI has generated an interface for called `BooksApi` that we need 
 
 Create a `BooksController.java` class with the following contents:
 
-source:controller/BooksController[tags=header|footer]
+source:controller/BooksController[tags=package|import|clazz|footer]
 
 === Implementing Controller Methods
 


### PR DESCRIPTION
Replaced the removed general `header` with the existing tags `package|import|clazz`.
Fixed the package tag that was missing its `end` marker.

<img width="1340" height="715" alt="Screenshot from 2025-10-20 13-50-29" src="https://github.com/user-attachments/assets/41f9007f-11bb-46db-b642-081d604dd3a0" />


#1582