### PR TITLE
Add Micronaut GraphQL JWT security guide

### DIFF
--- a/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/AuthenticationProviderUserPassword.java
+++ b/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/AuthenticationProviderUserPassword.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.security.authentication.AuthenticationFailureReason;
+import io.micronaut.security.authentication.AuthenticationRequest;
+import io.micronaut.security.authentication.AuthenticationResponse;
+import io.micronaut.security.authentication.provider.HttpRequestAuthenticationProvider;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class AuthenticationProviderUserPassword<B> implements HttpRequestAuthenticationProvider<B> {
+
+    private final UserRepository userRepository;
+
+    public AuthenticationProviderUserPassword(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public AuthenticationResponse authenticate(
+            @Nullable HttpRequest<B> httpRequest,
+            @NonNull AuthenticationRequest<String, String> authenticationRequest
+    ) {
+        return userRepository.findByUsername(authenticationRequest.getIdentity())
+                .filter(user -> user.getPassword().equals(authenticationRequest.getSecret()))
+                .map(user -> AuthenticationResponse.success(user.getUsername(), user.getRoles()))
+                .orElseGet(() -> AuthenticationResponse.failure(AuthenticationFailureReason.CREDENTIALS_DO_NOT_MATCH));
+    }
+}

--- a/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/CurrentUserDataFetcher.java
+++ b/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/CurrentUserDataFetcher.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.security.utils.SecurityService;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class CurrentUserDataFetcher implements DataFetcher<User> {
+
+    private final SecurityService securityService;
+    private final UserRepository userRepository;
+
+    public CurrentUserDataFetcher(SecurityService securityService, UserRepository userRepository) {
+        this.securityService = securityService;
+        this.userRepository = userRepository;
+    }
+
+    @Nullable
+    @Override
+    public User get(DataFetchingEnvironment environment) {
+        return securityService.username()
+                .flatMap(userRepository::findByUsername)
+                .orElse(null);
+    }
+}

--- a/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/GraphQLFactory.java
+++ b/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/GraphQLFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.core.io.ResourceResolver;
+import jakarta.inject.Singleton;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+@Factory
+public class GraphQLFactory {
+
+    @Bean
+    @Singleton
+    public GraphQL graphQL(ResourceResolver resourceResolver,
+                           CurrentUserDataFetcher currentUserDataFetcher,
+                           LoginDataFetcher loginDataFetcher) {
+        SchemaParser schemaParser = new SchemaParser();
+        SchemaGenerator schemaGenerator = new SchemaGenerator();
+
+        TypeDefinitionRegistry typeRegistry = new TypeDefinitionRegistry();
+        resourceResolver.getResourceAsStream("classpath:schema.graphqls")
+                .ifPresent(stream -> typeRegistry.merge(schemaParser.parse(new BufferedReader(new InputStreamReader(stream)))));
+
+        RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+                .type("Query", builder -> builder.dataFetcher("currentUser", currentUserDataFetcher))
+                .type("Mutation", builder -> builder.dataFetcher("login", loginDataFetcher))
+                .build();
+
+        GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring);
+        return GraphQL.newGraphQL(graphQLSchema).build();
+    }
+}

