### PR TITLE
Add Kotlin AWS Secrets Manager rotation guide

### DIFF
--- a/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/main/kotlin/example/micronaut/FunctionRequestHandler.kt
+++ b/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/main/kotlin/example/micronaut/FunctionRequestHandler.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.amazonaws.services.lambda.runtime.events.SecretsManagerRotationEvent
+import io.micronaut.aws.distributedconfiguration.KeyValueFetcher
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.function.aws.MicronautRequestHandler
+import io.micronaut.json.JsonMapper
+import jakarta.inject.Inject
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
+import software.amazon.awssdk.services.secretsmanager.model.PutSecretValueRequest
+import tools.jackson.core.JacksonException
+import java.io.IOException
+import java.util.Optional
+
+@Introspected
+class FunctionRequestHandler : MicronautRequestHandler<SecretsManagerRotationEvent, Void?>() { // <1>
+
+    @Inject
+    lateinit var jsonWebKeyGenerator: JsonWebKeyGenerator // <2>
+
+    @Inject
+    lateinit var objectMapper: JsonMapper // <3>
+
+    @Inject
+    lateinit var secretsManagerClient: SecretsManagerClient // <4>
+
+    @Inject
+    lateinit var keyValueFetcher: KeyValueFetcher // <5>
+
+    override fun execute(input: SecretsManagerRotationEvent): Void? {
+        LOG.info("step {} secretId: {}", input.step, input.secretId)
+        SecretsManagerRotationStep.of(input.step).ifPresent { step ->
+            if (step == SecretsManagerRotationStep.FINISH_SECRET) {
+                currentPrimary(input.secretId)
+                    .flatMap { generateSecretString(it) }
+                    .ifPresent { updateSecretString(input, it) }
+            }
+        }
+        return null
+    }
+
+    private fun currentPrimary(secretId: String): Optional<String> = // <6>
+        keyValueFetcher.keyValuesByPrefix(secretId)
+            .filter { it.containsKey(JWK_PRIMARY) }
+            .flatMap { Optional.ofNullable(it[JWK_PRIMARY]) }
+            .map { it.toString() }
+
+    private fun generateSecretString(currentPrimary: String): Optional<String> { // <7>
+        val jsonJwkOptional = jsonWebKeyGenerator.generateJsonWebKey(null)
+        if (jsonJwkOptional.isEmpty) {
+            return Optional.empty()
+        }
+        val newJwk = mapOf(
+            JWK_PRIMARY to jsonJwkOptional.get(),
+            JWK_SECONDARY to currentPrimary
+        )
+        return try {
+            Optional.of(objectMapper.writeValueAsString(newJwk))
+        } catch (e: JacksonException) {
+            LOG.warn("JacksonException", e)
+            Optional.empty()
+        } catch (e: IOException) {
+            LOG.warn("IOException", e)
+            Optional.empty()
+        }
+    }
+
+    private fun updateSecretString(input: SecretsManagerRotationEvent, secretString: String) { // <8>
+        secretsManagerClient.putSecretValue(PutSecretValueRequest.builder()
+            .clientRequestToken(input.clientRequestToken)
+            .secretId(input.secretId)
+            .secretString(secretString)
+            .build())
+    }
+
+    companion object {
+        private const val JWK_PRIMARY = "jwk.primary"
+        private const val JWK_SECONDARY = "jwk.secondary"
+
+        private val LOG = LoggerFactory.getLogger(FunctionRequestHandler::class.java)
+    }
+}

--- a/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/main/kotlin/example/micronaut/JsonWebKeyGenerator.kt
+++ b/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/main/kotlin/example/micronaut/JsonWebKeyGenerator.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import java.util.Optional
+
+/**
+ * [JSON Web Key](https://datatracker.ietf.org/doc/html/rfc7517)
+ */
+interface JsonWebKeyGenerator {
+
+    fun generateJsonWebKey(kid: String?): Optional<String>
+}

--- a/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/main/kotlin/example/micronaut/RS256JsonWebKeyGenerator.kt
+++ b/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/main/kotlin/example/micronaut/RS256JsonWebKeyGenerator.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.nimbusds.jose.JOSEException
+import com.nimbusds.jose.JWSAlgorithm.RS256
+import com.nimbusds.jose.jwk.KeyUse.SIGNATURE
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+import java.util.Optional
+import java.util.UUID
+
+@Singleton // <1>
+class RS256JsonWebKeyGenerator : JsonWebKeyGenerator {
+
+    override fun generateJsonWebKey(kid: String?): Optional<String> {
+        return try {
+            Optional.of(RSAKeyGenerator(2048)
+                .algorithm(RS256)
+                .keyUse(SIGNATURE) // indicate the intended use of the key
+                .keyID(kid ?: generateKid()) // give the key a unique ID
+                .generate()
+                .toJSONString())
+        } catch (e: JOSEException) {
+            LOG.warn("unable to generate RS256 key", e)
+            Optional.empty()
+        }
+    }
+
+    private fun generateKid(): String = UUID.randomUUID().toString().replace("-".toRegex(), "")
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(RS256JsonWebKeyGenerator::class.java)
+    }
+}

--- a/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/main/kotlin/example/micronaut/SecretsManagerRotationStep.kt
+++ b/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/main/kotlin/example/micronaut/SecretsManagerRotationStep.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import java.util.Optional
+
+enum class SecretsManagerRotationStep(private val step: String) {
+
+    CREATE_SECRET("createSecret"),
+    SET_SECRET("setSecret"),
+    TEST_SECRET("testSecret"),
+    FINISH_SECRET("finishSecret");
+
+    override fun toString(): String = step
+
+    companion object {
+        private val enumMap: Map<String, SecretsManagerRotationStep> = entries.associateBy { it.toString() }
+
+        fun of(step: String): Optional<SecretsManagerRotationStep> =
+            Optional.ofNullable(enumMap[step])
+    }
+}

