### PR TITLE
Fix GraalPyModule guide links

### DIFF
--- a/guides/micronaut-graalpy-python-package/micronaut-graalpy-python-package.adoc
+++ b/guides/micronaut-graalpy-python-package/micronaut-graalpy-python-package.adoc
@@ -29,7 +29,7 @@ In order to make it work, we first need a Java interface providing the intended 
 
 Create a Java interface with the following code:
 source:PygalModule[]
-<.> The @api@/io/micronaut/graal/graalpy/annotations/GraalPyModule.html[@GraalPyModule] annotation indicates that the bean created from the interface is intended to import the `pygal` Python package and expose it to the Java code using the https://www.graalvm.org/truffle/javadoc/org/graalvm/polyglot/Value.html#target-type-mapping-heading[Target type mapping].
+<.> The https://micronaut-projects.github.io/micronaut-graal-languages/latest/api/io/micronaut/graal/graalpy/annotations/GraalPyModule.html[@GraalPyModule] annotation indicates that the bean created from the interface is intended to import the `pygal` Python package and expose it to the Java code using the https://www.graalvm.org/truffle/javadoc/org/graalvm/polyglot/Value.html#target-type-mapping-heading[Target type mapping].
 <.> Java method matching the `StackedBar` Python class constructor.
 <.> Java interface with methods matching functions from the `StackedBar` Python class we want to use.
 <.> Java method matching the `StackedBar.add(title, values)` Python function.

--- a/guides/micronaut-graalpy/micronaut-graalpy.adoc
+++ b/guides/micronaut-graalpy/micronaut-graalpy.adoc
@@ -25,8 +25,8 @@ In order to make it work, we first need a Java interface providing the intended 
 
 Create a Java interface with the following code:
 source:HelloModule[]
-<1> The @api@/io/micronaut/graal/graalpy/annotations/GraalPyModule.html[@GraalPyModule] annotation indicates that the bean created from the interface
-is intended to import the `hello.py` Python module into GraalPy and and expose it to the Java code using
+<1> The https://micronaut-projects.github.io/micronaut-graal-languages/latest/api/io/micronaut/graal/graalpy/annotations/GraalPyModule.html[@GraalPyModule] annotation indicates that the bean created from the interface
+is intended to import the `hello.py` Python module into GraalPy and expose it to the Java code using
 the https://www.graalvm.org/truffle/javadoc/org/graalvm/polyglot/Value.html#target-type-mapping-heading[Target type mapping].
 <2> Java method matching the Python function `hello(txt)` in `hello.py`.
 


### PR DESCRIPTION
## Summary

- Replaces the broken global Micronaut API link for `@GraalPyModule` in both GraalPy guides.
- Uses the Micronaut Graal Languages `latest` Javadoc URL, matching the nearby guide documentation stream.
- Fixes an adjacent duplicated `and` in the same rendered callout paragraph after review feedback.
- Keeps the patch scoped to the two requested guide source files.

## Issue Linkage

Fixes #1635

## Release / Project Routing

- Target branch: `master`.
- Release target: Micronaut 5.x guide stream.
- QA-selected Micronaut organization project: `5.0.1 Release`.
- Ambiguity preserved from QA: `version.txt` is `5.0.0` and no visible open `5.0.0 Release` project exists; `5.0.1 Release` is the earliest visible open public 5.x Platform BOM board for this docs-only fix.
- Live project association note: `5.0.1 Release` exists as Micronaut org project `#146`, but the active GitHub token lacks the `project` write scope required by `addProjectV2ItemById`, so the PR could not be linked to the board from this run.
- Reviewer routing note: the linked issue creator is `sdelamo`; GitHub rejected the reviewer request because `sdelamo` is also the PR author.

## Verification

- `git diff --check`
- `curl -sS -o /dev/null -w "%{http_code} %{url_effective}\n" https://micronaut-projects.github.io/micronaut-graal-languages/latest/api/io/micronaut/graal/graalpy/annotations/GraalPyModule.html` -> `200`
- `./gradlew cleanAsciidoctorFolder micronautGraalpyGenerateDocs micronautGraalpyPythonPackageGenerateDocs`
- `./gradlew asciidoctor`
- `rg` confirmed the replacement URL in affected generated AsciiDoc and rendered HTML, with the old broken target absent from the affected paths.

## PR Assets

- [Rendered micronaut-graalpy guide PDF](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/533c73fa42a2e86d0e04f7f84e83c3e1c8db3ae2/assets/pr-1642/5620e99f91f9/mng-156-micronaut-graalpy-rendered.pdf)
- ![Rendered micronaut-graalpy-python-package Java binding screenshot](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/2e32b3d04855f3f13794bef12bd2e576db596a70/assets/pr-1642/5620e99f91f9/mng-156-micronaut-graalpy-python-package-java-binding.png)

Note: the full-page PDF upload for the Python package guide returned HTTP 500 from the asset route, so the focused rendered Java-binding screenshot is attached as the PR-visible fallback asset.

---
###### ✨ This message was AI-generated using gpt-5