### PR TITLE
Add Micronaut GraphQL Java Tools guide

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/GraphqlJavaTools.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/GraphqlJavaTools.java
@@ -1,0 +1,11 @@
+package io.micronaut.guides.feature;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class GraphqlJavaTools extends AbstractFeature {
+
+    public GraphqlJavaTools() {
+        super("graphql-java-tools");
+    }
+}

--- a/buildSrc/src/main/resources/pom.xml
+++ b/buildSrc/src/main/resources/pom.xml
@@ -202,5 +202,10 @@
             <artifactId>swagger-annotations</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.graphql-java-kickstart</groupId>
+            <artifactId>graphql-java-tools</artifactId>
+            <version>14.0.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/Author.java
+++ b/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/Author.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+public class Author {
+
+    private final String id;
+    private final String username;
+
+    public Author(String id, String username) {
+        this.id = id;
+        this.username = username;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/AuthorDataLoader.java
+++ b/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/AuthorDataLoader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.dataloader.MappedBatchLoader;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toMap;
+
+@Singleton
+public class AuthorDataLoader implements MappedBatchLoader<String, Author> {
+
+    private final AuthorRepository authorRepository;
+    private final ExecutorService executor;
+
+    public AuthorDataLoader(AuthorRepository authorRepository,
+                            @Named(TaskExecutors.IO) ExecutorService executor) {
+        this.authorRepository = authorRepository;
+        this.executor = executor;
+    }
+
+    @Override
+    public CompletionStage<Map<String, Author>> load(Set<String> keys) {
+        return CompletableFuture.supplyAsync(() ->
+                authorRepository.findAllById(keys)
+                        .stream()
+                        .collect(toMap(Author::getId, Function.identity())), executor);
+    }
+}

--- a/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/AuthorRepository.java
+++ b/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/AuthorRepository.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import jakarta.inject.Singleton;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Singleton
+public class AuthorRepository {
+
+    private final Map<String, Author> authors = new HashMap<>();
+
+    public List<Author> findAllById(Collection<String> ids) {
+        return authors.values().stream()
+                .filter(author -> ids.contains(author.getId()))
+                .toList();
+    }
+
+    public Author findOrCreate(String username) {
+        if (!authors.containsKey(username)) {
+            authors.put(username, new Author(UUID.randomUUID().toString(), username));
+        }
+        return authors.get(username);
+    }
+}

--- a/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/DataLoaderRegistryFactory.java
+++ b/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/DataLoaderRegistryFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.runtime.http.scope.RequestScope;
+import org.dataloader.DataLoaderFactory;
+import org.dataloader.DataLoaderRegistry;
+
+@Factory
+public class DataLoaderRegistryFactory {
+
+    private final AuthorDataLoader authorDataLoader;
+
+    public DataLoaderRegistryFactory(AuthorDataLoader authorDataLoader) {
+        this.authorDataLoader = authorDataLoader;
+    }
+
+    @RequestScope
+    public DataLoaderRegistry dataLoaderRegistry() {
+        DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
+        dataLoaderRegistry.register("author", DataLoaderFactory.newMappedDataLoader(authorDataLoader));
+        return dataLoaderRegistry;
+    }
+}

--- a/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/GraphQLFactory.java
+++ b/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/GraphQLFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.GraphQL;
+import graphql.kickstart.tools.SchemaParser;
+import graphql.schema.GraphQLSchema;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Singleton;
+
+@Factory
+public class GraphQLFactory {
+
+    @Bean
+    @Singleton
+    public GraphQL graphQL(ToDoQueryResolver toDoQueryResolver,
+                           ToDoMutationResolver toDoMutationResolver,
+                           ToDoResolver toDoResolver) {
+        GraphQLSchema graphQLSchema = SchemaParser.newParser()
+                .file("schema.graphqls")
+                .resolvers(toDoQueryResolver, toDoMutationResolver, toDoResolver)
+                .build()
+                .makeExecutableSchema();
+        return GraphQL.newGraphQL(graphQLSchema).build();
+    }
+}

--- a/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/ToDo.java
+++ b/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/ToDo.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+public class ToDo {
+
+    private String id;
+    private String title;
+    private boolean completed;
+    private String authorId;
+
+    public ToDo(String title, String authorId) {
+        this.title = title;
+        this.authorId = authorId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+
+    public String getAuthorId() {
+        return authorId;
+    }
+
+    public void setAuthorId(String authorId) {
+        this.authorId = authorId;
+    }
+}

--- a/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/ToDoMutationResolver.java
+++ b/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/ToDoMutationResolver.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ToDoMutationResolver implements GraphQLMutationResolver {
+
+    private final ToDoRepository toDoRepository;
+    private final AuthorRepository authorRepository;
+
+    public ToDoMutationResolver(ToDoRepository toDoRepository, AuthorRepository authorRepository) {
+        this.toDoRepository = toDoRepository;
+        this.authorRepository = authorRepository;
+    }
+
+    public ToDo createToDo(String title, String author) {
+        Author toDoAuthor = authorRepository.findOrCreate(author);
+        ToDo toDo = new ToDo(title, toDoAuthor.getId());
+        return toDoRepository.save(toDo);
+    }
+
+    public Boolean completeToDo(String id) {
+        ToDo toDo = toDoRepository.findById(id);
+        if (toDo == null) {
+            return false;
+        }
+        toDo.setCompleted(true);
+        toDoRepository.save(toDo);
+        return true;
+    }
+
+    public Boolean deleteToDo(String id) {
+        ToDo toDo = toDoRepository.findById(id);
+        if (toDo == null) {
+            return false;
+        }
+        toDoRepository.deleteById(id);
+        return true;
+    }
+}

--- a/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/ToDoQueryResolver.java
+++ b/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/ToDoQueryResolver.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.kickstart.tools.GraphQLQueryResolver;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ToDoQueryResolver implements GraphQLQueryResolver {
+
+    private final ToDoRepository toDoRepository;
+
+    public ToDoQueryResolver(ToDoRepository toDoRepository) {
+        this.toDoRepository = toDoRepository;
+    }
+
+    public Iterable<ToDo> toDos() {
+        return toDoRepository.findAll();
+    }
+}

--- a/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/ToDoRepository.java
+++ b/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/ToDoRepository.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import jakarta.inject.Singleton;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Singleton
+public class ToDoRepository {
+
+    private final Map<String, ToDo> toDos = new LinkedHashMap<>();
+
+    public ToDoRepository(AuthorRepository authorRepository) {
+        save(new ToDo("Book flights to Gran Canaria", authorRepository.findOrCreate("William").getId()));
+        save(new ToDo("Order torrefacto coffee beans", authorRepository.findOrCreate("George").getId()));
+        save(new ToDo("Watch La Casa de Papel", authorRepository.findOrCreate("George").getId()));
+    }
+
+    public Iterable<ToDo> findAll() {
+        return toDos.values();
+    }
+
+    public ToDo findById(String id) {
+        return toDos.get(id);
+    }
+
+    public ToDo save(ToDo toDo) {
+        if (toDo.getId() == null) {
+            toDo.setId(UUID.randomUUID().toString());
+        }
+        toDos.put(toDo.getId(), toDo);
+        return toDo;
+    }
+
+    public void deleteById(String id) {
+        toDos.remove(id);
+    }
+}

--- a/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/ToDoResolver.java
+++ b/guides/micronaut-graphql-java-tools/java/src/main/java/example/micronaut/ToDoResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import graphql.kickstart.tools.GraphQLResolver;
+import graphql.schema.DataFetchingEnvironment;
+import jakarta.inject.Singleton;
+import org.dataloader.DataLoader;
+
+import java.util.concurrent.CompletableFuture;
+
+@Singleton
+public class ToDoResolver implements GraphQLResolver<ToDo> {
+
+    public CompletableFuture<Author> author(ToDo toDo, DataFetchingEnvironment environment) {
+        DataLoader<String, Author> dataLoader = environment.getDataLoader("author");
+        return dataLoader.load(toDo.getAuthorId());
+    }
+}

--- a/guides/micronaut-graphql-java-tools/java/src/test/java/example/micronaut/GraphQLControllerTest.java
+++ b/guides/micronaut-graphql-java-tools/java/src/test/java/example/micronaut/GraphQLControllerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+@SuppressWarnings("unchecked")
+class GraphQLControllerTest {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void queryAndMutateToDos() {
+        Map<String, Object> initial = execute("{ toDos { id title completed author { username } } }");
+        List<Map<String, Object>> toDos = (List<Map<String, Object>>) ((Map<String, Object>) initial.get("data")).get("toDos");
+        assertEquals(3, toDos.size());
+        assertEquals("William", ((Map<String, Object>) toDos.get(0).get("author")).get("username"));
+
+        Map<String, Object> created = execute("mutation { createToDo(title:\\\"Write Java Tools guide\\\", author:\\\"Ada\\\") { id title completed author { username } } }");
+        Map<String, Object> createdToDo = (Map<String, Object>) ((Map<String, Object>) created.get("data")).get("createToDo");
+        assertEquals("Write Java Tools guide", createdToDo.get("title"));
+        assertEquals(Boolean.FALSE, createdToDo.get("completed"));
+        assertEquals("Ada", ((Map<String, Object>) createdToDo.get("author")).get("username"));
+        assertNotNull(createdToDo.get("id"));
+
+        Map<String, Object> completed = execute("mutation { completeToDo(id:\\\"" + createdToDo.get("id") + "\\\") }");
+        assertTrue((Boolean) ((Map<String, Object>) completed.get("data")).get("completeToDo"));
+
+        Map<String, Object> deleted = execute("mutation { deleteToDo(id:\\\"" + createdToDo.get("id") + "\\\") }");
+        assertTrue((Boolean) ((Map<String, Object>) deleted.get("data")).get("deleteToDo"));
+
+        Map<String, Object> missing = execute("mutation { deleteToDo(id:\\\"missing\\\") }");
+        assertFalse((Boolean) ((Map<String, Object>) missing.get("data")).get("deleteToDo"));
+    }
+
+    private Map<String, Object> execute(String graphql) {
+        String query = """
+        { "query": "%s" }
+        """.formatted(graphql);
+
+        HttpResponse<Map<String, Object>> response = client.toBlocking().exchange(
+                HttpRequest.POST("/graphql", query),
+                Argument.mapOf(String.class, Object.class)
+        );
+        assertEquals(HttpStatus.OK, response.status());
+        return response.body();
+    }
+}

--- a/guides/micronaut-graphql-java-tools/metadata.json
+++ b/guides/micronaut-graphql-java-tools/metadata.json
@@ -1,0 +1,15 @@
+{
+  "title": "Build a ToDo application with Micronaut GraphQL Java Tools",
+  "intro": "Learn how to build a schema-first GraphQL ToDo application with Micronaut GraphQL and GraphQL Java Tools.",
+  "authors": ["Graeme Rocher"],
+  "tags": ["graphql", "graphql-java-tools"],
+  "categories": ["GraphQL"],
+  "publicationDate": "2026-04-29",
+  "languages": ["JAVA"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["graphql", "serialization-jackson", "graphql-java-tools"]
+    }
+  ]
+}

--- a/guides/micronaut-graphql-java-tools/micronaut-graphql-java-tools.adoc
+++ b/guides/micronaut-graphql-java-tools/micronaut-graphql-java-tools.adoc
@@ -1,0 +1,120 @@
+common:header-top.adoc[]
+
+== Getting Started
+
+In this guide, you will create a Micronaut application written in @language@ that exposes a ToDo API with https://graphql.org/[GraphQL] and https://www.graphql-java-kickstart.com/tools/[GraphQL Java Tools].
+
+GraphQL Java Tools is a schema-first library. You define the GraphQL schema in `schema.graphqls`, then implement resolvers that match the query, mutation, and nested field names.
+
+common:requirements.adoc[]
+
+common:completesolution.adoc[]
+
+common:create-app-features.adoc[]
+
+== GraphiQL
+
+Enable GraphiQL for local exploration:
+
+resource:application.properties[]
+
+== Describe the schema
+
+Create `src/main/resources/schema.graphqls`:
+
+resource:schema.graphqls[]
+
+The schema exposes:
+
+* a `toDos` query
+* mutations to create, complete, and delete ToDos
+* a nested `author` field for every `ToDo`
+
+== Domain model
+
+Create an `Author` type:
+
+source:Author[]
+
+Create a `ToDo` type:
+
+source:ToDo[]
+
+== Repositories
+
+Store authors in memory:
+
+source:AuthorRepository[]
+
+Store ToDos in memory:
+
+source:ToDoRepository[]
+
+== DataLoader support
+
+Use a batch loader to resolve authors by id:
+
+source:AuthorDataLoader[]
+
+Register a request-scoped `DataLoaderRegistry`:
+
+source:DataLoaderRegistryFactory[]
+
+== GraphQL Java Tools resolvers
+
+Create the query resolver:
+
+source:ToDoQueryResolver[]
+
+Create the mutation resolver:
+
+source:ToDoMutationResolver[]
+
+Create a nested-field resolver for `ToDo.author`:
+
+source:ToDoResolver[]
+
+== GraphQL factory
+
+Create the executable schema with GraphQL Java Tools:
+
+source:GraphQLFactory[]
+
+common:runapp.adoc[]
+
+Query the current ToDos:
+
+[source,bash]
+----
+curl -X POST 'http://localhost:8080/graphql' \
+     -H 'content-type: application/json' \
+     --data-binary '{"query":"{ toDos { id title completed author { username } } }"}'
+----
+
+Create a new ToDo:
+
+[source,bash]
+----
+curl -X POST 'http://localhost:8080/graphql' \
+     -H 'content-type: application/json' \
+     --data-binary '{"query":"mutation { createToDo(title:\"Write GraphQL Java Tools guide\", author:\"Ada\") { id title author { username } } }"}'
+----
+
+== Test the application
+
+Create an integration test that exercises the full query and mutation flow:
+
+test:GraphQLControllerTest[]
+
+The test covers:
+
+* the initial ToDo list
+* creating a ToDo with an author
+* completing and deleting a ToDo
+* resolving the nested `author` field through the DataLoader-backed resolver
+
+== Next Steps
+
+Take a look at the https://micronaut-projects.github.io/micronaut-graphql/latest/guide/[Micronaut GraphQL documentation].
+
+common:helpWithMicronaut.adoc[]

--- a/guides/micronaut-graphql-java-tools/src/main/resources/application.properties
+++ b/guides/micronaut-graphql-java-tools/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+graphql.graphiql.enabled=true

--- a/guides/micronaut-graphql-java-tools/src/main/resources/schema.graphqls
+++ b/guides/micronaut-graphql-java-tools/src/main/resources/schema.graphqls
@@ -1,0 +1,21 @@
+type Query {
+  toDos: [ToDo!]!
+}
+
+type Mutation {
+  createToDo(title: String!, author: String!): ToDo
+  completeToDo(id: ID!): Boolean!
+  deleteToDo(id: ID!): Boolean!
+}
+
+type ToDo {
+  id: ID!
+  title: String!
+  completed: Boolean!
+  author: Author!
+}
+
+type Author {
+  id: ID!
+  username: String!
+}


### PR DESCRIPTION
## Summary
- add a new `micronaut-graphql-java-tools` guide that shows a schema-first ToDo API built with Micronaut GraphQL and GraphQL Java Tools
- register the `graphql-java-tools` starter feature in `buildSrc` and add its dependency coordinates for guide generation
- include a focused Java integration test covering query, create, complete, delete, and nested author resolution

## Verification
- attempted focused guide validation in this checkout
- blocked by a pre-existing `micronaut-guides` `buildSrc` compile failure in `io.spring.start` imports (`io.micronaut.starter.feature.springboot.template.*` and `io.micronaut.starter.feature.build.gradle.templates.useJunitPlatform` not found)

Resolves micronaut-projects/micronaut-graphql#241
