### PR TITLE
Add Kotlin variant for MongoDB async data guide

### DIFF
--- a/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/DefaultFruitService.kt
+++ b/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/DefaultFruitService.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+
+@Singleton // <1>
+class DefaultFruitService(private val fruitRepository: FruitRepository) : FruitService {
+
+    override fun list(): Publisher<Fruit> {
+        return fruitRepository.findAll()
+    }
+
+    override fun save(fruit: Fruit): Publisher<Fruit> {
+        return if (fruit.id == null) {
+            fruitRepository.save(fruit)
+        } else {
+            fruitRepository.update(fruit)
+        }
+    }
+
+    override fun find(id: String): Publisher<Fruit> {
+        return fruitRepository.findById(id)
+    }
+
+    override fun findByNameInList(name: List<String>): Publisher<Fruit> {
+        return fruitRepository.findByNameInList(name)
+    }
+}

--- a/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/Fruit.kt
+++ b/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/Fruit.kt
@@ -22,12 +22,14 @@ import jakarta.validation.constraints.NotBlank
 
 @MappedEntity // <1>
 class Fruit(
+    @field:Id // <2>
+    @field:GeneratedValue
+    var id: String? = null,
+
     @field:NotBlank // <3>
     val name: String,
     var description: String?
 ) {
 
-    @field:Id // <2>
-    @field:GeneratedValue
-    var id: String? = null
+    constructor(name: String, description: String?) : this(null, name, description)
 }

--- a/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/Fruit.kt
+++ b/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/Fruit.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import jakarta.validation.constraints.NotBlank
+
+@MappedEntity // <1>
+class Fruit(
+    @field:NotBlank // <3>
+    val name: String,
+    var description: String?
+) {
+
+    @field:Id // <2>
+    @field:GeneratedValue
+    var id: String? = null
+}

--- a/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/FruitController.kt
+++ b/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/FruitController.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.async.annotation.SingleResult
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Put
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.annotation.Status
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
+import org.reactivestreams.Publisher
+
+@Controller("/fruits") // <1>
+class FruitController(private val fruitService: FruitService) { // <2>
+
+    @Get // <3>
+    fun list(): Publisher<Fruit> {
+        return fruitService.list()
+    }
+
+    @Post // <4>
+    @Status(HttpStatus.CREATED) // <5>
+    @SingleResult
+    fun save(@Body @Valid fruit: Fruit): Publisher<Fruit> { // <6>
+        return fruitService.save(fruit)
+    }
+
+    @Put
+    @SingleResult
+    fun update(@Body @Valid fruit: Fruit): Publisher<Fruit> {
+        return fruitService.save(fruit)
+    }
+
+    @Get("/{id}") // <7>
+    fun find(@PathVariable id: String): Publisher<Fruit> {
+        return fruitService.find(id)
+    }
+
+    @Get("/q") // <8>
+    fun query(@QueryValue @NotNull names: List<String>): Publisher<Fruit> { // <9>
+        return fruitService.findByNameInList(names)
+    }
+}

--- a/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/FruitRepository.kt
+++ b/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/FruitRepository.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.mongodb.annotation.MongoRepository
+import io.micronaut.data.repository.reactive.ReactiveStreamsCrudRepository
+import org.reactivestreams.Publisher
+
+@MongoRepository // <1>
+interface FruitRepository : ReactiveStreamsCrudRepository<Fruit, String> { // <2>
+
+    fun findByNameInList(names: List<String>): Publisher<Fruit> // <3>
+}

--- a/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/FruitService.kt
+++ b/guides/micronaut-data-mongodb-asynchronous/kotlin/src/main/kotlin/example/micronaut/FruitService.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.reactivestreams.Publisher
+
+interface FruitService {
+
+    fun list(): Publisher<Fruit>
+
+    fun save(fruit: Fruit): Publisher<Fruit>
+
+    fun find(id: String): Publisher<Fruit>
+
+    fun findByNameInList(name: List<String>): Publisher<Fruit>
+}