--- a/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/test/kotlin/example/micronaut/JsonWebKeyGeneratorTest.kt
+++ b/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/test/kotlin/example/micronaut/JsonWebKeyGeneratorTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class JsonWebKeyGeneratorTest {
+
+    @Test
+    fun beanOfTypeJsonWebKeyGeneratorExists() {
+        ApplicationContext.run(Environment.CLI, Environment.TEST).use { ctx ->
+            assertTrue(ctx.containsBean(JsonWebKeyGenerator::class.java))
+        }
+    }
+}

--- a/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/test/kotlin/example/micronaut/RS256JsonWebKeyGeneratorTest.kt
+++ b/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/test/kotlin/example/micronaut/RS256JsonWebKeyGeneratorTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.nimbusds.jose.jwk.JWK
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RS256JsonWebKeyGeneratorTest {
+
+    @Test
+    fun generatesJWK() {
+        ApplicationContext.run(Environment.CLI, Environment.TEST).use { ctx ->
+            assertTrue(ctx.containsBean(RS256JsonWebKeyGenerator::class.java))
+
+            val generator = ctx.getBean(RS256JsonWebKeyGenerator::class.java)
+            val jwkJsonOptional = generator.generateJsonWebKey(null)
+            assertTrue(jwkJsonOptional.isPresent)
+
+            val jwkJson = jwkJsonOptional.get()
+            assertDoesNotThrow<JWK> { JWK.parse(jwkJson) }
+        }
+    }
+}

--- a/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/test/kotlin/example/micronaut/SecretsManagerRotationStepTest.kt
+++ b/guides/micronaut-aws-secretsmanager-rotation/kotlin/src/test/kotlin/example/micronaut/SecretsManagerRotationStepTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class SecretsManagerRotationStepTest {
+
+    @ParameterizedTest(name = "for {0} string inferred SecretsManagerRotationStep should be {1}")
+    @MethodSource("stepProvider")
+    fun shouldResolveRotationStepFromString(str: String, step: SecretsManagerRotationStep) {
+        val resolvedStep = SecretsManagerRotationStep.of(str)
+
+        assertTrue(resolvedStep.isPresent)
+        assertEquals(step, resolvedStep.get())
+    }
+
+    companion object {
+        @JvmStatic
+        fun stepProvider(): Stream<Arguments> = Stream.of(
+            Arguments.of("createSecret", SecretsManagerRotationStep.CREATE_SECRET),
+            Arguments.of("setSecret", SecretsManagerRotationStep.SET_SECRET),
+            Arguments.of("testSecret", SecretsManagerRotationStep.TEST_SECRET),
+            Arguments.of("finishSecret", SecretsManagerRotationStep.FINISH_SECRET)
+        )
+    }
+}

--- a/guides/micronaut-aws-secretsmanager-rotation/metadata.json
+++ b/guides/micronaut-aws-secretsmanager-rotation/metadata.json
@@ -6,7 +6,7 @@
   "cloud": "AWS",
   "categories": ["AWS Lambda", "Secrets Manager"],
   "publicationDate": "2021-08-10",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "maximumJavaVersion": 25,
   "env": { "AWS_ACCESS_KEY_ID": "XXX", "AWS_SECRET_ACCESS_KEY": "YYY", "AWS_REGION": "us-east-1" },
   "apps": [

--- a/guides/micronaut-aws-secretsmanager-rotation/src/test/resources/bootstrap-test.properties
+++ b/guides/micronaut-aws-secretsmanager-rotation/src/test/resources/bootstrap-test.properties
@@ -1,0 +1,1 @@
+micronaut.config-client.enabled=false


### PR DESCRIPTION
## Summary
- Add Kotlin source and JUnit tests for the AWS Secrets Manager rotation guide.
- Update the guide metadata so Kotlin is available alongside Java.
- Add a test-scoped bootstrap property so generated tests do not require a live config client.

## Release Target
- Target branch: `master`
- Release target: `5.0.1` patch line
- Micronaut organization project selected by QA: `5.0.1 Release` (#146)
- Issue linkage: Closes #1200

## Validation
- `git fetch origin master && git rebase origin/master`
- `git diff --check origin/master...HEAD`
- `./gradlew micronautAwsSecretsmanagerRotationRunTestScript --stacktrace`
- Confirmed generated Gradle Kotlin zip and rendered guide HTML exist, Kotlin appears in the language matrix, and unresolved macro/placeholders search returned no matches.

## PR Assets
- [Rendered guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/6af99ac261e1e8ea9b81b9a04d500c2094bcbb02/assets/pr-1651/70763ae17b46/micronaut-aws-secretsmanager-rotation.html)

## Routing Notes
- Requested reviewer: `sdelamo`, the linked GitHub issue creator. GitHub rejected the request with `Review cannot be requested from pull request author. (HTTP 422)` because `sdelamo` is also the PR author.
- Project association: `5.0.1 Release` (#146) exists and is open, but no live project link was applied. `gh pr edit --add-project` failed because the active token lacks `read:org`, `gh project item-add 146 --owner micronaut-projects` returned `unknown owner type`, and direct GraphQL `addProjectV2ItemById` failed with `INSUFFICIENT_SCOPES` because the active token lacks `project` scope.

## Notes
QA documented the broader native-image build path as blocked by the local GraalVM reachability-metadata schema mismatch that also affects the existing generated Java project. I did not treat that as a defect in this Kotlin guide addition.

Closes #1200

---
###### ✨ This message was AI-generated using gpt-5-codex
