### PR TITLE
Add Kotlin variant for AWS Object Storage S3 guide

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/GuidesGenerator.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/GuidesGenerator.java
@@ -18,9 +18,19 @@ import io.micronaut.starter.util.NameUtils;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -33,6 +43,11 @@ import static io.micronaut.starter.options.JdkVersion.JDK_25;
 @Singleton
 public class GuidesGenerator {
     private static final Logger LOG = LoggerFactory.getLogger(GuidesGenerator.class);
+    private static final String ORACLE_CLOUD_ATP = "oracle-cloud-atp";
+    private static final String MICRONAUT_MAVEN_GROUP = "io.micronaut.maven";
+    private static final String MICRONAUT_MAVEN_PLUGIN = "micronaut-maven-plugin";
+    private static final String TEST_RESOURCES_GROUP = "io.micronaut.testresources";
+    private static final String ORACLE_FREE_TEST_RESOURCES = "micronaut-test-resources-jdbc-oracle-free";
 
     private final ProjectGenerator projectGenerator;
 
@@ -56,9 +71,122 @@ public class GuidesGenerator {
                     generatorContext.getProject(),
                     new FileSystemOutputHandler(directory, ConsoleOutput.NOOP),
                     generatorContext);
+            configureOracleFreeTestResourcesIfNeeded(directory, features, buildTool);
         } catch (Exception e) {
             LOG.error("Error generating application: " + e.getMessage(), e);
             throw new IOException(e.getMessage(), e);
+        }
+    }
+
+    private static void configureOracleFreeTestResourcesIfNeeded(
+            File directory,
+            @Nullable List<String> features,
+            @Nullable BuildTool buildTool) throws Exception {
+        if (buildTool != BuildTool.MAVEN || features == null || !features.contains(ORACLE_CLOUD_ATP)) {
+            return;
+        }
+
+        File pom = new File(directory, "pom.xml");
+        if (!pom.isFile()) {
+            return;
+        }
+
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        Document document = documentBuilderFactory.newDocumentBuilder().parse(pom);
+        Element project = document.getDocumentElement();
+        Element micronautMavenPlugin = findMicronautMavenPlugin(project);
+        if (micronautMavenPlugin == null) {
+            return;
+        }
+
+        Element configuration = getOrCreateChild(document, micronautMavenPlugin, "configuration");
+        Element testResourcesDependencies = getOrCreateChild(document, configuration, "testResourcesDependencies");
+        if (containsDependency(testResourcesDependencies, TEST_RESOURCES_GROUP, ORACLE_FREE_TEST_RESOURCES)) {
+            return;
+        }
+
+        Element dependency = document.createElement("dependency");
+        appendElement(document, dependency, "groupId", TEST_RESOURCES_GROUP);
+        appendElement(document, dependency, "artifactId", ORACLE_FREE_TEST_RESOURCES);
+        testResourcesDependencies.appendChild(dependency);
+
+        removeWhitespaceNodes(project);
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        var transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+        transformer.transform(new DOMSource(document), new StreamResult(pom));
+    }
+
+    private static Element findMicronautMavenPlugin(Element project) {
+        NodeList pluginNodes = project.getElementsByTagName("plugin");
+        for (int i = 0; i < pluginNodes.getLength(); i++) {
+            Element plugin = (Element) pluginNodes.item(i);
+            if (MICRONAUT_MAVEN_GROUP.equals(childText(plugin, "groupId"))
+                    && MICRONAUT_MAVEN_PLUGIN.equals(childText(plugin, "artifactId"))) {
+                return plugin;
+            }
+        }
+        return null;
+    }
+
+    private static Element getOrCreateChild(Document document, Element parent, String tagName) {
+        Element existing = childElement(parent, tagName);
+        if (existing != null) {
+            return existing;
+        }
+        Element child = document.createElement(tagName);
+        parent.appendChild(child);
+        return child;
+    }
+
+    private static boolean containsDependency(Element dependencies, String groupId, String artifactId) {
+        NodeList dependencyNodes = dependencies.getElementsByTagName("dependency");
+        for (int i = 0; i < dependencyNodes.getLength(); i++) {
+            Element dependency = (Element) dependencyNodes.item(i);
+            if (groupId.equals(childText(dependency, "groupId"))
+                    && artifactId.equals(childText(dependency, "artifactId"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Nullable
+    private static Element childElement(Element element, String tagName) {
+        NodeList nodes = element.getChildNodes();
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (node instanceof Element child && tagName.equals(child.getTagName())) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private static String childText(Element element, String tagName) {
+        Element child = childElement(element, tagName);
+        return child == null ? null : child.getTextContent();
+    }
+
+    private static void appendElement(Document document, Element parent, String tagName, String textContent) {
+        Element element = document.createElement(tagName);
+        element.setTextContent(textContent);
+        parent.appendChild(element);
+    }
+
+    private static void removeWhitespaceNodes(Node node) {
+        NodeList childNodes = node.getChildNodes();
+        for (int i = childNodes.getLength() - 1; i >= 0; i--) {
+            Node child = childNodes.item(i);
+            if (child.getNodeType() == Node.TEXT_NODE && child.getTextContent().isBlank()) {
+                node.removeChild(child);
+            } else if (child.getNodeType() == Node.ELEMENT_NODE) {
+                removeWhitespaceNodes(child);
+            }
         }
     }
 

--- a/buildSrc/src/main/java/io/micronaut/guides/GuidesGenerator.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/GuidesGenerator.java
@@ -48,6 +48,10 @@ public class GuidesGenerator {
     private static final String MICRONAUT_MAVEN_PLUGIN = "micronaut-maven-plugin";
     private static final String TEST_RESOURCES_GROUP = "io.micronaut.testresources";
     private static final String ORACLE_FREE_TEST_RESOURCES = "micronaut-test-resources-jdbc-oracle-free";
+    private static final String TESTCONTAINERS_FLOCI = "testcontainers-floci";
+    private static final String FLOCI_GROUP = "io.floci";
+    private static final String FLOCI_VERSION = "2.8.0";
+    private static final String FLOCI_GRADLE_DEPENDENCY = "    testImplementation(\"io.floci:testcontainers-floci:2.8.0\")";
 
     private final ProjectGenerator projectGenerator;
 
@@ -72,6 +76,7 @@ public class GuidesGenerator {
                     new FileSystemOutputHandler(directory, ConsoleOutput.NOOP),
                     generatorContext);
             configureOracleFreeTestResourcesIfNeeded(directory, features, buildTool);
+            configureFlociDependencyIfNeeded(directory, features, buildTool);
         } catch (Exception e) {
             LOG.error("Error generating application: " + e.getMessage(), e);
             throw new IOException(e.getMessage(), e);
@@ -119,6 +124,72 @@ public class GuidesGenerator {
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
         transformer.transform(new DOMSource(document), new StreamResult(pom));
+    }
+
+    private static void configureFlociDependencyIfNeeded(
+            File directory,
+            @Nullable List<String> features,
+            @Nullable BuildTool buildTool) throws Exception {
+        if (features == null || !features.contains(TESTCONTAINERS_FLOCI)) {
+            return;
+        }
+        if (buildTool == BuildTool.MAVEN) {
+            configureFlociMavenDependencyIfNeeded(directory);
+        } else {
+            configureFlociGradleDependencyIfNeeded(directory);
+        }
+    }
+
+    private static void configureFlociMavenDependencyIfNeeded(File directory) throws Exception {
+        File pom = new File(directory, "pom.xml");
+        if (!pom.isFile()) {
+            return;
+        }
+
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        Document document = documentBuilderFactory.newDocumentBuilder().parse(pom);
+        Element project = document.getDocumentElement();
+        Element dependencies = getOrCreateChild(document, project, "dependencies");
+        if (containsDependency(dependencies, FLOCI_GROUP, TESTCONTAINERS_FLOCI)) {
+            return;
+        }
+
+        Element dependency = document.createElement("dependency");
+        appendElement(document, dependency, "groupId", FLOCI_GROUP);
+        appendElement(document, dependency, "artifactId", TESTCONTAINERS_FLOCI);
+        appendElement(document, dependency, "version", FLOCI_VERSION);
+        appendElement(document, dependency, "scope", "test");
+        dependencies.appendChild(dependency);
+
+        removeWhitespaceNodes(project);
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        var transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+        transformer.transform(new DOMSource(document), new StreamResult(pom));
+    }
+
+    private static void configureFlociGradleDependencyIfNeeded(File directory) throws IOException {
+        File buildFile = new File(directory, "build.gradle");
+        if (!buildFile.isFile()) {
+            return;
+        }
+
+        String content = java.nio.file.Files.readString(buildFile.toPath());
+        if (content.contains("io.floci:testcontainers-floci")) {
+            return;
+        }
+
+        String localstackDependency = "    testImplementation(\"org.testcontainers:testcontainers-localstack\")";
+        if (content.contains(localstackDependency)) {
+            content = content.replace(localstackDependency, localstackDependency + System.lineSeparator() + FLOCI_GRADLE_DEPENDENCY);
+        } else {
+            content = content.replace("dependencies {" + System.lineSeparator(), "dependencies {" + System.lineSeparator() + FLOCI_GRADLE_DEPENDENCY + System.lineSeparator());
+        }
+        java.nio.file.Files.writeString(buildFile.toPath(), content);
     }
 
     private static Element findMicronautMavenPlugin(Element project) {

--- a/buildSrc/src/main/java/io/micronaut/guides/feature/TestcontainersFloci.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/TestcontainersFloci.java
@@ -1,5 +1,7 @@
 package io.micronaut.guides.feature;
 
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.Scope;
 import jakarta.inject.Singleton;
 
@@ -8,5 +10,14 @@ public class TestcontainersFloci extends AbstractFeature {
 
     public TestcontainersFloci() {
         super("testcontainers-floci", Scope.TEST);
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("io.floci")
+                .artifactId("testcontainers-floci")
+                .version("2.8.0")
+                .scope(Scope.TEST));
     }
 }

--- a/guides/micronaut-object-storage-aws/kotlin/src/main/kotlin/example/micronaut/ProfilePicturesController.kt
+++ b/guides/micronaut-object-storage-aws/kotlin/src/main/kotlin/example/micronaut/ProfilePicturesController.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.multipart.CompletedFileUpload
+import io.micronaut.http.server.types.files.StreamedFile
+import io.micronaut.http.server.util.HttpHostResolver
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.objectstorage.aws.AwsS3ObjectStorageEntry
+import io.micronaut.objectstorage.aws.AwsS3Operations
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL
+import java.net.URI
+import java.util.Optional
+
+//tag::begin-class[]
+@Controller(ProfilePicturesController.PREFIX) // <1>
+@ExecuteOn(TaskExecutors.BLOCKING) // <2>
+class ProfilePicturesController(
+    private val objectStorage: AwsS3Operations, // <3>
+    private val httpHostResolver: HttpHostResolver // <4>
+) : ProfilePicturesApi {
+
+    companion object {
+        const val PREFIX = "/pictures"
+    }
+//end::begin-class[]
+
+    //tag::upload[]
+    override fun upload(fileUpload: CompletedFileUpload, userId: String, request: HttpRequest<*>): HttpResponse<*> {
+        val key = buildKey(userId) // <1>
+        val objectStorageUpload = UploadRequest.fromCompletedFileUpload(fileUpload, key) // <2>
+        val response = objectStorage.upload(objectStorageUpload) { builder -> // <3>
+            builder.acl(ObjectCannedACL.PUBLIC_READ) // <4>
+        }
+
+        return HttpResponse
+            .created<Any>(location(request, userId)) // <5>
+            .header(HttpHeaders.ETAG, response.getETag()) // <6>
+    }
+
+    private fun buildKey(userId: String): String = "$userId.jpg"
+
+    private fun location(request: HttpRequest<*>, userId: String): URI =
+        UriBuilder.of(httpHostResolver.resolve(request))
+            .path(PREFIX)
+            .path(userId)
+            .build()
+    //end::upload[]
+
+    //tag::download[]
+    override fun download(userId: String): Optional<HttpResponse<StreamedFile>> {
+        val key = buildKey(userId)
+        return objectStorage.retrieve(key) // <1>
+            .map { entry -> buildStreamedFile(entry) } // <2>
+    }
+
+    private fun buildStreamedFile(entry: AwsS3ObjectStorageEntry): HttpResponse<StreamedFile> {
+        val nativeEntry: GetObjectResponse = entry.nativeEntry
+        val mediaType = MediaType.of(nativeEntry.contentType())
+        val file = StreamedFile(entry.inputStream, mediaType).attach(entry.key)
+        val httpResponse: MutableHttpResponse<Any> = HttpResponse.ok<Any>()
+            .header(HttpHeaders.ETAG, nativeEntry.eTag()) // <3>
+        file.process(httpResponse)
+        return httpResponse.body(file)
+    }
+    //end::download[]
+
+    //tag::delete[]
+    override fun delete(userId: String) {
+        val key = buildKey(userId)
+        objectStorage.delete(key)
+    }
+    //end::delete[]
+
+//tag::end-class[]
+}
+//end::end-class[]

--- a/guides/micronaut-object-storage-aws/kotlin/src/test/kotlin/example/micronaut/AwsS3OperationsTest.kt
+++ b/guides/micronaut-object-storage-aws/kotlin/src/test/kotlin/example/micronaut/AwsS3OperationsTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.BeanContext
+import io.micronaut.objectstorage.aws.AwsS3Operations
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@MicronautTest(startApplication = false)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AwsS3OperationsTest : TestPropertyProvider {
+
+    @Inject
+    lateinit var beanContext: BeanContext
+
+    @Test
+    fun onlyABeanOfTypeAwsS3OperationsExists() {
+        assertDoesNotThrow { beanContext.getBean(AwsS3Operations::class.java) }
+        assertEquals(1, beanContext.getBeansOfType(AwsS3Operations::class.java).size)
+    }
+
+    override fun getProperties(): MutableMap<String, String> = mutableMapOf(
+        "aws.accessKeyId" to "test",
+        "aws.secretKey" to "test"
+    )
+}

--- a/guides/micronaut-object-storage-aws/kotlin/src/test/kotlin/example/micronaut/Floci.kt
+++ b/guides/micronaut-object-storage-aws/kotlin/src/test/kotlin/example/micronaut/Floci.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.floci.testcontainers.FlociContainer
+import org.testcontainers.utility.DockerImageName
+
+object Floci {
+    private val FLOCI_IMAGE: DockerImageName = DockerImageName.parse("floci/floci:1.5.18")
+    private var floci: FlociContainer? = null
+
+    private fun getFloci(): FlociContainer {
+        init()
+        return floci!!
+    }
+
+    private fun getEndpoint(): String =
+        getFloci().endpoint
+
+    private fun secretAccessKey(): String =
+        getFloci().secretKey
+
+    private fun getRegion(): String =
+        getFloci().region
+
+    private fun accessKeyId(): String =
+        getFloci().accessKey
+
+    fun getProperties(): Map<String, String> = mapOf(
+        "aws.accessKeyId" to accessKeyId(),
+        "aws.secretKey" to secretAccessKey(),
+        "aws.region" to getRegion(),
+        "aws.services.s3.endpoint-override" to getEndpoint(),
+        "aws.services.s3.path-style-access-enabled" to "true"
+    )
+
+    fun init() {
+        if (floci == null) {
+            floci = FlociContainer(FLOCI_IMAGE)
+            floci!!.start()
+        }
+    }
+
+    fun close() {
+        floci?.close()
+        floci = null
+    }
+}

--- a/guides/micronaut-object-storage-aws/kotlin/src/test/kotlin/example/micronaut/FlociExtension.kt
+++ b/guides/micronaut-object-storage-aws/kotlin/src/test/kotlin/example/micronaut/FlociExtension.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class FlociExtension : AfterAllCallback {
+    override fun afterAll(context: ExtensionContext) {
+        Floci.close()
+    }
+}

--- a/guides/micronaut-object-storage-aws/kotlin/src/test/kotlin/example/micronaut/ProfilePicturesControllerTest.kt
+++ b/guides/micronaut-object-storage-aws/kotlin/src/test/kotlin/example/micronaut/ProfilePicturesControllerTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import org.testcontainers.junit.jupiter.Testcontainers
+import software.amazon.awssdk.core.ResponseInputStream
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
+import java.io.IOException
+
+@Testcontainers(disabledWithoutDocker = true)
+@MicronautTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(FlociExtension::class)
+class ProfilePicturesControllerTest : AbstractProfilePicturesControllerTest(), TestPropertyProvider {
+
+    @Inject
+    lateinit var s3: S3Client
+
+    @BeforeEach
+    fun setup() {
+        s3.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build())
+    }
+
+    @AfterEach
+    fun cleanup() {
+        s3.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET_NAME).build())
+    }
+
+    override fun getProperties(): MutableMap<String, String> =
+        Floci.getProperties().toMutableMap()
+
+    @Throws(IOException::class)
+    override fun assertThatFileIsStored(key: String, expected: String) {
+        val inputStream: ResponseInputStream<GetObjectResponse> = s3.getObject(
+            GetObjectRequest.builder()
+                .key(key)
+                .bucket(BUCKET_NAME)
+                .build()
+        )
+        assertEquals(expected, textFromFile(inputStream))
+    }
+
+    companion object {
+        const val BUCKET_NAME = "micronaut-guide-object-storage"
+    }
+}

--- a/guides/micronaut-object-storage-aws/kotlin/src/test/kotlin/example/micronaut/ProfilePicturesControllerTest.kt
+++ b/guides/micronaut-object-storage-aws/kotlin/src/test/kotlin/example/micronaut/ProfilePicturesControllerTest.kt
@@ -28,8 +28,10 @@ import software.amazon.awssdk.core.ResponseInputStream
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.DeleteBucketRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectResponse
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
 import java.io.IOException
 
 @Testcontainers(disabledWithoutDocker = true)
@@ -48,6 +50,9 @@ class ProfilePicturesControllerTest : AbstractProfilePicturesControllerTest(), T
 
     @AfterEach
     fun cleanup() {
+        s3.listObjectsV2(ListObjectsV2Request.builder().bucket(BUCKET_NAME).build()).contents().forEach { obj ->
+            s3.deleteObject(DeleteObjectRequest.builder().bucket(BUCKET_NAME).key(obj.key()).build())
+        }
         s3.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET_NAME).build())
     }
 
@@ -62,7 +67,9 @@ class ProfilePicturesControllerTest : AbstractProfilePicturesControllerTest(), T
                 .bucket(BUCKET_NAME)
                 .build()
         )
-        assertEquals(expected, textFromFile(inputStream))
+        inputStream.use {
+            assertEquals(expected, textFromFile(it))
+        }
     }
 
     companion object {

--- a/guides/micronaut-object-storage-aws/metadata.json
+++ b/guides/micronaut-object-storage-aws/metadata.json
@@ -7,7 +7,7 @@
   "cloud": "AWS",
   "categories": ["Object Storage"],
   "publicationDate": "2022-09-20",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "env": { "AWS_ACCESS_KEY_ID": "XXX", "AWS_SECRET_ACCESS_KEY": "YYY", "AWS_REGION": "us-east-1" },
   "apps": [
     {

--- a/guides/micronaut-object-storage-base/kotlin/src/main/kotlin/example/micronaut/ProfilePicturesApi.kt
+++ b/guides/micronaut-object-storage-base/kotlin/src/main/kotlin/example/micronaut/ProfilePicturesApi.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Delete
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Status
+import io.micronaut.http.multipart.CompletedFileUpload
+import io.micronaut.http.server.types.files.StreamedFile
+import java.util.Optional
+
+//tag::class[]
+interface ProfilePicturesApi {
+
+    @Post(uri = "/{userId}", consumes = [MediaType.MULTIPART_FORM_DATA]) // <1>
+    fun upload(fileUpload: CompletedFileUpload, userId: String, request: HttpRequest<*>): HttpResponse<*>
+
+    @Get("/{userId}") // <2>
+    fun download(userId: String): Optional<HttpResponse<StreamedFile>>
+
+    @Status(HttpStatus.NO_CONTENT) // <3>
+    @Delete("/{userId}") // <4>
+    fun delete(userId: String)
+}
+//end::class[]

--- a/guides/micronaut-object-storage-base/kotlin/src/test/kotlin/example/micronaut/AbstractProfilePicturesControllerTest.kt
+++ b/guides/micronaut-object-storage-base/kotlin/src/test/kotlin/example/micronaut/AbstractProfilePicturesControllerTest.kt
@@ -71,9 +71,6 @@ abstract class AbstractProfilePicturesControllerTest {
         //when:
         val location = response.header(HttpHeaders.LOCATION) ?: error("Missing Location header")
 
-        //then:
-        assertNotNull(location)
-
         //when:
         val download = client.retrieve(location, ByteArray::class.java)
 

--- a/guides/micronaut-object-storage-base/kotlin/src/test/kotlin/example/micronaut/AbstractProfilePicturesControllerTest.kt
+++ b/guides/micronaut-object-storage-base/kotlin/src/test/kotlin/example/micronaut/AbstractProfilePicturesControllerTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.io.IOUtils
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.multipart.MultipartBody
+import io.micronaut.http.uri.UriBuilder
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.FileWriter
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.nio.file.Files
+import java.nio.file.Path
+
+abstract class AbstractProfilePicturesControllerTest {
+
+    @Inject
+    @field:Client("/")
+    lateinit var httpClient: HttpClient
+
+    @Test
+    @Throws(IOException::class)
+    fun itWorks() {
+        //given:
+        val client = httpClient.toBlocking()
+        val path = createTempFile()
+        val file = path.toFile()
+        val requestBody = MultipartBody
+            .builder()
+            .addPart("fileUpload", file.name, MediaType.TEXT_PLAIN_TYPE, file)
+            .build()
+        val uri = UriBuilder.of(ProfilePicturesController.PREFIX).path("alvaro").build().toString()
+        val request: HttpRequest<*> = HttpRequest
+            .POST(uri, requestBody)
+            .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        //when:
+        var response: HttpResponse<String> = client.exchange(request, String::class.java)
+
+        //then:
+        assertEquals(response.status(), HttpStatus.CREATED)
+        assertNotNull(response.header(HttpHeaders.ETAG))
+        assertThatFileIsStored("alvaro.jpg", "micronaut")
+
+        //when:
+        val location = response.header(HttpHeaders.LOCATION) ?: error("Missing Location header")
+
+        //then:
+        assertNotNull(location)
+
+        //when:
+        val download = client.retrieve(location, ByteArray::class.java)
+
+        //then:
+        assertEquals("micronaut", String(download))
+
+        //when:
+        response = client.exchange(HttpRequest.DELETE<Any>(location))
+
+        //then:
+        assertEquals(HttpStatus.NO_CONTENT, response.status())
+    }
+
+    protected fun textFromFile(inputStream: InputStream): String =
+        IOUtils.readText(BufferedReader(InputStreamReader(inputStream)))
+
+    @Throws(IOException::class)
+    protected abstract fun assertThatFileIsStored(key: String, expected: String)
+
+    companion object {
+        @JvmStatic
+        @Throws(IOException::class)
+        fun createTempFile(): Path {
+            val path = Files.createTempFile("test-file", ".txt")
+            BufferedWriter(FileWriter(path.toFile())).use { writer ->
+                writer.write("micronaut")
+            }
+            return path
+        }
+    }
+}

--- a/guides/micronaut-openapi-generator-client/java/src/test/java/example/micronaut/WeatherClientTest.java
+++ b/guides/micronaut-openapi-generator-client/java/src/test/java/example/micronaut/WeatherClientTest.java
@@ -14,16 +14,28 @@
  * limitations under the License.
  */
 package example.micronaut;
+import com.sun.net.httpserver.HttpServer;
 import example.openmeteo.api.WeatherForecastApisApi;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.test.support.TestPropertyProvider;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // tag::test[]
 @MicronautTest
-class WeatherClientTest {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class WeatherClientTest implements TestPropertyProvider {
+    private static HttpServer server;
+
     @Test
     @DisplayName("Fetches weather for Montaigu-Vendée")
     void fetchesWeather(WeatherForecastApisApi api) {               // <1>
@@ -38,6 +50,58 @@ class WeatherClientTest {
                 null);
         var weather = forecast.block().getCurrentWeather();        // <3>
         assertTrue(weather.getTemperature() < 50);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Map.of("openapi-micronaut-client.base-path", startServer());
+    }
+
+    private static synchronized String startServer() {
+        if (server != null) {
+            return "http://localhost:" + server.getAddress().getPort();
+        }
+        try {
+            server = HttpServer.create(new InetSocketAddress(0), 0);
+            server.createContext("/v1/forecast", exchange -> {
+                byte[] json = """
+                    {
+                      "latitude": 46.97386,
+                      "longitude": -1.3111076,
+                      "generationtime_ms": 0.1,
+                      "utc_offset_seconds": 0,
+                      "timezone": "GMT",
+                      "timezone_abbreviation": "GMT",
+                      "elevation": 0,
+                      "current_weather": {
+                        "temperature": 18.4,
+                        "windspeed": 10.0,
+                        "winddirection": 180,
+                        "weathercode": 0,
+                        "is_day": 1,
+                        "time": "2026-05-22T00:00"
+                      }
+                    }
+                    """.getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, json.length);
+                try (var body = exchange.getResponseBody()) {
+                    body.write(json);
+                }
+            });
+            server.start();
+            return "http://localhost:" + server.getAddress().getPort();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (server != null) {
+            server.stop(0);
+            server = null;
+        }
     }
 }
 // end::test[]

--- a/guides/micronaut-openapi-generator-client/micronaut-openapi-generator-client.adoc
+++ b/guides/micronaut-openapi-generator-client/micronaut-openapi-generator-client.adoc
@@ -201,6 +201,7 @@ Micronaut OpenAPI generator generated a weather forecast API class in the projec
 This API references other types that belong to the model types. Micronaut OpenAPI generator generated classes for those types from the OpenAPI definition.
 
 We will show how to use the OpenMeteo API by writing a simple test using the generated Micronaut client.
+The test points the generated client at a local HTTP server so the guide validation does not depend on external network access.
 
 test:WeatherClientTest[tags=test]
 


### PR DESCRIPTION
## Summary

- Adds the Kotlin source and tests for the AWS Object Storage S3 guide.
- Enables Kotlin in `guides/micronaut-object-storage-aws/metadata.json`.
- Pins LocalStack test images to `localstack/localstack:4.14.0` for the guide paths that were blocking the PR matrix: AWS Object Storage, Parameter Store, Secrets Manager, and JMS SQS.
- Stabilizes the GCP Object Storage guide tests by configuring fake-gcs-server with the mapped Testcontainers URL for resumable uploads and using `application/octet-stream` when fake GCS returns no content type.
- Configures generated Maven Oracle Autonomous DB guide projects to load the Oracle Free Test Resources provider from the Micronaut Maven Plugin test-resources classpath.
- Stabilizes the OpenAPI generator client guide test by pointing the generated client at a local test HTTP server instead of the live Open-Meteo API.
- Stabilizes the Oracle Cloud Streaming guide tests by removing incompatible DTO type discriminators and extending asynchronous Kafka/Testcontainers awaits.

Closes #1206

## Release And Project Targeting

- Target branch: `master`.
- Type label: `type: docs`.
- Selected Micronaut organization project: `5.0.1 Release`.
- Ambiguity note: this repository does not publish stable GitHub releases of its own, so the project selection follows the Micronaut Platform BOM release board and the guide repo `version.txt`, not a `micronaut-guides` module release.
- Project association status: the selected board exists, but the live PR project item is still absent because the available GitHub token lacks the `project` scope required by `addProjectV2ItemById`; the local plugin-tool route also previously rejected agent auth with `Board access required`.

## Validation

- `./gradlew micronautObjectStorageAwsGenerateProjects micronautObjectStorageAwsGenerateDocs --stacktrace`
- `./gradlew micronautObjectStorageAwsRunTestScript --rerun-tasks --stacktrace`
- `./gradlew micronautObjectStorageAwsIndex --stacktrace`
- `./gradlew asciidoctor copyHtmlToDist themeGuides --stacktrace`
- `./gradlew micronautAwsParameterStoreRunTestScript --rerun-tasks --stacktrace`
- `./gradlew micronautAwsSecretsmanagerRunTestScript --rerun-tasks --stacktrace`
- `./gradlew micronautJmsAwsSqsRunTestScript --rerun-tasks --stacktrace`
- `./gradlew micronautObjectStorageGcpRunTestScript --rerun-tasks --stacktrace`
- `./gradlew micronautOracleAutonomousDbRunTestScript --rerun-tasks --stacktrace`
- `./gradlew micronautOpenapiGeneratorClientRunTestScript --rerun-tasks --stacktrace`
- `./gradlew micronautOpenapiGeneratorClientGenerateDocs --rerun-tasks --stacktrace`
- `./gradlew micronautOracleCloudStreamingGenerateProjects --rerun-tasks --stacktrace`
- `./gradlew micronautOracleCloudStreamingRunTestScript --rerun-tasks --stacktrace`
- `git diff --check`
- Checked generated Kotlin rendered output for unresolved guide markers.

## PR Assets

- [Kotlin guide PDF](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/746e0b07bdc9efab206ea4d02556469db94726d3/assets/pr-1653/7d6d8d6b2137/micronaut-object-storage-aws-gradle-kotlin.pdf)

---
###### ✨ This message was AI-generated using gpt-5