### PR TITLE
Add Micronaut GraphQL chat guide

### DIFF
--- a/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/ChatDataFetcher.java
+++ b/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/ChatDataFetcher.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ChatDataFetcher implements DataFetcher<ChatMessage> {
+
+    private final ChatRepository chatRepository;
+
+    public ChatDataFetcher(ChatRepository chatRepository) {
+        this.chatRepository = chatRepository;
+    }
+
+    @Override
+    public ChatMessage get(DataFetchingEnvironment environment) {
+        return chatRepository.save(environment.getArgument("from"), environment.getArgument("text"));
+    }
+}

--- a/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/ChatMessage.java
+++ b/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/ChatMessage.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+public class ChatMessage {
+
+    private final String from;
+    private final String text;
+
+    public ChatMessage(String from, String text) {
+        this.from = from;
+        this.text = text;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/ChatRepository.java
+++ b/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/ChatRepository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import jakarta.inject.Singleton;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class ChatRepository {
+
+    // <1>
+    private final List<ChatMessage> messages = new ArrayList<>();
+    // <2>
+    private final Sinks.Many<ChatMessage> sink = Sinks.many().multicast().onBackpressureBuffer();
+
+    public List<ChatMessage> findAll() {
+        return List.copyOf(messages);
+    }
+
+    public ChatMessage save(String from, String text) {
+        ChatMessage message = new ChatMessage(from, text);
+        messages.add(message);
+        sink.tryEmitNext(message);
+        return message;
+    }
+
+    public Flux<ChatMessage> stream() {
+        return sink.asFlux();
+    }
+}

--- a/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/GraphQLFactory.java
+++ b/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/GraphQLFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.core.io.ResourceResolver;
+import jakarta.inject.Singleton;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+@Factory
+public class GraphQLFactory {
+
+    @Bean
+    @Singleton
+    public GraphQL graphQL(ResourceResolver resourceResolver,
+                           MessagesDataFetcher messagesDataFetcher,
+                           ChatDataFetcher chatDataFetcher,
+                           StreamDataFetcher streamDataFetcher) {
+        SchemaParser schemaParser = new SchemaParser();
+        SchemaGenerator schemaGenerator = new SchemaGenerator();
+
+        TypeDefinitionRegistry typeRegistry = new TypeDefinitionRegistry();
+        // <1>
+        resourceResolver.getResourceAsStream("classpath:schema.graphqls")
+                .ifPresent(stream -> typeRegistry.merge(schemaParser.parse(new BufferedReader(new InputStreamReader(stream)))));
+
+        // <2>
+        RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+                .type("Query", builder -> builder.dataFetcher("messages", messagesDataFetcher))
+                .type("Mutation", builder -> builder.dataFetcher("chat", chatDataFetcher))
+                .type("Subscription", builder -> builder.dataFetcher("stream", streamDataFetcher))
+                .build();
+
+        GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+        // <3>
+        return GraphQL.newGraphQL(graphQLSchema).build();
+    }
+}

--- a/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/MessagesDataFetcher.java
+++ b/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/MessagesDataFetcher.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class MessagesDataFetcher implements DataFetcher<Iterable<ChatMessage>> {
+
+    private final ChatRepository chatRepository;
+
+    public MessagesDataFetcher(ChatRepository chatRepository) {
+        this.chatRepository = chatRepository;
+    }
+
+    @Override
+    public Iterable<ChatMessage> get(DataFetchingEnvironment environment) {
+        return chatRepository.findAll();
+    }
+}

--- a/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/StreamDataFetcher.java
+++ b/guides/micronaut-graphql-chat/java/src/main/java/example/micronaut/StreamDataFetcher.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+
+@Singleton
+public class StreamDataFetcher implements DataFetcher<Publisher<ChatMessage>> {
+
+    private final ChatRepository chatRepository;
+
+    public StreamDataFetcher(ChatRepository chatRepository) {
+        this.chatRepository = chatRepository;
+    }
+
+    @Override
+    public Publisher<ChatMessage> get(DataFetchingEnvironment environment) {
+        return chatRepository.stream();
+    }
+}

--- a/guides/micronaut-graphql-chat/java/src/test/java/example/micronaut/GraphQLControllerTest.java
+++ b/guides/micronaut-graphql-chat/java/src/test/java/example/micronaut/GraphQLControllerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+@SuppressWarnings("unchecked")
+class GraphQLControllerTest {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void queryAndMutateMessages() {
+        Map<String, Object> initial = execute("{ messages { from text } }");
+        List<Map<String, Object>> messages = (List<Map<String, Object>>) ((Map<String, Object>) initial.get("data")).get("messages");
+        assertEquals(0, messages.size());
+
+        Map<String, Object> created = execute("mutation { chat(from:\\\"Ada\\\", text:\\\"Hello GraphQL\\\") { from text } }");
+        Map<String, Object> createdMessage = (Map<String, Object>) ((Map<String, Object>) created.get("data")).get("chat");
+        assertEquals("Ada", createdMessage.get("from"));
+        assertEquals("Hello GraphQL", createdMessage.get("text"));
+
+        Map<String, Object> queried = execute("{ messages { from text } }");
+        List<Map<String, Object>> updatedMessages = (List<Map<String, Object>>) ((Map<String, Object>) queried.get("data")).get("messages");
+        assertEquals(List.of(Map.of("from", "Ada", "text", "Hello GraphQL")), updatedMessages);
+    }
+
+    private Map<String, Object> execute(String graphql) {
+        String query = """
+        { "query": "%s" }
+        """.formatted(graphql);
+
+        HttpResponse<Map<String, Object>> response = client.toBlocking().exchange(
+                HttpRequest.POST("/graphql", query),
+                Argument.mapOf(String.class, Object.class)
+        );
+        assertEquals(HttpStatus.OK, response.status());
+        return response.body();
+    }
+}

--- a/guides/micronaut-graphql-chat/java/src/test/java/example/micronaut/GraphQLSubscriptionTest.java
+++ b/guides/micronaut-graphql-chat/java/src/test/java/example/micronaut/GraphQLSubscriptionTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.websocket.WebSocketClient;
+import io.micronaut.websocket.annotation.ClientWebSocket;
+import io.micronaut.websocket.annotation.OnMessage;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MicronautTest
+@SuppressWarnings("unchecked")
+class GraphQLSubscriptionTest {
+
+    @Inject
+    BeanContext beanContext;
+
+    @Inject
+    EmbeddedServer embeddedServer;
+
+    @Inject
+    JsonMapper jsonMapper;
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void subscriptionReceivesNewMessages() throws Exception {
+        try (GraphQLWsClient webSocketClient = createWebSocketClient()) {
+            webSocketClient.send("{\"type\":\"connection_init\"}");
+
+            Map<String, Object> ack = nextResponse(webSocketClient);
+            assertEquals("connection_ack", ack.get("type"));
+
+            webSocketClient.send("""
+                    {"id":"chat-stream","type":"subscribe","payload":{"query":"subscription { stream { from text } }"}}
+                    """.trim());
+
+            client.toBlocking().exchange(
+                    HttpRequest.POST("/graphql", "{\"query\":\"mutation { chat(from:\\\"Ada\\\", text:\\\"Hello GraphQL\\\") { from text } }\"}"),
+                    Argument.STRING
+            );
+
+            Map<String, Object> next = nextResponse(webSocketClient);
+            assertEquals("next", next.get("type"));
+            Map<String, Object> payload = (Map<String, Object>) next.get("payload");
+            Map<String, Object> data = (Map<String, Object>) payload.get("data");
+            Map<String, Object> stream = (Map<String, Object>) data.get("stream");
+            assertEquals("Ada", stream.get("from"));
+            assertEquals("Hello GraphQL", stream.get("text"));
+
+            webSocketClient.send("{\"id\":\"chat-stream\",\"type\":\"complete\"}");
+        }
+    }
+
+    private GraphQLWsClient createWebSocketClient() {
+        WebSocketClient webSocketClient = beanContext.getBean(WebSocketClient.class);
+        URI uri = URI.create("ws://localhost:" + embeddedServer.getPort() + "/graphql-ws");
+        return Flux.from(webSocketClient.connect(GraphQLWsClient.class, uri)).blockFirst();
+    }
+
+    private Map<String, Object> nextResponse(GraphQLWsClient client) throws InterruptedException, IOException {
+        String message = client.nextResponse();
+        assertNotNull(message);
+        return jsonMapper.readValue(message, Argument.mapOf(String.class, Object.class));
+    }
+
+    @ClientWebSocket(uri = "${graphql.graphql-ws.path:/graphql-ws}", subprotocol = "graphql-transport-ws")
+    abstract static class GraphQLWsClient implements AutoCloseable {
+
+        private final BlockingQueue<String> responses = new ArrayBlockingQueue<>(10);
+
+        @OnMessage
+        void onMessage(String message) {
+            responses.add(message);
+        }
+
+        abstract void send(String message);
+
+        String nextResponse() throws InterruptedException {
+            return responses.poll(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/guides/micronaut-graphql-chat/metadata.json
+++ b/guides/micronaut-graphql-chat/metadata.json
@@ -1,0 +1,15 @@
+{
+  "title": "Build a GraphQL chat application with Micronaut GraphQL",
+  "intro": "Learn how to expose GraphQL queries, mutations, and subscriptions over graphql-ws with Micronaut GraphQL.",
+  "authors": ["Graeme Rocher"],
+  "tags": ["graphql", "websocket", "subscriptions"],
+  "categories": ["GraphQL"],
+  "publicationDate": "2026-04-29",
+  "languages": ["JAVA"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["graphql", "websocket", "reactor", "serialization-jackson"]
+    }
+  ]
+}

--- a/guides/micronaut-graphql-chat/micronaut-graphql-chat.adoc
+++ b/guides/micronaut-graphql-chat/micronaut-graphql-chat.adoc
@@ -1,0 +1,126 @@
+common:header-top.adoc[]
+
+== Getting Started
+
+In this guide, you will create a Micronaut application written in @language@ that exposes a small chat API with https://graphql.org/[GraphQL].
+
+The application combines:
+
+* a GraphQL query to fetch the current messages
+* a GraphQL mutation to post a new message
+* a GraphQL subscription delivered over the `graphql-ws` WebSocket protocol
+
+common:requirements.adoc[]
+
+common:completesolution.adoc[]
+
+common:create-app-features.adoc[]
+
+== Configuration
+
+Enable GraphiQL and GraphQL over WebSockets:
+
+resource:application.properties[]
+
+<1> Enables the GraphiQL UI for local development.
+<2> Enables the `graphql-ws` protocol support provided by Micronaut GraphQL.
+
+== Describe the schema
+
+Create `src/main/resources/schema.graphqls`:
+
+resource:schema.graphqls[]
+
+<1> Exposes the current messages via a query.
+<2> Exposes a mutation to post a new chat message.
+<3> Exposes a subscription that emits every new message.
+
+== Domain model
+
+Create a simple `ChatMessage` type:
+
+source:ChatMessage[]
+
+== Repository
+
+Use an in-memory repository to keep the example focused on GraphQL wiring:
+
+source:ChatRepository[]
+
+<1> Keep previously posted messages so the query can return them.
+<2> Publish every new message to a Reactor sink so subscribers receive updates.
+
+== Data fetchers
+
+Create a data fetcher for each GraphQL operation.
+
+=== Query
+
+source:MessagesDataFetcher[]
+
+=== Mutation
+
+source:ChatDataFetcher[]
+
+=== Subscription
+
+source:StreamDataFetcher[]
+
+== GraphQL factory
+
+Bind the schema to the data fetchers:
+
+source:GraphQLFactory[]
+
+<1> Load and parse the GraphQL schema.
+<2> Wire the query, mutation, and subscription operations.
+<3> Build the executable `GraphQL` bean used by the `/graphql` and `/graphql-ws` endpoints.
+
+common:runapp.adoc[]
+
+Query the message history:
+
+[source,bash]
+----
+curl -X POST 'http://localhost:8080/graphql' \
+     -H 'content-type: application/json' \
+     --data-binary '{"query":"{ messages { from text } }"}'
+----
+
+Create a new message:
+
+[source,bash]
+----
+curl -X POST 'http://localhost:8080/graphql' \
+     -H 'content-type: application/json' \
+     --data-binary '{"query":"mutation { chat(from:\"Ada\", text:\"Hello GraphQL\") { from text } }"}'
+----
+
+You can then connect a WebSocket client to `ws://localhost:8080/graphql-ws` using the `graphql-transport-ws` subprotocol and subscribe with:
+
+[source,json]
+----
+{
+  "id": "chat-stream",
+  "type": "subscribe",
+  "payload": {
+    "query": "subscription { stream { from text } }"
+  }
+}
+----
+
+== Test the application
+
+Create an HTTP test for the query and mutation flow:
+
+test:GraphQLControllerTest[]
+
+Create a WebSocket test for the subscription flow:
+
+test:GraphQLSubscriptionTest[]
+
+== Next Steps
+
+Take a look at the https://micronaut-projects.github.io/micronaut-graphql/latest/guide/[Micronaut GraphQL documentation].
+
+common:helpWithMicronaut.adoc[]

--- a/guides/micronaut-graphql-chat/src/main/resources/application.properties
+++ b/guides/micronaut-graphql-chat/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+graphql.graphiql.enabled=true
+graphql.graphql-ws.enabled=true
+# <1> GraphiQL is useful during development.
+# <2> This turns on the graphql-ws endpoint.

--- a/guides/micronaut-graphql-chat/src/main/resources/schema.graphqls
+++ b/guides/micronaut-graphql-chat/src/main/resources/schema.graphqls
@@ -1,0 +1,19 @@
+type Query {
+  messages: [ChatMessage!]!
+}
+# <1>
+
+type Mutation {
+  chat(from: String!, text: String!): ChatMessage!
+}
+# <2>
+
+type Subscription {
+  stream: ChatMessage!
+}
+# <3>
+
+type ChatMessage {
+  from: String!
+  text: String!
+}


### PR DESCRIPTION
## Summary
- add a new `micronaut-graphql-chat` guide that shows GraphQL queries, mutations, and subscriptions backed by Micronaut GraphQL
- enable `graphql-ws` and document how to subscribe over the `graphql-transport-ws` protocol
- include focused Java tests for HTTP query/mutation behavior and WebSocket subscription delivery

## Verification
- attempted `JAVA_HOME=/opt/jdks/jdk21 PATH=/opt/jdks/jdk21/bin:$PATH ./gradlew micronautGraphqlChatRunTestScript micronautGraphqlChatGenerateDocs --stacktrace`
- blocked by a pre-existing `micronaut-guides` `buildSrc` compile failure in `io.spring.start` imports (`io.micronaut.starter.feature.springboot.template.*` and `io.micronaut.starter.feature.build.gradle.templates.useJunitPlatform` not found)

Resolves micronaut-projects/micronaut-graphql#241