--- a/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/LoginDataFetcher.java
+++ b/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/LoginDataFetcher.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.GraphQLContext;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.authentication.AuthenticationResponse;
+import io.micronaut.security.authentication.Authenticator;
+import io.micronaut.security.authentication.UsernamePasswordCredentials;
+import io.micronaut.security.handlers.LoginHandler;
+import jakarta.inject.Singleton;
+import reactor.core.publisher.Flux;
+
+@Singleton
+public class LoginDataFetcher implements DataFetcher<LoginPayload> {
+
+    private final Authenticator<HttpRequest<?>> authenticator;
+    private final LoginHandler<HttpRequest<?>, MutableHttpResponse<?>> loginHandler;
+    private final UserRepository userRepository;
+
+    public LoginDataFetcher(Authenticator<HttpRequest<?>> authenticator,
+                            LoginHandler<HttpRequest<?>, MutableHttpResponse<?>> loginHandler,
+                            UserRepository userRepository) {
+        this.authenticator = authenticator;
+        this.loginHandler = loginHandler;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public LoginPayload get(DataFetchingEnvironment environment) {
+        GraphQLContext graphQLContext = environment.getGraphQlContext();
+        HttpRequest<?> httpRequest = graphQLContext.get("httpRequest");
+        MutableHttpResponse<?> httpResponse = graphQLContext.get("httpResponse");
+
+        String username = environment.getArgument("username");
+        String password = environment.getArgument("password");
+
+        AuthenticationResponse authenticationResponse = Flux.from(
+                authenticator.authenticate(httpRequest, new UsernamePasswordCredentials(username, password))
+        ).blockFirst();
+
+        if (authenticationResponse != null &&
+                authenticationResponse.isAuthenticated() &&
+                authenticationResponse.getAuthentication().isPresent()) {
+            Authentication authentication = authenticationResponse.getAuthentication().get();
+            MutableHttpResponse<?> loginResponse = loginHandler.loginSuccess(authentication, httpRequest);
+            if (httpResponse != null) {
+                loginResponse.getCookies().forEach(httpResponse::cookie);
+            }
+            return userRepository.findByUsername(username)
+                    .map(LoginPayload::ofUser)
+                    .orElseGet(() -> LoginPayload.ofError("User not found"));
+        }
+
+        String error = authenticationResponse != null
+                ? authenticationResponse.getMessage().orElse("Invalid credentials")
+                : "Invalid credentials";
+        return LoginPayload.ofError(error);
+    }
+}

--- a/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/LoginPayload.java
+++ b/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/LoginPayload.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.core.annotation.Nullable;
+
+public class LoginPayload {
+
+    private final User user;
+    private final String error;
+
+    private LoginPayload(User user, String error) {
+        this.user = user;
+        this.error = error;
+    }
+
+    public static LoginPayload ofUser(User user) {
+        return new LoginPayload(user, null);
+    }
+
+    public static LoginPayload ofError(String error) {
+        return new LoginPayload(null, error);
+    }
+
+    @Nullable
+    public User getUser() {
+        return user;
+    }
+
+    @Nullable
+    public String getError() {
+        return error;
+    }
+}

--- a/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/RequestResponseCustomizer.java
+++ b/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/RequestResponseCustomizer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.ExecutionInput;
+import io.micronaut.configuration.graphql.GraphQLExecutionInputCustomizer;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+
+@Singleton
+@Primary
+public class RequestResponseCustomizer implements GraphQLExecutionInputCustomizer {
+
+    @Override
+    public Publisher<ExecutionInput> customize(ExecutionInput executionInput,
+                                               HttpRequest httpRequest,
+                                               @Nullable MutableHttpResponse<String> httpResponse) {
+        executionInput.getGraphQLContext()
+                .put("httpRequest", httpRequest)
+                .put("httpResponse", httpResponse);
+        return Publishers.just(executionInput);
+    }
+}

--- a/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/User.java
+++ b/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/User.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import java.util.List;
+
+public class User {
+
+    private final String username;
+    private final String password;
+    private final String firstName;
+    private final String lastName;
+    private final List<String> roles;
+
+    public User(String username, String password, String firstName, String lastName, List<String> roles) {
+        this.username = username;
+        this.password = password;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.roles = roles;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+}

--- a/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/UserRepository.java
+++ b/guides/micronaut-graphql-jwt-security/java/src/main/java/example/micronaut/UserRepository.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Singleton
+public class UserRepository {
+
+    private static final Map<String, User> USERS = Map.of(
+            "test", new User("test", "test", "Test", "Test", List.of("ROLE_USER")),
+            "admin", new User("admin", "password", "Admin", "Adminovich", List.of("ROLE_ADMIN"))
+    );
+
+    public Optional<User> findByUsername(String username) {
+        return Optional.ofNullable(USERS.get(username));
+    }
+}

--- a/guides/micronaut-graphql-jwt-security/java/src/test/java/example/micronaut/GraphQLSecurityTest.java
+++ b/guides/micronaut-graphql-jwt-security/java/src/test/java/example/micronaut/GraphQLSecurityTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@MicronautTest
+@SuppressWarnings("unchecked")
+class GraphQLSecurityTest {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void anonymousCurrentUserReturnsNull() {
+        Map<String, Object> body = execute("{ currentUser { username } }");
+        Map<String, Object> data = (Map<String, Object>) body.get("data");
+        assertNull(data.get("currentUser"));
+    }
+
+    @Test
+    void loginSetsCookieAndAllowsCurrentUserQuery() {
+        HttpResponse<Map<String, Object>> loginResponse = exchange("mutation { login(username:\\\"admin\\\", password:\\\"password\\\") { user { username roles } error } }");
+        String cookie = loginResponse.getHeaders().get("Set-Cookie");
+        assertNotNull(cookie);
+
+        Map<String, Object> loginData = (Map<String, Object>) loginResponse.body().get("data");
+        Map<String, Object> loginPayload = (Map<String, Object>) loginData.get("login");
+        Map<String, Object> user = (Map<String, Object>) loginPayload.get("user");
+        assertEquals("admin", user.get("username"));
+        assertNull(loginPayload.get("error"));
+
+        HttpRequest<String> currentUserRequest = HttpRequest.POST(
+                "/graphql",
+                "{\"query\":\"{ currentUser { username firstName lastName roles } }\"}"
+        ).header("Cookie", cookie.split(";", 2)[0]);
+
+        HttpResponse<Map<String, Object>> currentUserResponse = client.toBlocking().exchange(
+                currentUserRequest,
+                Argument.mapOf(String.class, Object.class)
+        );
+
+        Map<String, Object> currentUserData = (Map<String, Object>) currentUserResponse.body().get("data");
+        Map<String, Object> currentUser = (Map<String, Object>) currentUserData.get("currentUser");
+        assertEquals("admin", currentUser.get("username"));
+        assertEquals("Admin", currentUser.get("firstName"));
+    }
+
+    @Test
+    void failedLoginReturnsError() {
+        Map<String, Object> body = execute("mutation { login(username:\\\"admin\\\", password:\\\"wrong\\\") { user { username } error } }");
+        Map<String, Object> data = (Map<String, Object>) body.get("data");
+        Map<String, Object> loginPayload = (Map<String, Object>) data.get("login");
+        assertNull(loginPayload.get("user"));
+        assertNotNull(loginPayload.get("error"));
+    }
+
+    private Map<String, Object> execute(String graphql) {
+        return exchange(graphql).body();
+    }
+
+    private HttpResponse<Map<String, Object>> exchange(String graphql) {
+        String query = """
+        { "query": "%s" }
+        """.formatted(graphql);
+
+        HttpResponse<Map<String, Object>> response = client.toBlocking().exchange(
+                HttpRequest.POST("/graphql", query),
+                Argument.mapOf(String.class, Object.class)
+        );
+        assertEquals(HttpStatus.OK, response.status());
+        return response;
+    }
+}

--- a/guides/micronaut-graphql-jwt-security/metadata.json
+++ b/guides/micronaut-graphql-jwt-security/metadata.json
@@ -1,0 +1,15 @@
+{
+  "title": "Secure GraphQL with Micronaut Security JWT",
+  "intro": "Learn how to authenticate a GraphQL mutation and query with Micronaut Security JWT cookies.",
+  "authors": ["Graeme Rocher"],
+  "tags": ["graphql", "security", "jwt"],
+  "categories": ["GraphQL"],
+  "publicationDate": "2026-04-29",
+  "languages": ["JAVA"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["graphql", "security-jwt", "reactor", "serialization-jackson"]
+    }
+  ]
+}

--- a/guides/micronaut-graphql-jwt-security/micronaut-graphql-jwt-security.adoc
+++ b/guides/micronaut-graphql-jwt-security/micronaut-graphql-jwt-security.adoc
@@ -1,0 +1,112 @@
+common:header-top.adoc[]
+
+== Getting Started
+
+In this guide, you will create a Micronaut application written in @language@ that secures a GraphQL API with https://jwt.io/[JSON Web Tokens].
+
+The application exposes:
+
+* a `login` mutation which authenticates a user and writes the JWT to a cookie
+* a `currentUser` query which returns the authenticated user from the Micronaut Security context
+
+common:requirements.adoc[]
+
+common:completesolution.adoc[]
+
+common:create-app-features.adoc[]
+
+== Configuration
+
+Configure JWT cookie authentication and allow anonymous access to the GraphQL endpoint so the `login` mutation can run:
+
+resource:application.properties[]
+
+== Describe the schema
+
+Create `src/main/resources/schema.graphqls`:
+
+resource:schema.graphqls[]
+
+== Domain model
+
+Create a `User` type:
+
+source:User[]
+
+Store a couple of in-memory users in a repository:
+
+source:UserRepository[]
+
+== Authentication provider
+
+Create an `AuthenticationProvider` backed by the repository:
+
+source:AuthenticationProviderUserPassword[]
+
+== Pass the request and response into GraphQL
+
+The login mutation needs access to the `HttpRequest` and `MutableHttpResponse` so it can ask Micronaut Security to write the authentication cookie.
+
+source:RequestResponseCustomizer[]
+
+== Data fetchers
+
+Create a query data fetcher that resolves the currently authenticated user:
+
+source:CurrentUserDataFetcher[]
+
+Create a payload object for the login mutation:
+
+source:LoginPayload[]
+
+Create the login mutation data fetcher:
+
+source:LoginDataFetcher[]
+
+The mutation authenticates the supplied credentials, copies the login cookie to the GraphQL HTTP response, and returns either the logged-in user or an error message.
+
+== GraphQL factory
+
+Bind the schema to the query and mutation fetchers:
+
+source:GraphQLFactory[]
+
+common:runapp.adoc[]
+
+Log in with a GraphQL mutation:
+
+[source,bash]
+----
+curl -i -X POST 'http://localhost:8080/graphql' \
+     -H 'content-type: application/json' \
+     --data-binary '{"query":"mutation { login(username:\"admin\", password:\"password\") { user { username roles } error } }"}'
+----
+
+Reuse the returned `Set-Cookie` header to query the authenticated user:
+
+[source,bash]
+----
+curl -X POST 'http://localhost:8080/graphql' \
+     -H 'content-type: application/json' \
+     -H 'Cookie: JWT=...' \
+     --data-binary '{"query":"{ currentUser { username firstName lastName roles } }"}'
+----
+
+== Test the application
+
+Create an integration test for the GraphQL authentication flow:
+
+test:GraphQLSecurityTest[]
+
+The test covers:
+
+* an anonymous `currentUser` query returning `null`
+* a successful `login` mutation setting a cookie
+* an authenticated `currentUser` query returning the logged-in user
+* a failed `login` mutation returning an error payload
+
+== Next Steps
+
+Take a look at the https://micronaut-projects.github.io/micronaut-graphql/latest/guide/[Micronaut GraphQL documentation] and the https://micronaut-projects.github.io/micronaut-security/latest/guide/#jwt[Micronaut Security JWT guide].
+
+common:helpWithMicronaut.adoc[]

--- a/guides/micronaut-graphql-jwt-security/src/main/resources/application.properties
+++ b/guides/micronaut-graphql-jwt-security/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+micronaut.application.name=micronautguide
+micronaut.security.authentication=cookie
+micronaut.security.token.refresh.cookie.enabled=false
+micronaut.security.token.jwt.signatures.secret.generator.secret="${JWT_GENERATOR_SIGNATURE_SECRET:pleaseChangeThisSecretForANewOne}"
+micronaut.security.intercept-url-map[0].pattern=/**
+micronaut.security.intercept-url-map[0].http-method=GET
+micronaut.security.intercept-url-map[0].access[0]=isAnonymous()
+micronaut.security.intercept-url-map[1].pattern=/**
+micronaut.security.intercept-url-map[1].http-method=POST
+micronaut.security.intercept-url-map[1].access[0]=isAnonymous()
+graphql.graphiql.enabled=true

--- a/guides/micronaut-graphql-jwt-security/src/main/resources/schema.graphqls
+++ b/guides/micronaut-graphql-jwt-security/src/main/resources/schema.graphqls
@@ -1,0 +1,19 @@
+type Query {
+  currentUser: User
+}
+
+type Mutation {
+  login(username: String!, password: String!): LoginPayload!
+}
+
+type User {
+  username: String!
+  firstName: String!
+  lastName: String!
+  roles: [String!]!
+}
+
+type LoginPayload {
+  user: User
+  error: String
+}


### PR DESCRIPTION
## Summary
- add a new `micronaut-graphql-jwt-security` guide that shows GraphQL login and authenticated queries backed by Micronaut Security JWT cookies
- pass the HTTP request and response into the GraphQL context so the login mutation can write the authentication cookie
- include a focused Java integration test covering anonymous access, successful login, authenticated follow-up queries, and failed login

## Verification
- attempted focused guide validation in this checkout
- blocked by a pre-existing `micronaut-guides` `buildSrc` compile failure in `io.spring.start` imports (`io.micronaut.starter.feature.springboot.template.*` and `io.micronaut.starter.feature.build.gradle.templates.useJunitPlatform` not found)

Resolves micronaut-projects/micronaut-graphql#241
