### PR TITLE
Add Oracle test resources to Maven guide projects

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/guides/GuideProjectGenerator.groovy
@@ -30,6 +30,7 @@ import static groovy.io.FileType.FILES
 import static io.micronaut.core.util.StringUtils.EMPTY_STRING
 import static io.micronaut.starter.api.TestFramework.JUNIT
 import static io.micronaut.starter.api.TestFramework.SPOCK
+import static io.micronaut.starter.options.BuildTool.MAVEN
 import static io.micronaut.starter.options.JdkVersion.JDK_25
 import static io.micronaut.starter.options.Language.GROOVY
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
@@ -48,6 +49,8 @@ class GuideProjectGenerator implements AutoCloseable {
     private static final String BASE_PACKAGE = 'example.micronaut'
     private static final List<JdkVersion> JDK_VERSIONS_SUPPORTED_BY_GRAALVM = [JDK_25]
     public static final String LICENSEHEADER = "LICENSEHEADER"
+    private static final String ORACLE_CLOUD_ATP = 'oracle-cloud-atp'
+    private static final String ORACLE_FREE_TEST_RESOURCES = 'micronaut-test-resources-jdbc-oracle-free'
 
     private final ApplicationContext applicationContext
     private final GuidesGenerator guidesGenerator
@@ -183,9 +186,42 @@ class GuideProjectGenerator implements AutoCloseable {
                         copyFile(inputDir, destinationRoot, zipInclude)
                     }
                 }
+                configureOracleFreeTestResourcesForMaven(destination, buildTool, appFeatures)
                 addLicenses(new File(outputDir.absolutePath, folder))
             }
         }
+    }
+
+    private static void configureOracleFreeTestResourcesForMaven(File destination,
+                                                                 BuildTool buildTool,
+                                                                 List<String> appFeatures) {
+        if (buildTool != MAVEN || !appFeatures.contains(ORACLE_CLOUD_ATP)) {
+            return
+        }
+        File pom = new File(destination, 'pom.xml')
+        if (!pom.exists()) {
+            return
+        }
+
+        String pomText = pom.text
+        if (pomText.contains(ORACLE_FREE_TEST_RESOURCES)) {
+            return
+        }
+
+        String marker = '          <configFile>aot-${packaging}.properties</configFile>\n'
+        if (!pomText.contains(marker)) {
+            throw new GradleException("Cannot configure Oracle Test Resources dependency in ${pom.absolutePath}")
+        }
+
+        String dependency = """          <testResourcesDependencies>
+            <dependency>
+              <groupId>io.micronaut.testresources</groupId>
+              <artifactId>${ORACLE_FREE_TEST_RESOURCES}</artifactId>
+              <version>\${micronaut.test.resources.version}</version>
+            </dependency>
+          </testResourcesDependencies>
+"""
+        pom.text = pomText.replace(marker, marker + dependency)
     }
 
     void addLicenses(File folder) {


### PR DESCRIPTION
## Summary
- Rebases the PR onto current `master`; the original LocalStack and Oracle Cloud Streaming follow-up commits are now superseded by upstream `master` changes.
- Adds the Oracle Free Test Resources module to generated Maven projects that use `oracle-cloud-atp`, matching the generated Gradle projects and restoring the Oracle Autonomous DB Maven Java test path.
- Keeps CI secrets, GitHub Actions, credentials, and cloud account requirements unchanged.

## Related
- Keeps the baseline Test Guides follow-through for #1644 mergeable after `master` changed under the branch.
- Related to #1106. This PR intentionally does not close #1106; #1644 carries `Fixes #1106` for the original Groovy scope-types issue.

## Verification
- `git diff --check origin/master...HEAD`
- `./gradlew buildSrc:compileGroovy --stacktrace`
- `./gradlew micronautOracleAutonomousDbRunTestScript --rerun-tasks --stacktrace` was attempted but could not complete locally because the current runtime has no Docker socket available (`/var/run/docker.sock` missing). The failure occurred while starting Testcontainers for the Maven Java Oracle test path, after the generated Maven project loaded the Oracle Free resolver.

## Release And Project
- Target branch: `master`
- Release target: Micronaut 5 default-branch docs/sample-code/test baseline fix
- Selected Micronaut organization project: `5.0.1 Release` (#146)
- Project-link note: live project association previously could not be applied because the active token lacks Micronaut organization project scope.

## PR Assets
- No rendered asset attached. The change is confined to guide project-generation support covered by focused build verification and pending GitHub Actions guide-test verification.

---
###### ✨ This message was AI-generated using gpt-5
