### PR TITLE
docs(mongodb): Add @ReflectiveAccess to Fruit POJO and fix native-image documentation

### DIFF
--- a/guides/micronaut-mongodb-asynchronous/java/src/main/java/example/micronaut/Fruit.java
+++ b/guides/micronaut-mongodb-asynchronous/java/src/main/java/example/micronaut/Fruit.java
@@ -18,12 +18,14 @@ package example.micronaut;
 import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.serde.annotation.Serdeable;
 import org.bson.codecs.pojo.annotations.BsonCreator;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import jakarta.validation.constraints.NotBlank;
 
+@ReflectiveAccess
 @Serdeable // <1>
 public class Fruit {
 

--- a/guides/micronaut-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/Fruit.kt
+++ b/guides/micronaut-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/Fruit.kt
@@ -21,6 +21,7 @@ import org.bson.codecs.pojo.annotations.BsonCreator
 import org.bson.codecs.pojo.annotations.BsonProperty
 import jakarta.validation.constraints.NotBlank
 
+@ReflectiveAccess
 @Serdeable // <1>
 data class Fruit @Creator @BsonCreator constructor( // <4>
     @field:BsonProperty("name") @param:BsonProperty("name") @field:NotBlank val name: String, // <2> <3>

--- a/guides/micronaut-mongodb-asynchronous/micronaut-mongodb-asynchronous.adoc
+++ b/guides/micronaut-mongodb-asynchronous/micronaut-mongodb-asynchronous.adoc
@@ -19,6 +19,8 @@ callout:constraints[]
 <.> Since the POJO does not have an empty constructor, use the annotations `@BsonCreator` and `BsonProperty` to define data conversion between BSON and POJO with the MongoDB Java driver. See https://docs.mongodb.com/drivers/java/sync/current/fundamentals/data-formats/pojo-customization/#pojos-without-no-argument-constructors[POJOs without No-Argument Constructor].
 callout:creator[]
 
+Native image note: The MongoDB POJO codec uses reflection to access constructors and fields. When building a native image with GraalVM, you must provide this metadata explicitly. Annotating the domain class with @ReflectiveAccess ensures Micronaut's Graal annotation processor generates the required reflection configuration automatically.
+
 === Repository
 
 Create a repository interface to encapsulate the CRUD actions for `Fruit`.
@@ -76,7 +78,7 @@ Add a https://docs.micronaut.io/latest/guide/#httpClient[Micronaut declarative H
 
 test:FruitClient[]
 
-By using the feature `mongo-sync`, the application includes the following test dependencies:
+By using the feature `mongo-reactive`, the application includes the following test dependencies:
 
 :dependencies:
 dependency:junit-jupiter[groupId=org.testcontainers,scope=test]

--- a/guides/micronaut-mongodb-synchronous/java/src/main/java/example/micronaut/Fruit.java
+++ b/guides/micronaut-mongodb-synchronous/java/src/main/java/example/micronaut/Fruit.java
@@ -18,12 +18,14 @@ package example.micronaut;
 import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.serde.annotation.Serdeable;
 import org.bson.codecs.pojo.annotations.BsonCreator;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import jakarta.validation.constraints.NotBlank;
 
+@ReflectiveAccess
 @Serdeable // <1>
 public class Fruit {
 

--- a/guides/micronaut-mongodb-synchronous/kotlin/src/main/kotlin/example/micronaut/Fruit.kt
+++ b/guides/micronaut-mongodb-synchronous/kotlin/src/main/kotlin/example/micronaut/Fruit.kt
@@ -16,11 +16,13 @@
 package example.micronaut
 
 import io.micronaut.core.annotation.Creator
+import io.micronaut.core.annotation.ReflectiveAccess
 import io.micronaut.serde.annotation.Serdeable
 import org.bson.codecs.pojo.annotations.BsonCreator
 import org.bson.codecs.pojo.annotations.BsonProperty
 import jakarta.validation.constraints.NotBlank
 
+@ReflectiveAccess
 @Serdeable // <1>
 data class Fruit @Creator @BsonCreator constructor( // <4>
     @field:BsonProperty("name") @param:BsonProperty("name") @field:NotBlank val name: String, // <2> <3>

--- a/guides/micronaut-mongodb-synchronous/micronaut-mongodb-synchronous.adoc
+++ b/guides/micronaut-mongodb-synchronous/micronaut-mongodb-synchronous.adoc
@@ -19,8 +19,8 @@ callout:constraints[]
 <.> Since the POJO does not have an empty constructor, use the annotations `@BsonCreator` and `BsonProperty` to define data conversion between BSON and POJO with the MongoDB Java driver. See https://docs.mongodb.com/drivers/java/sync/current/fundamentals/data-formats/pojo-customization/#pojos-without-no-argument-constructors[POJOs without No-Argument Constructor].
 callout:creator[]
 
-+Native image note: The MongoDB POJO codec uses reflection to access constructors and fields. When building a native image with GraalVM, you must provide this metadata explicitly. Annotating the domain class with @ReflectiveAccess ensures Micronaut's Graal annotation processor generates the required reflection configuration automatically.
-+
+Native image note: The MongoDB POJO codec uses reflection to access constructors and fields. When building a native image with GraalVM, you must provide this metadata explicitly. Annotating the domain class with @ReflectiveAccess ensures Micronaut's Graal annotation processor generates the required reflection configuration automatically.
+
 === Repository
 
 Create a repository interface to encapsulate the CRUD actions for `Fruit`.

--- a/guides/micronaut-mongodb-synchronous/micronaut-mongodb-synchronous.adoc
+++ b/guides/micronaut-mongodb-synchronous/micronaut-mongodb-synchronous.adoc
@@ -19,6 +19,8 @@ callout:constraints[]
 <.> Since the POJO does not have an empty constructor, use the annotations `@BsonCreator` and `BsonProperty` to define data conversion between BSON and POJO with the MongoDB Java driver. See https://docs.mongodb.com/drivers/java/sync/current/fundamentals/data-formats/pojo-customization/#pojos-without-no-argument-constructors[POJOs without No-Argument Constructor].
 callout:creator[]
 
++Native image note: The MongoDB POJO codec uses reflection to access constructors and fields. When building a native image with GraalVM, you must provide this metadata explicitly. Annotating the domain class with @ReflectiveAccess ensures Micronaut's Graal annotation processor generates the required reflection configuration automatically.
++
 === Repository
 
 Create a repository interface to encapsulate the CRUD actions for `Fruit`.


### PR DESCRIPTION
### Summary

This PR improves the MongoDB guides by fixing native-image compatibility issues and correcting outdated wording.

### Changes included

#### 1. Add `@ReflectiveAccess` to Fruit POJO
The MongoDB Java driver’s POJO codec uses reflection to access constructors and fields.  
When building GraalVM native images, reflection metadata must be explicitly provided.

Adding `@ReflectiveAccess` ensures Micronaut’s Graal annotation processor generates the required reflection configuration automatically.

Files updated:
- micronaut-mongodb-synchronous/java/Fruit.java  
- micronaut-mongodb-asynchronous/java/Fruit.java  
- micronaut-mongodb-synchronous/kotlin/Fruit.kt  

#### 2. Documentation improvements
- Added a **native-image note** explaining why `@ReflectiveAccess` is required for MongoDB POJO codec.
- Corrected “`mongo-sync`” → “`mongo-reactive`” in the asynchronous guide’s Test section.
- Cleaned formatting around the POJO section so examples render properly.

Files updated:
- `micronaut-mongodb-synchronous.adoc`
- `micronaut-mongodb-asynchronous.adoc`

### Why this is needed
Without reflection metadata, GraalVM native images fail with:
