### PR TITLE
Update native-maven-plugin to 0.11.3

### DIFF
--- a/src/docs/common/snippets/common-graal-with-plugins-multi.adoc
+++ b/src/docs/common/snippets/common-graal-with-plugins-multi.adoc
@@ -61,7 +61,7 @@ It is possible to customize the name of the native executable or pass additional
 <plugin>
     <groupId>org.graalvm.buildtools</groupId>
     <artifactId>native-maven-plugin</artifactId>
-    <version>0.10.3</version>
+    <version>0.11.3</version>
     <configuration>
         <!--1-->
         <imageName>mn-graalvm-application</imageName>

--- a/src/docs/common/snippets/common-graal-with-plugins.adoc
+++ b/src/docs/common/snippets/common-graal-with-plugins.adoc
@@ -63,7 +63,7 @@ It is possible to customize the name of the native executable or pass additional
 <plugin>
     <groupId>org.graalvm.buildtools</groupId>
     <artifactId>native-maven-plugin</artifactId>
-    <version>0.10.3</version>
+    <version>0.11.3</version>
     <configuration>
          <!--1-->
          <imageName>mn-graalvm-application</imageName>


### PR DESCRIPTION
the latest native-maven-plugin is 0.11.3 which support generating native image with java 25.