### PR TITLE
Add Kotlin URI builder guide samples

### DIFF
--- a/guides/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder/metadata.json
+++ b/guides/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["spring-boot"],
   "categories": ["Spring Boot"],
   "publicationDate": "2022-09-13",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "framework": "Spring Boot",

--- a/guides/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder/micronautframework/kotlin/src/test/kotlin/example/micronaut/UriBuilderTest.kt
+++ b/guides/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder/micronautframework/kotlin/src/test/kotlin/example/micronaut/UriBuilderTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.uri.UriBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class UriBuilderTest {
+
+    @Test
+    fun youCanUseUriBuilderToBuildUris() {
+        val isbn = "1680502395"
+        assertEquals(
+            "/book/1680502395?lang=es",
+            UriBuilder.of("/book")
+                .path(isbn)
+                .queryParam("lang", "es")
+                .build()
+                .toString()
+        )
+    }
+}

--- a/guides/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder/springboot/kotlin/src/test/kotlin/example/micronaut/UriComponentsBuilderTest.kt
+++ b/guides/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder/springboot/kotlin/src/test/kotlin/example/micronaut/UriComponentsBuilderTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.web.util.UriComponentsBuilder
+
+class UriComponentsBuilderTest {
+
+    @Test
+    fun youCanUseUriComponentsBuilderToBuildUris() {
+        val isbn = "1680502395"
+        assertEquals(
+            "/book/1680502395?lang=es",
+            UriComponentsBuilder.fromUriString("/book")
+                .path("/$isbn")
+                .queryParam("lang", "es")
+                .build()
+                .toUriString()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Kotlin as a supported language for the Building URIs Spring Boot to Micronaut guide.
- Adds equivalent Kotlin tests for the Spring Boot `UriComponentsBuilder` and Micronaut `UriBuilder` snippets.
- Leaves the existing Java samples and guide prose unchanged; the separate Groovy request remains out of scope.

## Validation
- `./gradlew springBootToMicronautUriComponentsBuilderVsUriBuilderRunTestScript --stacktrace`
- `./gradlew springBootToMicronautUriComponentsBuilderVsUriBuilderBuild -x springBootToMicronautUriComponentsBuilderVsUriBuilderRunNativeTestScript --stacktrace`
- Rendered Gradle Kotlin guide output includes both Kotlin snippet paths and the expected `/book/1680502395?lang=es` assertion.

## Release Targeting
- Target branch: `master`
- Type label: `type: docs`
- Micronaut organization project selected by QA: `5.0.1 Release`
- Note: the selected project is a Micronaut Platform BOM release board; `micronaut-guides` itself has no stable repository release tags.

## PR Assets
- [Rendered Gradle Kotlin guide output](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/792b2f33639f148c748a75a69b1de9aeaae7e70b/assets/pr-1652/30d36920b7b1/spring-boot-to-micronaut-uri-components-builder-vs-uri-builder-gradle-kotlin-reb.html)

Closes #1111

---
###### ✨ This message was AI-generated using gpt-5.3-codex