--- a/guides/micronaut-data-mongodb-asynchronous/kotlin/src/test/kotlin/example/micronaut/ControllerIsolationTest.kt
+++ b/guides/micronaut-data-mongodb-asynchronous/kotlin/src/test/kotlin/example/micronaut/ControllerIsolationTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Singleton
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+@MicronautTest(transactional = false) // <1>
+@Property(name = "spec.name", value = "controller-isolation")
+class ControllerIsolationTest(@param:Client("/") private val httpClient: HttpClient) {
+
+    @Test
+    fun checkSerialization() {
+        val response = httpClient.toBlocking().exchange(
+            HttpRequest.GET<Any>("/fruits"),
+            Argument.listOf(Fruit::class.java)
+        )
+
+        assertEquals(HttpStatus.OK, response.status)
+        assertEquals(MediaType.APPLICATION_JSON, response.headers.get(HttpHeaders.CONTENT_TYPE))
+        assertNotNull(response.body())
+
+        val all = response.body()!!.joinToString(",") { "${it.name}:${it.description}" }
+        assertEquals("apple:red,banana:yellow", all)
+    }
+
+    @Singleton
+    @Replaces(DefaultFruitService::class)
+    @Requires(property = "spec.name", value = "controller-isolation")
+    class MockService : FruitService {
+
+        override fun list(): Publisher<Fruit> {
+            return Flux.just(
+                Fruit("apple", "red"),
+                Fruit("banana", "yellow")
+            )
+        }
+
+        override fun save(fruit: Fruit): Publisher<Fruit> {
+            return Mono.just(fruit)
+        }
+
+        override fun find(id: String): Publisher<Fruit> {
+            return Mono.empty()
+        }
+
+        override fun findByNameInList(name: List<String>): Publisher<Fruit> {
+            return Flux.empty()
+        }
+    }
+}

--- a/guides/micronaut-data-mongodb-asynchronous/kotlin/src/test/kotlin/example/micronaut/FruitClient.kt
+++ b/guides/micronaut-data-mongodb-asynchronous/kotlin/src/test/kotlin/example/micronaut/FruitClient.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Put
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.client.annotation.Client
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
+import java.util.Optional
+
+@Client("/fruits")
+interface FruitClient {
+
+    @Get
+    fun list(): Iterable<Fruit>
+
+    @Get("/{id}")
+    fun find(@PathVariable id: String): Optional<Fruit>
+
+    @Get("/q")
+    fun query(@QueryValue @NotNull names: List<String>): Iterable<Fruit>
+
+    @Post
+    fun save(@Body @Valid fruit: Fruit): HttpResponse<Fruit>
+
+    @Put
+    fun update(@Body @Valid fruit: Fruit): Fruit
+}

--- a/guides/micronaut-data-mongodb-asynchronous/kotlin/src/test/kotlin/example/micronaut/FruitControllerTest.kt
+++ b/guides/micronaut-data-mongodb-asynchronous/kotlin/src/test/kotlin/example/micronaut/FruitControllerTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpStatus
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+
+@MicronautTest(transactional = false) // <1>
+class FruitControllerTest {
+
+    @Inject
+    lateinit var fruitClient: FruitClient
+
+    @Inject
+    lateinit var fruitRepository: FruitRepository
+
+    @AfterEach // <2>
+    fun cleanup() {
+        Flux.from(fruitRepository.deleteAll()).blockFirst()
+    }
+
+    @Test
+    fun emptyDatabaseContainsNoFruit() {
+        assertEquals(0, fruitClient.list().count())
+    }
+
+    @Test
+    fun testInteractionWithTheController() {
+        var response = fruitClient.save(Fruit("banana", null))
+        assertEquals(HttpStatus.CREATED, response.status)
+        val banana = response.body()!!
+
+        var fruits = fruitClient.list()
+        var fruitList = fruits.toList()
+        assertEquals(1, fruitList.size)
+        assertEquals(banana.name, fruitList[0].name)
+        assertNull(fruitList[0].description)
+
+        response = fruitClient.save(Fruit("apple", "Keeps the doctor away"))
+        assertEquals(HttpStatus.CREATED, response.status)
+
+        fruits = fruitClient.list()
+        assertTrue(fruits.any { it.description == "Keeps the doctor away" })
+
+        banana.description = "Yellow and curved"
+        fruitClient.update(banana)
+
+        fruits = fruitClient.list()
+
+        assertEquals(
+            setOf("Keeps the doctor away", "Yellow and curved"),
+            fruits.map { it.description }.toSet()
+        )
+    }
+
+    @Test
+    fun testSearchWorksAsExpected() {
+        fruitClient.save(Fruit("apple", "Keeps the doctor away"))
+        fruitClient.save(Fruit("pineapple", "Delicious"))
+        fruitClient.save(Fruit("lemon", "Lemonentary my dear Dr Watson"))
+
+        val fruit = fruitClient.query(listOf("apple", "pineapple"))
+
+        assertTrue(fruit.all { it.name == "apple" || it.name == "pineapple" })
+    }
+}

