### PR TITLE
Add Kotlin support for OCI object storage guide

### DIFF
--- a/guides/micronaut-object-storage-base/kotlin/src/main/kotlin/example/micronaut/ProfilePicturesApi.kt
+++ b/guides/micronaut-object-storage-base/kotlin/src/main/kotlin/example/micronaut/ProfilePicturesApi.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Delete
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Status
+import io.micronaut.http.multipart.CompletedFileUpload
+import io.micronaut.http.server.types.files.StreamedFile
+import java.util.Optional
+
+//tag::class[]
+interface ProfilePicturesApi {
+
+    @Post(uri = "/{userId}", consumes = [MediaType.MULTIPART_FORM_DATA]) // <1>
+    fun upload(fileUpload: CompletedFileUpload, userId: String, request: HttpRequest<*>): HttpResponse<*>
+
+    @Get("/{userId}") // <2>
+    fun download(userId: String): Optional<HttpResponse<StreamedFile>>
+
+    @Status(HttpStatus.NO_CONTENT) // <3>
+    @Delete("/{userId}") // <4>
+    fun delete(userId: String)
+}
+//end::class[]

--- a/guides/micronaut-object-storage-base/kotlin/src/test/kotlin/example/micronaut/AbstractProfilePicturesControllerTest.kt
+++ b/guides/micronaut-object-storage-base/kotlin/src/test/kotlin/example/micronaut/AbstractProfilePicturesControllerTest.kt
@@ -30,11 +30,10 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import java.io.BufferedReader
-import java.io.BufferedWriter
-import java.io.FileWriter
 import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -78,7 +77,7 @@ abstract class AbstractProfilePicturesControllerTest {
         val download = client.retrieve(location, ByteArray::class.java)
 
         //then:
-        assertEquals("micronaut", String(download))
+        assertEquals("micronaut", String(download, UTF_8))
 
         //when:
         response = client.exchange(HttpRequest.DELETE<Any>(location))
@@ -88,7 +87,7 @@ abstract class AbstractProfilePicturesControllerTest {
     }
 
     protected fun textFromFile(inputStream: InputStream): String =
-        IOUtils.readText(BufferedReader(InputStreamReader(inputStream)))
+        IOUtils.readText(BufferedReader(InputStreamReader(inputStream, UTF_8)))
 
     @Throws(IOException::class)
     protected abstract fun assertThatFileIsStored(key: String, expected: String)
@@ -98,9 +97,7 @@ abstract class AbstractProfilePicturesControllerTest {
         @Throws(IOException::class)
         fun createTempFile(): Path {
             val path = Files.createTempFile("test-file", ".txt")
-            BufferedWriter(FileWriter(path.toFile())).use { writer ->
-                writer.write("micronaut")
-            }
+            Files.write(path, "micronaut".toByteArray(UTF_8))
             return path
         }
     }

--- a/guides/micronaut-object-storage-base/kotlin/src/test/kotlin/example/micronaut/AbstractProfilePicturesControllerTest.kt
+++ b/guides/micronaut-object-storage-base/kotlin/src/test/kotlin/example/micronaut/AbstractProfilePicturesControllerTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.io.IOUtils
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.multipart.MultipartBody
+import io.micronaut.http.uri.UriBuilder
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.FileWriter
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.nio.file.Files
+import java.nio.file.Path
+
+abstract class AbstractProfilePicturesControllerTest {
+
+    @Inject
+    @field:Client("/")
+    lateinit var httpClient: HttpClient
+
+    @Test
+    @Throws(IOException::class)
+    fun itWorks() {
+        //given:
+        val client = httpClient.toBlocking()
+        val path = createTempFile()
+        val file = path.toFile()
+        val requestBody = MultipartBody
+            .builder()
+            .addPart("fileUpload", file.name, MediaType.TEXT_PLAIN_TYPE, file)
+            .build()
+        val uri = UriBuilder.of(ProfilePicturesController.PREFIX).path("alvaro").build().toString()
+        val request: HttpRequest<*> = HttpRequest
+            .POST(uri, requestBody)
+            .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        //when:
+        var response: HttpResponse<String> = client.exchange(request, String::class.java)
+
+        //then:
+        assertEquals(response.status(), HttpStatus.CREATED)
+        assertNotNull(response.header(HttpHeaders.ETAG))
+        assertThatFileIsStored("alvaro.jpg", "micronaut")
+
+        //when:
+        val location = response.header(HttpHeaders.LOCATION) ?: error("Missing Location header")
+
+        //then:
+        assertNotNull(location)
+
+        //when:
+        val download = client.retrieve(location, ByteArray::class.java)
+
+        //then:
+        assertEquals("micronaut", String(download))
+
+        //when:
+        response = client.exchange(HttpRequest.DELETE<Any>(location))
+
+        //then:
+        assertEquals(HttpStatus.NO_CONTENT, response.status())
+    }
+
+    protected fun textFromFile(inputStream: InputStream): String =
+        IOUtils.readText(BufferedReader(InputStreamReader(inputStream)))
+
+    @Throws(IOException::class)
+    protected abstract fun assertThatFileIsStored(key: String, expected: String)
+
+    companion object {
+        @JvmStatic
+        @Throws(IOException::class)
+        fun createTempFile(): Path {
+            val path = Files.createTempFile("test-file", ".txt")
+            BufferedWriter(FileWriter(path.toFile())).use { writer ->
+                writer.write("micronaut")
+            }
+            return path
+        }
+    }
+}

--- a/guides/micronaut-object-storage-oracle-cloud/kotlin/src/main/kotlin/example/micronaut/ProfilePicturesController.kt
+++ b/guides/micronaut-object-storage-oracle-cloud/kotlin/src/main/kotlin/example/micronaut/ProfilePicturesController.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.multipart.CompletedFileUpload
+import io.micronaut.http.server.types.files.StreamedFile
+import io.micronaut.http.server.util.HttpHostResolver
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.objectstorage.oraclecloud.OracleCloudStorageEntry
+import io.micronaut.objectstorage.oraclecloud.OracleCloudStorageOperations
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import java.net.URI
+import java.util.Optional
+
+//tag::begin-class[]
+@Controller(ProfilePicturesController.PREFIX) // <1>
+@ExecuteOn(TaskExecutors.BLOCKING) // <2>
+class ProfilePicturesController(
+    private val objectStorage: OracleCloudStorageOperations, // <3>
+    private val httpHostResolver: HttpHostResolver // <4>
+) : ProfilePicturesApi {
+
+    companion object {
+        const val PREFIX = "/pictures"
+    }
+//end::begin-class[]
+
+    //tag::upload[]
+    override fun upload(fileUpload: CompletedFileUpload, userId: String, request: HttpRequest<*>): HttpResponse<*> {
+        val key = buildKey(userId) // <1>
+        val objectStorageUpload = UploadRequest.fromCompletedFileUpload(fileUpload, key) // <2>
+        val response = objectStorage.upload(objectStorageUpload) // <3>
+
+        return HttpResponse
+            .created<Any>(location(request, userId)) // <4>
+            .header(HttpHeaders.ETAG, response.getETag()) // <5>
+    }
+
+    private fun buildKey(userId: String): String = "$userId.jpg"
+
+    private fun location(request: HttpRequest<*>, userId: String): URI =
+        UriBuilder.of(httpHostResolver.resolve(request))
+            .path(PREFIX)
+            .path(userId)
+            .build()
+    //end::upload[]
+
+    //tag::download[]
+    override fun download(userId: String): Optional<HttpResponse<StreamedFile>> {
+        val key = buildKey(userId)
+        return objectStorage.retrieve(key) // <1>
+            .map { entry -> buildStreamedFile(entry) } // <2>
+    }
+
+    private fun buildStreamedFile(entry: OracleCloudStorageEntry): HttpResponse<StreamedFile> {
+        val nativeEntry: GetObjectResponse = entry.nativeEntry
+        val mediaType = MediaType.of(nativeEntry.contentType)
+        val file = StreamedFile(entry.inputStream, mediaType).attach(entry.key)
+        val httpResponse: MutableHttpResponse<Any> = HttpResponse.ok<Any>()
+            .header(HttpHeaders.ETAG, nativeEntry.eTag) // <3>
+        file.process(httpResponse)
+        return httpResponse.body(file)
+    }
+    //end::download[]
+
+    //tag::delete[]
+    override fun delete(userId: String) {
+        val key = buildKey(userId)
+        objectStorage.delete(key)
+    }
+    //end::delete[]
+
+//tag::end-class[]
+}
+//end::end-class[]

--- a/guides/micronaut-object-storage-oracle-cloud/kotlin/src/test/kotlin/example/micronaut/OciEmulatorContainer.kt
+++ b/guides/micronaut-object-storage-oracle-cloud/kotlin/src/test/kotlin/example/micronaut/OciEmulatorContainer.kt
@@ -20,9 +20,12 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.utility.DockerImageName
 import java.io.IOException
 import java.io.InputStream
+import java.io.UncheckedIOException
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.function.Supplier
+
+private const val PRIVATE_KEY_PATH = "src/test/resources/key.pem"
 
 class OciEmulatorContainer(dockerImageName: DockerImageName) : GenericContainer<OciEmulatorContainer>(dockerImageName) {
 
@@ -49,9 +52,9 @@ class OciEmulatorContainer(dockerImageName: DockerImageName) : GenericContainer<
     val privateKeySupplier: Supplier<InputStream>
         get() = Supplier {
             try {
-                Files.newInputStream(Paths.get("src/test/resources/key.pem"))
+                Files.newInputStream(Paths.get(PRIVATE_KEY_PATH))
             } catch (e: IOException) {
-                throw RuntimeException(e)
+                throw UncheckedIOException("Unable to read test OCI private key from $PRIVATE_KEY_PATH", e)
             }
         }
 

--- a/guides/micronaut-object-storage-oracle-cloud/kotlin/src/test/kotlin/example/micronaut/OciEmulatorContainer.kt
+++ b/guides/micronaut-object-storage-oracle-cloud/kotlin/src/test/kotlin/example/micronaut/OciEmulatorContainer.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.oracle.bmc.Region
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+import java.io.IOException
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.function.Supplier
+
+class OciEmulatorContainer(dockerImageName: DockerImageName) : GenericContainer<OciEmulatorContainer>(dockerImageName) {
+
+    override fun configure() {
+        super.configure()
+        addExposedPort(DEFAULT_PORT)
+    }
+
+    val endpoint: String
+        get() = "http://127.0.0.1:${getMappedPort(DEFAULT_PORT)}"
+
+    val compartmentId: String
+        get() = "ocid1.compartment.oc1..testcompartment"
+
+    val tenantId: String
+        get() = "ocid1.tenancy.oc1..testtenancy"
+
+    val userId: String
+        get() = "ocid1.user.oc1..testuser"
+
+    val fingerprint: String
+        get() = "50:a6:c1:a1:da:71:57:dc:87:ae:90:af:9c:38:99:67"
+
+    val privateKeySupplier: Supplier<InputStream>
+        get() = Supplier {
+            try {
+                Files.newInputStream(Paths.get("src/test/resources/key.pem"))
+            } catch (e: IOException) {
+                throw RuntimeException(e)
+            }
+        }
+
+    val region: Region
+        get() = Region.SA_SAOPAULO_1
+
+    companion object {
+        val DEFAULT_IMAGE_NAME: DockerImageName = DockerImageName.parse("cameritelabs/oci-emulator")
+        const val DEFAULT_PORT = 12000
+    }
+}

--- a/guides/micronaut-object-storage-oracle-cloud/kotlin/src/test/kotlin/example/micronaut/ProfilePicturesControllerTest.kt
+++ b/guides/micronaut-object-storage-oracle-cloud/kotlin/src/test/kotlin/example/micronaut/ProfilePicturesControllerTest.kt
@@ -89,7 +89,9 @@ class ProfilePicturesControllerTest : AbstractProfilePicturesControllerTest() {
                 .build()
         )
 
-        assertEquals(expected, textFromFile(response.inputStream))
+        response.inputStream.use { inputStream ->
+            assertEquals(expected, textFromFile(inputStream))
+        }
     }
 
     @Singleton

--- a/guides/micronaut-object-storage-oracle-cloud/kotlin/src/test/kotlin/example/micronaut/ProfilePicturesControllerTest.kt
+++ b/guides/micronaut-object-storage-oracle-cloud/kotlin/src/test/kotlin/example/micronaut/ProfilePicturesControllerTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider
+import com.oracle.bmc.objectstorage.ObjectStorage
+import com.oracle.bmc.objectstorage.ObjectStorageClient
+import com.oracle.bmc.objectstorage.model.CreateBucketDetails
+import com.oracle.bmc.objectstorage.requests.CreateBucketRequest
+import com.oracle.bmc.objectstorage.requests.DeleteBucketRequest
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.event.BeanCreatedEvent
+import io.micronaut.context.event.BeanCreatedEventListener
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.objectstorage.oraclecloud.OracleCloudStorageConfiguration
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.io.IOException
+
+private const val SPEC_NAME = "ProfilePicturesControllerTest"
+
+@Testcontainers(disabledWithoutDocker = true)
+@MicronautTest
+@Property(name = "spec.name", value = SPEC_NAME)
+class ProfilePicturesControllerTest : AbstractProfilePicturesControllerTest() {
+
+    @Inject
+    lateinit var client: ObjectStorage
+
+    @Inject
+    lateinit var configuration: OracleCloudStorageConfiguration
+
+    @BeforeEach
+    fun beforeEach() {
+        val bucketDetails = CreateBucketDetails.builder()
+            .compartmentId(ociEmulator.compartmentId)
+            .name(configuration.bucket)
+            .build()
+
+        client.createBucket(
+            CreateBucketRequest.builder()
+                .namespaceName(configuration.namespace)
+                .createBucketDetails(bucketDetails)
+                .build()
+        )
+    }
+
+    @AfterEach
+    fun afterEach() {
+        client.deleteBucket(
+            DeleteBucketRequest.builder()
+                .namespaceName(configuration.namespace)
+                .bucketName(configuration.bucket)
+                .build()
+        )
+    }
+
+    @Throws(IOException::class)
+    override fun assertThatFileIsStored(key: String, expected: String) {
+        val response = client.getObject(
+            GetObjectRequest.builder()
+                .bucketName(configuration.bucket)
+                .namespaceName(configuration.namespace)
+                .objectName(key)
+                .build()
+        )
+
+        assertEquals(expected, textFromFile(response.inputStream))
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    class ObjectStorageListener : BeanCreatedEventListener<ObjectStorageClient> {
+
+        override fun onCreated(@NonNull event: BeanCreatedEvent<ObjectStorageClient>): ObjectStorageClient {
+            val client = event.bean
+            client.setEndpoint(ociEmulator.endpoint)
+            return client
+        }
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    class OciEmulatorAuthenticationFactory {
+
+        @Bean
+        @Singleton
+        fun authenticationDetailsProvider(): SimpleAuthenticationDetailsProvider =
+            SimpleAuthenticationDetailsProvider.builder()
+                .tenantId(ociEmulator.tenantId)
+                .userId(ociEmulator.userId)
+                .fingerprint(ociEmulator.fingerprint)
+                .privateKeySupplier(ociEmulator.privateKeySupplier)
+                .region(ociEmulator.region)
+                .build()
+    }
+
+    companion object {
+        val ociEmulator = OciEmulatorContainer(OciEmulatorContainer.DEFAULT_IMAGE_NAME)
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            ociEmulator.start()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            ociEmulator.stop()
+        }
+    }
+}

--- a/guides/micronaut-object-storage-oracle-cloud/metadata.json
+++ b/guides/micronaut-object-storage-oracle-cloud/metadata.json
@@ -7,7 +7,7 @@
   "categories": ["Object Storage"],
   "cloud": "OCI",
   "publicationDate": "2022-09-26",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary

- Adds Kotlin support to the OCI Object Storage guide metadata.
- Adds the Kotlin profile-picture API, controller, OCI emulator container, and Testcontainers-backed controller test.
- Keeps the PR scoped to MNG-95; unrelated dirty worktree changes are not included.

## Verification

- `./gradlew micronautObjectStorageOracleCloudGenerateProjects micronautObjectStorageOracleCloudGenerateDocs --stacktrace --console=plain`
- `docker info --format '{{.ServerVersion}}'` -> `29.4.3`
- `./gradlew test --rerun-tasks --stacktrace --console=plain` from `build/code/micronaut-object-storage-oracle-cloud/micronaut-object-storage-oracle-cloud-gradle-kotlin`
- `./gradlew micronautObjectStorageOracleCloudIndex --stacktrace --console=plain`
- Rendered guide scan for unresolved placeholders/directives/errors returned no findings.
- `./gradlew micronautObjectStorageOracleCloudRunTestScript --stacktrace --console=plain`
- After Copilot review fixes in `fab9610`: repeated `micronautObjectStorageOracleCloudGenerateProjects micronautObjectStorageOracleCloudGenerateDocs`, generated Gradle Kotlin project `./gradlew test --rerun-tasks`, and `micronautObjectStorageOracleCloudRunTestScript`; all passed locally.

## Release And Project

Target branch: `master`.
Release target: `5.0.1 Release` Micronaut Platform BOM board.
Ambiguity preserved from QA intake: this repository has no stable GitHub release history and `version.txt` still says `5.0.0`, so `5.0.1 Release` is selected as the earliest open Micronaut Platform BOM release board that can consume this default-branch docs change.

Live project association was attempted, but GitHub rejected the mutation because the token lacks the `project` scope: `addProjectV2ItemById` requires `project`; available scopes are `admin:repo_hook`, `read:project`, `read:user`, `repo`, and `workflow`.

Reviewer routing: issue author `sdelamo` could not be requested as reviewer because GitHub rejected requesting review from the pull request author.

CI note: the first PR run failed outside this PR scope in `micronaut-aws-parameter-store` because `localstack/localstack:latest` exited with license activation failure and requested `LOCALSTACK_AUTH_TOKEN`. A new run was queued after `fab9610`.

Closes #1196

## PR Assets

[Generated OCI Object Storage guide PDF](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/d1c097bfee5ef6c2640a8beefafef9e7c333d511/assets/pr-1650/0311130eb0bd/micronaut-object-storage-oracle-cloud.pdf)

---
###### ✨ This message was AI-generated using gpt-5.5-pro