--- a/guides/micronaut-data-mongodb-asynchronous/kotlin/src/test/kotlin/example/micronaut/FruitValidationControllerTest.kt
+++ b/guides/micronaut-data-mongodb-asynchronous/kotlin/src/test/kotlin/example/micronaut/FruitValidationControllerTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@MicronautTest(transactional = false) // <1>
+class FruitValidationControllerTest(@param:Client("/") private val httpClient: HttpClient) {
+
+    @Test
+    fun fruitIsValidated() {
+        val exception = assertThrows<HttpClientResponseException> {
+            httpClient.toBlocking().exchange<Any, Any>(
+                HttpRequest.POST("/fruits", Fruit("", ""))
+            )
+        }
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.status)
+    }
+}

--- a/guides/micronaut-data-mongodb-asynchronous/metadata.json
+++ b/guides/micronaut-data-mongodb-asynchronous/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["database", "micronaut-data", "mongodb", "async"],
   "categories": ["MongoDB"],
   "publicationDate": "2022-05-05",
-  "languages": ["JAVA", "GROOVY"],
+  "languages": ["JAVA", "GROOVY", "KOTLIN"],
   "apps": [
     {
       "name": "default",

--- a/guides/micronaut-data-mongodb-asynchronous/micronaut-data-mongodb-asynchronous.adoc
+++ b/guides/micronaut-data-mongodb-asynchronous/micronaut-data-mongodb-asynchronous.adoc
@@ -26,7 +26,7 @@ dependency:mongodb-driver-reactivestreams[groupId=org.mongodb,scope=runtimeOnly]
 
 :exclude-for-languages:
 
-:exclude-for-languages:java
+:exclude-for-languages:java,kotlin
 
 dependency:mongodb-driver-reactivestreams[groupId=org.mongodb]
 

--- a/guides/micronaut-data-mongodb-asynchronous/micronaut-data-mongodb-asynchronous.adoc
+++ b/guides/micronaut-data-mongodb-asynchronous/micronaut-data-mongodb-asynchronous.adoc
@@ -34,7 +34,7 @@ dependency:mongodb-driver-reactivestreams[groupId=org.mongodb]
 
 :dependencies:
 
-:exclude-for-languages:groovy
+:exclude-for-languages:groovy,kotlin
 
 === POJO
 
@@ -42,11 +42,19 @@ Create a `Fruit` POJO:
 
 :exclude-for-languages:
 
-:exclude-for-languages:java
+:exclude-for-languages:java,kotlin
 
 === POGO
 
 Create a `Fruit` POGO:
+
+:exclude-for-languages:
+
+:exclude-for-languages:java,groovy
+
+=== Entity
+
+Create a `Fruit` entity:
 
 :exclude-for-languages:
 
@@ -101,7 +109,7 @@ Add a https://docs.micronaut.io/latest/guide/#httpClient[Micronaut declarative H
 
 test:FruitClient[]
 
-Then create a test that verifies the validation of the `Fruit` POJO when we create a new entity via `POST`:
+Then create a test that verifies the validation of the `Fruit` entity when we create a new entity via `POST`:
 
 test:FruitValidationControllerTest[]
 


### PR DESCRIPTION
## Summary

- Adds the Kotlin source and test tree for the Micronaut Data MongoDB asynchronous guide.
- Enables `KOTLIN` in the guide metadata so the Kotlin Gradle sample is generated and zipped.
- Adds Kotlin-specific guide wording for the `Fruit` entity while preserving the existing Java POJO and Groovy POGO sections.

## Validation

- `./gradlew micronautDataMongodbAsynchronousGenerateProjects micronautDataMongodbAsynchronousGenerateDocs micronautDataMongodbAsynchronousGradleKotlinZipCode --stacktrace`
- `./gradlew micronautDataMongodbAsynchronousGenerateDocs micronautDataMongodbAsynchronousIndex --stacktrace`
- In `build/code/micronaut-data-mongodb-asynchronous/micronaut-data-mongodb-asynchronous-gradle-kotlin`: `./gradlew test --rerun-tasks --stacktrace`
- `git diff --check -- guides/micronaut-data-mongodb-asynchronous/metadata.json guides/micronaut-data-mongodb-asynchronous/micronaut-data-mongodb-asynchronous.adoc guides/micronaut-data-mongodb-asynchronous/kotlin`

## Release And Routing

- Target branch: `master`
- Type label: `type: docs`
- Selected Micronaut organization project: `5.0.1 Release`
- Ambiguity note: `micronaut-guides` has no stable release/tag history and no open `5.0.0 Release` project even though `version.txt` is `5.0.0`; `5.0.1 Release` is the earliest visible open public 5.x Micronaut Platform BOM board for this docs/sample addition.

## PR Assets

- [Generated Kotlin sample ZIP](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/5aabd82fcaaebad00dad69d34139e354c6967e13/assets/pr-1654/b3c5bddc2586/micronaut-data-mongodb-asynchronous-gradle-kotlin.zip)

Closes #1214

---
###### ✨ This message was AI-generated using gpt-5