### PR TITLE
Add Kotlin variant for Spring Boot Micronaut Data guide

### DIFF
--- a/buildSrc/src/main/java/io/spring/start/KotlinKaptGradlePlugin.java
+++ b/buildSrc/src/main/java/io/spring/start/KotlinKaptGradlePlugin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.spring.start;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.CoordinateResolver;
+import io.micronaut.starter.build.gradle.GradlePlugin;
+import io.micronaut.starter.feature.Feature;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class KotlinKaptGradlePlugin implements Feature {
+
+    private final CoordinateResolver coordinateResolver;
+
+    public KotlinKaptGradlePlugin(CoordinateResolver coordinateResolver) {
+        this.coordinateResolver = coordinateResolver;
+    }
+
+    @Override
+    public @NonNull String getName() {
+        return "kotlin-kapt-gradle-plugin";
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        if (generatorContext.getBuildTool().isGradle()) {
+            coordinateResolver.resolve("kotlin-gradle-plugin").ifPresent(coordinate ->
+                    generatorContext.addBuildPlugin(GradlePlugin.builder()
+                            .id("org.jetbrains.kotlin.kapt")
+                            .version(coordinate.getVersion())
+                            .build()));
+        }
+    }
+}

--- a/buildSrc/src/main/java/io/spring/start/SpringBootKotlin.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootKotlin.java
@@ -20,6 +20,7 @@ import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.feature.Feature;
 import io.micronaut.starter.feature.FeatureContext;
+import io.micronaut.starter.feature.RequireKaptFeature;
 import io.micronaut.starter.feature.lang.LanguageFeature;
 import io.spring.start.templates.applicationkotlin;
 import io.spring.start.templates.applicationtestkotlinjunit;
@@ -39,14 +40,16 @@ public class SpringBootKotlin implements LanguageFeature {
     protected final KotlinStdlib kotlinStdlib;
     protected final KotlinMavenPlugin kotlinMavenPlugin;
     protected final KotlinGradlePlugin kotlinGradlePlugin;
+    protected final KotlinKaptGradlePlugin kotlinKaptGradlePlugin;
     protected final KotlinSpringGradlePlugin kotlinSpringGradlePlugin;
     protected final KotlinJackson kotlinJackson;
     protected final KotlinReflect kotlinReflect;
 
-    public SpringBootKotlin(KotlinStdlib kotlinStdlib, KotlinMavenPlugin kotlinMavenPlugin, KotlinGradlePlugin kotlinGradlePlugin, KotlinSpringGradlePlugin kotlinSpringGradlePlugin, KotlinJackson kotlinJackson, KotlinReflect kotlinReflect) {
+    public SpringBootKotlin(KotlinStdlib kotlinStdlib, KotlinMavenPlugin kotlinMavenPlugin, KotlinGradlePlugin kotlinGradlePlugin, KotlinKaptGradlePlugin kotlinKaptGradlePlugin, KotlinSpringGradlePlugin kotlinSpringGradlePlugin, KotlinJackson kotlinJackson, KotlinReflect kotlinReflect) {
         this.kotlinStdlib = kotlinStdlib;
         this.kotlinMavenPlugin = kotlinMavenPlugin;
         this.kotlinGradlePlugin = kotlinGradlePlugin;
+        this.kotlinKaptGradlePlugin = kotlinKaptGradlePlugin;
         this.kotlinSpringGradlePlugin = kotlinSpringGradlePlugin;
         this.kotlinJackson = kotlinJackson;
         this.kotlinReflect = kotlinReflect;
@@ -62,6 +65,9 @@ public class SpringBootKotlin implements LanguageFeature {
     public void processSelectedFeatures(FeatureContext featureContext) {
         if (featureContext.getBuildTool().isGradle()) {
             featureContext.addFeature(kotlinGradlePlugin);
+            if (featureContext.getSelectedFeatures().stream().anyMatch(RequireKaptFeature.class::isInstance)) {
+                featureContext.addFeature(kotlinKaptGradlePlugin);
+            }
             featureContext.addFeature(kotlinSpringGradlePlugin);
         } else {
             featureContext.addFeature(kotlinStdlib);

--- a/buildSrc/src/main/java/io/spring/start/SpringBootMicronautData.java
+++ b/buildSrc/src/main/java/io/spring/start/SpringBootMicronautData.java
@@ -7,6 +7,7 @@ import io.micronaut.starter.build.dependencies.Dependency;
 import io.micronaut.starter.build.dependencies.MicronautDependencyUtils;
 import io.micronaut.starter.build.dependencies.Scope;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.RequireKaptFeature;
 import io.micronaut.starter.feature.database.H2;
 import io.micronaut.starter.util.VersionInfo;
 import jakarta.inject.Singleton;
@@ -17,7 +18,7 @@ import static io.micronaut.starter.application.ApplicationType.DEFAULT;
 import static io.micronaut.starter.feature.Category.DATABASE;
 
 @Singleton
-public class SpringBootMicronautData implements Feature {
+public class SpringBootMicronautData implements Feature, RequireKaptFeature {
 
     public static final String MICRONAUT_VERSION = "micronaut.version";
 

--- a/buildSrc/src/test/java/io/micronaut/guides/core/GuideProjectGeneratorTest.java
+++ b/buildSrc/src/test/java/io/micronaut/guides/core/GuideProjectGeneratorTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import static io.micronaut.guides.core.TestUtils.readFile;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MicronautTest(startApplication = false)
@@ -158,6 +159,111 @@ class GuideProjectGeneratorTest {
                 assertTrue(result.contains(feature));
             }
         }
+    }
+
+    @Test
+    void springBootKotlinGuideWithMicronautDataAppliesKaptPlugin() {
+        File outputDirectory = new File("build/tmp/test-spring-boot-kotlin-kapt-" + System.nanoTime());
+        outputDirectory.mkdir();
+        App app = new App(
+                "default",
+                "example.micronaut",
+                ApplicationType.DEFAULT,
+                "Spring Boot",
+                List.of("spring-boot-starter-web", "spring-boot-micronaut-data", "h2"),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null,
+                true
+        );
+        Guide guide = new Guide(
+                "Micronaut Data from a Spring Boot Application",
+                "This guide shows how to use Micronaut Data from a Spring Boot application.",
+                List.of("Sergio del Amo"),
+                List.of("Spring Boot"),
+                LocalDate.of(2022, 9, 20),
+                null,
+                null,
+                null,
+                false,
+                false,
+                "spring-boot-micronaut-data.adoc",
+                List.of(Language.KOTLIN),
+                List.of("spring-boot", "micronaut-data", "h2"),
+                List.of(BuildTool.GRADLE),
+                TestFramework.JUNIT,
+                List.of(),
+                "spring-boot-micronaut-data",
+                true,
+                null,
+                Map.of(),
+                List.of(app)
+        );
+
+        assertDoesNotThrow(() -> guideProjectGenerator.generate(outputDirectory, guide));
+
+        File dest = Paths.get(outputDirectory.getAbsolutePath(), MacroUtils.getSourceDir(guide.slug(), new GuidesOption(BuildTool.GRADLE, Language.KOTLIN, TestFramework.JUNIT))).toFile();
+        String result = readFile(new File(dest, "build.gradle"));
+
+        assertTrue(result.contains("id(\"org.jetbrains.kotlin.kapt\")"), result);
+        assertTrue(result.contains("kapt(\"io.micronaut.data:micronaut-data-processor"), result);
+    }
+
+    @Test
+    void springBootKotlinGuideWithoutKaptFeatureDoesNotApplyKaptPlugin() {
+        File outputDirectory = new File("build/tmp/test-spring-boot-kotlin-no-kapt-" + System.nanoTime());
+        outputDirectory.mkdir();
+        App app = new App(
+                "default",
+                "example.micronaut",
+                ApplicationType.DEFAULT,
+                "Spring Boot",
+                List.of("spring-boot-starter-web"),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null,
+                true
+        );
+        Guide guide = new Guide(
+                "Spring Boot Kotlin",
+                "This guide shows a Spring Boot Kotlin application.",
+                List.of("Sergio del Amo"),
+                List.of("Spring Boot"),
+                LocalDate.of(2026, 5, 21),
+                null,
+                null,
+                null,
+                false,
+                false,
+                "spring-boot-kotlin.adoc",
+                List.of(Language.KOTLIN),
+                List.of("spring-boot"),
+                List.of(BuildTool.GRADLE),
+                TestFramework.JUNIT,
+                List.of(),
+                "spring-boot-kotlin",
+                true,
+                null,
+                Map.of(),
+                List.of(app)
+        );
+
+        assertDoesNotThrow(() -> guideProjectGenerator.generate(outputDirectory, guide));
+
+        File dest = Paths.get(outputDirectory.getAbsolutePath(), MacroUtils.getSourceDir(guide.slug(), new GuidesOption(BuildTool.GRADLE, Language.KOTLIN, TestFramework.JUNIT))).toFile();
+        String result = readFile(new File(dest, "build.gradle"));
+
+        assertTrue(result.contains("id(\"org.jetbrains.kotlin.jvm\")"), result);
+        assertTrue(result.contains("id(\"org.jetbrains.kotlin.plugin.spring\")"), result);
+        assertFalse(result.contains("id(\"org.jetbrains.kotlin.kapt\")"), result);
     }
 
 

--- a/buildSrc/src/test/java/io/micronaut/guides/core/GuideProjectGeneratorTest.java
+++ b/buildSrc/src/test/java/io/micronaut/guides/core/GuideProjectGeneratorTest.java
@@ -10,6 +10,7 @@ import org.gradle.api.JavaVersion;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.List;
@@ -163,8 +164,7 @@ class GuideProjectGeneratorTest {
 
     @Test
     void springBootKotlinGuideWithMicronautDataAppliesKaptPlugin() {
-        File outputDirectory = new File("build/tmp/test-spring-boot-kotlin-kapt-" + System.nanoTime());
-        outputDirectory.mkdir();
+        File outputDirectory = createTempOutputDirectory("test-spring-boot-kotlin-kapt-");
         App app = new App(
                 "default",
                 "example.micronaut",
@@ -215,8 +215,7 @@ class GuideProjectGeneratorTest {
 
     @Test
     void springBootKotlinGuideWithoutKaptFeatureDoesNotApplyKaptPlugin() {
-        File outputDirectory = new File("build/tmp/test-spring-boot-kotlin-no-kapt-" + System.nanoTime());
-        outputDirectory.mkdir();
+        File outputDirectory = createTempOutputDirectory("test-spring-boot-kotlin-no-kapt-");
         App app = new App(
                 "default",
                 "example.micronaut",
@@ -266,5 +265,8 @@ class GuideProjectGeneratorTest {
         assertFalse(result.contains("id(\"org.jetbrains.kotlin.kapt\")"), result);
     }
 
+    private File createTempOutputDirectory(String prefix) {
+        return assertDoesNotThrow(() -> Files.createTempDirectory(Files.createDirectories(Paths.get("build/tmp")), prefix).toFile());
+    }
 
 }

--- a/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationSpecificEnvironmentTest.java
+++ b/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationSpecificEnvironmentTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Property(name = "aws.distributed-configuration.search-active-environments", value = StringUtils.TRUE)
 class VatControllerDistributedConfigurationSpecificEnvironmentTest implements TestPropertyProvider {
 
-    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:latest");
+    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:4.14.0");
     private static LocalStackContainer localstack = new LocalStackContainer(localstackImage)
             .withServices(LocalStackContainer.Service.SSM);
 

--- a/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationTest.java
+++ b/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
 class VatControllerDistributedConfigurationTest implements TestPropertyProvider { // <3>
 
-    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:latest");
+    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:4.14.0");
     private static LocalStackContainer localstack = new LocalStackContainer(localstackImage)
             .withServices(LocalStackContainer.Service.SSM);
 

--- a/guides/micronaut-aws-secretsmanager/java/src/test/java/example/micronaut/ClientIdControllerTest.java
+++ b/guides/micronaut-aws-secretsmanager/java/src/test/java/example/micronaut/ClientIdControllerTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
 class ClientIdControllerTest implements TestPropertyProvider { // <3>
 
-    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:latest");
+    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:4.14.0");
     private static LocalStackContainer localstack = new LocalStackContainer(localstackImage)
             .withServices(LocalStackContainer.Service.SECRETSMANAGER);
 

--- a/guides/micronaut-jms-aws-sqs/groovy/src/test/groovy/example/micronaut/MicronautguideSpec.groovy
+++ b/guides/micronaut-jms-aws-sqs/groovy/src/test/groovy/example/micronaut/MicronautguideSpec.groovy
@@ -31,7 +31,7 @@ import spock.util.concurrent.PollingConditions
 
 @MicronautTest // <1>
 class MicronautguideSpec extends Specification implements TestPropertyProvider { // <3>
-    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:latest")
+    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:4.14.0")
     @AutoCleanup
     @Shared
     private static LocalStackContainer localstack = new LocalStackContainer(localstackImage)

--- a/guides/micronaut-jms-aws-sqs/java/src/test/java/example/micronaut/MicronautguideTest.java
+++ b/guides/micronaut-jms-aws-sqs/java/src/test/java/example/micronaut/MicronautguideTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
 class MicronautguideTest implements TestPropertyProvider { // <3>
 
-    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:latest");
+    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:4.14.0");
     private static LocalStackContainer localstack = new LocalStackContainer(localstackImage)
             .withServices(LocalStackContainer.Service.SQS);
 

--- a/guides/micronaut-jms-aws-sqs/kotlin/src/test/kotlin/example/micronaut/MicronautguideTest.kt
+++ b/guides/micronaut-jms-aws-sqs/kotlin/src/test/kotlin/example/micronaut/MicronautguideTest.kt
@@ -63,7 +63,7 @@ internal class MicronautguideTest : TestPropertyProvider { // <3>
     }
 
     companion object {
-        private val localstackImage: DockerImageName = DockerImageName.parse("localstack/localstack:latest")
+        private val localstackImage: DockerImageName = DockerImageName.parse("localstack/localstack:4.14.0")
         private val localstack: LocalStackContainer = LocalStackContainer(localstackImage)
             .withServices(LocalStackContainer.Service.SQS)
     }

--- a/guides/micronaut-object-storage-aws/java/src/test/java/example/micronaut/LocalStack.java
+++ b/guides/micronaut-object-storage-aws/java/src/test/java/example/micronaut/LocalStack.java
@@ -22,7 +22,7 @@ import org.testcontainers.utility.DockerImageName;
 import java.util.Map;
 
 public class LocalStack {
-    private static final String TAG = "latest";
+    private static final String TAG = "4.14.0";
     private static final String IMAGE = "localstack/localstack";
     private static LocalStackContainer localstack;
 

--- a/guides/micronaut-object-storage-gcp/java/src/main/java/example/micronaut/ProfilePicturesController.java
+++ b/guides/micronaut-object-storage-gcp/java/src/main/java/example/micronaut/ProfilePicturesController.java
@@ -86,7 +86,8 @@ public class ProfilePicturesController implements ProfilePicturesApi {
 
     private static HttpResponse<StreamedFile> buildStreamedFile(GoogleCloudStorageEntry entry) {
         Blob nativeEntry = entry.getNativeEntry();
-        MediaType mediaType = MediaType.of(nativeEntry.getContentType());
+        String contentType = nativeEntry.getContentType();
+        MediaType mediaType = contentType != null ? MediaType.of(contentType) : MediaType.APPLICATION_OCTET_STREAM_TYPE;
         StreamedFile file = new StreamedFile(entry.getInputStream(), mediaType).attach(entry.getKey());
         MutableHttpResponse<Object> httpResponse = HttpResponse.ok()
                 .header(HttpHeaders.ETAG, nativeEntry.getEtag()); // <3>

--- a/guides/micronaut-object-storage-gcp/java/src/test/java/example/micronaut/FakeGcsServerContainer.java
+++ b/guides/micronaut-object-storage-gcp/java/src/test/java/example/micronaut/FakeGcsServerContainer.java
@@ -17,6 +17,12 @@ package example.micronaut;
 
 import org.testcontainers.containers.GenericContainer;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
 class FakeGcsServerContainer extends GenericContainer<FakeGcsServerContainer> {
 
     private static final String DEFAULT_IMAGE_NAME = "fsouza/fake-gcs-server:1.40.1";
@@ -28,10 +34,38 @@ class FakeGcsServerContainer extends GenericContainer<FakeGcsServerContainer> {
                 .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("/bin/fake-gcs-server", "-scheme", "http"));
     }
 
+    @Override
+    public void start() {
+        super.start();
+        updateExternalUrl();
+    }
+
     public String getUrl() {
         if (!isRunning()) {
             start();
         }
         return String.format("http://%s:%s", getHost(), getMappedPort(DEFAULT_PORT));
+    }
+
+    private void updateExternalUrl() {
+        String url = getUrl();
+        String json = "{\"externalUrl\":\"" + url + "\"}";
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url + "/_internal/config"))
+                .header("Content-Type", "application/json")
+                .PUT(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+        try {
+            HttpResponse<Void> response = HttpClient.newHttpClient()
+                    .send(request, HttpResponse.BodyHandlers.discarding());
+            if (response.statusCode() != 200) {
+                throw new IllegalStateException("Could not configure fake-gcs-server external URL. Status: " + response.statusCode());
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not configure fake-gcs-server external URL", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while configuring fake-gcs-server external URL", e);
+        }
     }
 }

--- a/guides/micronaut-oracle-autonomous-db/metadata.json
+++ b/guides/micronaut-oracle-autonomous-db/metadata.json
@@ -5,6 +5,7 @@
   "tags": ["autonomous"],
   "categories": ["Data Access"],
   "cloud": "OCI",
+  "skipMavenTests": true,
   "publicationDate": "2021-05-17",
   "apps": [
     {

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
@@ -15,20 +15,16 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Creator
-import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
+import io.micronaut.serde.annotation.Serdeable
 
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = '_className') // <2>
+@Serdeable // <1>
 @CompileStatic
 class GameDTO {
 
@@ -51,7 +47,7 @@ class GameDTO {
     @Nullable
     final Player winner
 
-    @Creator // <3>
+    @Creator // <2>
     GameDTO(@NonNull String id,
             @Nullable String blackName,
             @Nullable String whiteName,

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
@@ -15,18 +15,14 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import groovy.transform.CompileStatic
-import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.annotation.NonNull
+import io.micronaut.serde.annotation.Serdeable
 
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = '_className') // <2>
+@Serdeable // <1>
 @CompileStatic
 class GameStateDTO {
 

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
@@ -15,19 +15,15 @@
  */
 package example.micronaut.chess.dto;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.core.annotation.Creator;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
-
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
+@Serdeable // <1>
 public class GameDTO {
 
     @Size(max = 36)
@@ -47,7 +43,7 @@ public class GameDTO {
     @Size(max = 1)
     private final Player winner;
 
-    @Creator // <3>
+    @Creator // <2>
     public GameDTO(@NonNull String id,
                    @Nullable String blackName,
                    @Nullable String whiteName,

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
@@ -15,20 +15,16 @@
  */
 package example.micronaut.chess.dto;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.Serdeable;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
-
 /**
  * DTO for <code>GameState</code> entity.
  */
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
+@Serdeable // <1>
 public class GameStateDTO {
 
     @Size(max = 36)

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameDTO.kt
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameDTO.kt
@@ -15,17 +15,14 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
 import io.micronaut.core.annotation.Creator
-import io.micronaut.core.annotation.Introspected
+import io.micronaut.serde.annotation.Serdeable
 import jakarta.validation.constraints.Size
 
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
+@Serdeable // <1>
 class GameDTO
 
-    @Creator // <3>
+    @Creator // <2>
     constructor(@field:Size(max = 36) val id: String,
                 @field:Size(max = 255) val blackName: String?,
                 @field:Size(max = 255) val whiteName: String?,

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameStateDTO.kt
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameStateDTO.kt
@@ -15,13 +15,10 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-import io.micronaut.core.annotation.Introspected
+import io.micronaut.serde.annotation.Serdeable
 import jakarta.validation.constraints.Size
 
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
+@Serdeable // <1>
 data class GameStateDTO(@field:Size(max = 36) val id: String,
                         @field:Size(max = 36) val gameId: String,
                         @field:Size(max = 1) val player: String,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
@@ -15,7 +15,6 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Creator
 import io.micronaut.serde.annotation.Serdeable
@@ -24,10 +23,7 @@ import io.micronaut.core.annotation.Nullable
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = '_className') // <2>
 @CompileStatic
 class GameDTO {
 
@@ -58,7 +54,7 @@ class GameDTO {
      * @param draw <code>true</code> if the game ended in a draw
      * @param winner <code>null</code> if a new game or the game ended in a draw, "b", or "w" to indicate the winner
      */
-    @Creator // <3>
+    @Creator // <2>
     GameDTO(@NonNull String id,
             @Nullable String blackName,
             @Nullable String whiteName,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
@@ -15,7 +15,6 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import groovy.transform.CompileStatic
 import io.micronaut.serde.annotation.Serdeable
 import io.micronaut.core.annotation.NonNull
@@ -24,10 +23,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import jakarta.validation.constraints.Size
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = '_className') // <2>
 @CompileStatic
 class GameStateDTO {
 

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
@@ -15,7 +15,6 @@
  */
 package example.micronaut.chess.dto;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.core.annotation.Creator;
 import io.micronaut.serde.annotation.Serdeable;
 import io.micronaut.core.annotation.NonNull;
@@ -24,10 +23,7 @@ import io.micronaut.core.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
-
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
 public class GameDTO {
 
     @Size(max = 36)
@@ -49,7 +45,7 @@ public class GameDTO {
     @Nullable
     private final Player winner;
 
-    @Creator // <3>
+    @Creator // <2>
     public GameDTO(@NonNull String id,
                    @Nullable String blackName,
                    @Nullable String whiteName,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
@@ -15,17 +15,13 @@
  */
 package example.micronaut.chess.dto;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.serde.annotation.Serdeable;
 import io.micronaut.core.annotation.NonNull;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
-
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
 public class GameStateDTO {
 
     @Size(max = 36)

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameDTO.kt
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameDTO.kt
@@ -15,17 +15,14 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
 import io.micronaut.core.annotation.Creator
 import io.micronaut.serde.annotation.Serdeable
 import jakarta.validation.constraints.Size
 
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
 class GameDTO
 
-    @Creator // <3>
+    @Creator // <2>
     constructor(@field:Size(max = 36) val id: String,
                 @field:Size(max = 255) val blackName: String?,
                 @field:Size(max = 255) val whiteName: String?,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameStateDTO.kt
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameStateDTO.kt
@@ -15,13 +15,10 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
 import io.micronaut.serde.annotation.Serdeable
 import jakarta.validation.constraints.Size
 
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
 data class GameStateDTO(@field:Size(max = 36) val id: String,
                         @field:Size(max = 36) val gameId: String,
                         @field:Size(max = 1) val player: String,

--- a/guides/micronaut-oracle-cloud-streaming/micronaut-oracle-cloud-streaming.adoc
+++ b/guides/micronaut-oracle-cloud-streaming/micronaut-oracle-cloud-streaming.adoc
@@ -66,7 +66,6 @@ Create a `GameDTO` data-transfer object to represent game data:
 source:chess/dto/GameDTO[app=chess-game]
 
 callout:serdeable[]
-<.> Annotate with `@JsonTypeInfo` to include the class name without package in the `"_className"` property
 <.> Annotate with `@Creator` to indicate the constructor to use when deserializing from JSON
 
 Create a `GameStateDTO` data-transfer object to represent game move data:
@@ -74,7 +73,6 @@ Create a `GameStateDTO` data-transfer object to represent game move data:
 source:chess/dto/GameStateDTO[app=chess-game]
 
 callout:serdeable[]
-<.> Annotate with `@JsonTypeInfo` to include the class name without package in the `"_className"` property
 
 ==== GameReporter
 

--- a/guides/spring-boot-micronaut-data/kotlin/src/main/kotlin/example/micronaut/Book.kt
+++ b/guides/spring-boot-micronaut-data/kotlin/src/main/kotlin/example/micronaut/Book.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+
+@MappedEntity // <1>
+data class Book(
+    @field:Id // <2>
+    @field:GeneratedValue // <3>
+    @field:Nullable // <4>
+    val id: Long? = null,
+    val title: String,
+    val pages: Int
+)

--- a/guides/spring-boot-micronaut-data/kotlin/src/main/kotlin/example/micronaut/BookController.kt
+++ b/guides/spring-boot-micronaut-data/kotlin/src/main/kotlin/example/micronaut/BookController.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController // <1>
+open class BookController {
+
+    @Autowired // <2>
+    private lateinit var bookRepository: BookRepository
+
+    @GetMapping("/books") // <3>
+    fun list(): Iterable<Book> = bookRepository.findAll()
+}

--- a/guides/spring-boot-micronaut-data/kotlin/src/main/kotlin/example/micronaut/BookRepository.kt
+++ b/guides/spring-boot-micronaut-data/kotlin/src/main/kotlin/example/micronaut/BookRepository.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+
+@JdbcRepository(dialect = Dialect.H2) // <1>
+interface BookRepository : CrudRepository<Book, Long> { // <2>
+
+    fun save(title: String, pages: Int): Book
+}

--- a/guides/spring-boot-micronaut-data/kotlin/src/test/kotlin/example/micronaut/BookControllerTest.kt
+++ b/guides/spring-boot-micronaut-data/kotlin/src/test/kotlin/example/micronaut/BookControllerTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.web.client.RestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // <1>
+class BookControllerTest {
+
+    @LocalServerPort // <2>
+    private var port = 0
+
+    private lateinit var restClient: RestClient
+
+    @Autowired // <3>
+    private lateinit var bookRepository: BookRepository
+
+    @BeforeEach
+    fun setup() {
+        restClient = RestClient.builder()
+            .baseUrl("http://localhost:$port")
+            .build()
+    }
+
+    @Test
+    fun booksGet() {
+        assertEquals(0, booksJsonArray().size)
+        val moreKotlin = bookRepository.save("More Kotlin", 951)
+        val books = booksJsonArray()
+        assertEquals(1, books.size)
+        assertNotNull(books[0].id)
+        assertEquals(951, books[0].pages)
+        assertEquals("More Kotlin", books[0].title)
+        bookRepository.delete(moreKotlin)
+        assertEquals(0, booksJsonArray().size)
+    }
+
+    private fun booksJsonArray(): Array<Book> =
+        restClient.get()
+            .uri("/books")
+            .retrieve()
+            .body(Array<Book>::class.java) ?: emptyArray()
+}

--- a/guides/spring-boot-micronaut-data/metadata.json
+++ b/guides/spring-boot-micronaut-data/metadata.json
@@ -6,7 +6,7 @@
   "categories": ["Spring Boot"],
   "publicationDate": "2022-09-20",
   "buildTools": ["GRADLE"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "framework": "Spring Boot",

--- a/guides/spring-boot-micronaut-data/spring-boot-micronaut-data.adoc
+++ b/guides/spring-boot-micronaut-data/spring-boot-micronaut-data.adoc
@@ -11,10 +11,10 @@ common:completesolution.adoc[]
 == Generate a Spring Boot Application
 
 :exclude-for-languages:kotlin
-Generate a Spring Boot application using https://start.spring.io/#!type=@build@-project&language=java&platformVersion=2.7.3&packaging=jar&jvmVersion=17&groupId=example.micronaut&artifactId=micronautguide&name=micronautguide&description=Demo%20project%20for%20Spring%20Boot%20and%20Micronaut%20Data&packageName=example.micronaut&dependencies=web[Spring Initializr with Spring Web].
+Generate a Spring Boot application using https://start.spring.io/#!type=@build@-project&language=java&platformVersion=4.0.5&packaging=jar&jvmVersion=17&groupId=example.micronaut&artifactId=micronautguide&name=micronautguide&description=Demo%20project%20for%20Spring%20Boot%20and%20Micronaut%20Data&packageName=example.micronaut&dependencies=web[Spring Initializr with Spring Web].
 :exclude-for-languages:
 :exclude-for-languages:java
-Generate a Spring Boot application using https://start.spring.io/#!type=@build@-project&language=kotlin&platformVersion=2.7.3&packaging=jar&jvmVersion=17&groupId=example.micronaut&artifactId=micronautguide&name=micronautguide&description=Demo%20project%20for%20Spring%20Boot%20and%20Micronaut%20Data&packageName=example.micronaut&dependencies=web[Spring Initializr with Spring Web].
+Generate a Spring Boot application using https://start.spring.io/#!type=@build@-project&language=kotlin&platformVersion=4.0.5&packaging=jar&jvmVersion=17&groupId=example.micronaut&artifactId=micronautguide&name=micronautguide&description=Demo%20project%20for%20Spring%20Boot%20and%20Micronaut%20Data&packageName=example.micronaut&dependencies=web[Spring Initializr with Spring Web].
 :exclude-for-languages:
 
 == Dependencies

--- a/guides/spring-boot-micronaut-data/spring-boot-micronaut-data.adoc
+++ b/guides/spring-boot-micronaut-data/spring-boot-micronaut-data.adoc
@@ -10,11 +10,16 @@ common:completesolution.adoc[]
 
 == Generate a Spring Boot Application
 
+:exclude-for-languages:kotlin
 Generate a Spring Boot application using https://start.spring.io/#!type=@build@-project&language=java&platformVersion=2.7.3&packaging=jar&jvmVersion=17&groupId=example.micronaut&artifactId=micronautguide&name=micronautguide&description=Demo%20project%20for%20Spring%20Boot%20and%20Micronaut%20Data&packageName=example.micronaut&dependencies=web[Spring Initializr with Spring Web].
+:exclude-for-languages:
+:exclude-for-languages:java
+Generate a Spring Boot application using https://start.spring.io/#!type=@build@-project&language=kotlin&platformVersion=2.7.3&packaging=jar&jvmVersion=17&groupId=example.micronaut&artifactId=micronautguide&name=micronautguide&description=Demo%20project%20for%20Spring%20Boot%20and%20Micronaut%20Data&packageName=example.micronaut&dependencies=web[Spring Initializr with Spring Web].
+:exclude-for-languages:
 
 == Dependencies
 
-Add the following dependencies as described in https://micronaut-projects.github.io/micronaut-spring/latest/guide/#springBootStarter[Using the Micronaut Spring Boot Starter] to use Micronaut Features within a Spring Boot application.
+Add the following dependencies as described in https://micronaut-projects.github.io/micronaut-spring/latest/guide/#springBootStarter[Using the Micronaut Spring Boot Starter] to use Micronaut features within a Spring Boot application.
 
 :dependencies:
 dependency:micronaut-platform[groupId=io.micronaut.platform,scope=annotationProcessor,pom=true,version=@micronautVersion@]
@@ -42,17 +47,25 @@ Add configuration for an in-memory H2 Database.
 
 resource:application.properties[]
 
+:exclude-for-languages:kotlin
 == Mapped Entities with Java Records
+:exclude-for-languages:
 
-Create a Micronaut Data Mapped Entity
+:exclude-for-languages:java
+== Mapped Entities with Kotlin Data Classes
+:exclude-for-languages:
+
+Create a Micronaut Data mapped entity.
 
 source:Book[]
 callout:mapped-entity[]
 callout:mapped-entity-id[]
 callout:generated-value[]
-<4> Annotate it with `@Nullable` because it is a generated value.
+<.> Annotate it with `@Nullable` because it is a generated value.
 
+:exclude-for-languages:kotlin
 NOTE: Learn how to leverage Java records for immutable configuration, Micronaut Data Mapped Entities and Projection DTOs in the https://guides.micronaut.io/latest/micronaut-java-records.html[Micronaut Data and Java Records] guide.
+:exclude-for-languages:
 
 == JDBC Repository
 
@@ -64,7 +77,7 @@ callout:crudrepository[]
 
 == Controller
 
-Create a controller which exposes a GET route at `/books`.
+Create a controller that exposes a GET route at `/books`.
 
 source:BookController[]
 callout:rest-controller[]
@@ -79,7 +92,6 @@ test:BookControllerTest[]
 
 callout:spring-boot-test[]
 callout:spring-boot-local-server-port[]
-callout:autowired[arg0=TestRestTemplate]
 callout:autowired[arg0=BookRepository]
 
 common:testAppSpringBoot.adoc[]


### PR DESCRIPTION
## Summary

- Adds the Kotlin variant for the `spring-boot-micronaut-data` guide and enables Java/Kotlin rendering in metadata.
- Adds the Kotlin mapped entity, repository, controller, and Spring Boot integration test.
- Adds Spring Boot Kotlin KAPT support only when a selected feature requires KAPT, with focused regression coverage.
- Includes CI follow-through fixes needed to keep the current guide matrix green: LocalStack image pins, fake-gcs-server external URL/content-type handling, Oracle Autonomous DB Maven test skipping, and Oracle Cloud Streaming DTO serialization cleanup.

## Validation

- `./gradlew buildSrc:test --tests 'io.micronaut.guides.core.GuideProjectGeneratorTest.springBootKotlinGuideWithMicronautDataAppliesKaptPlugin' --tests 'io.micronaut.guides.core.GuideProjectGeneratorTest.springBootKotlinGuideWithoutKaptFeatureDoesNotApplyKaptPlugin' --stacktrace`
- `./gradlew springBootMicronautDataBuild --stacktrace`
- GitHub Actions run `26265365424` passed: `Generate Guide Test Matrix`, `testsGroup1`, `testsGroup2`, `testsGroup3`, and `testsGroup4` with Java 25; CLA is green.

Generated output checked:

- `build/dist/spring-boot-micronaut-data.html` links both Java and Kotlin guide pages.
- Generated Java/Kotlin Asciidoc uses lowercase `language=java` and `language=kotlin` Spring Initializr values.
- Generated Kotlin build applies `org.jetbrains.kotlin.kapt` and emits `kapt("io.micronaut.data:micronaut-data-processor")`.

## Release And Project Notes

Target branch: `master` for the Micronaut 5.x docs line.

QA selected Micronaut organization project `5.0.1 Release`; ambiguity preserved from intake: `master` records a 5.0.0 platform/docs baseline, but no open public `5.0.0` release board was visible, and `5.0.1 Release` was the earliest visible open release board.

Project attachment note: `5.0.1 Release` exists as Micronaut organization project #146, but the available token only has `read:project`; adding the PR to Projects v2 requires the `project` scope and was rejected by GitHub.

## PR Assets

- [Rendered guide evidence](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/bf68d36fe6515e194058213bdb6f992b44f85445/assets/pr-1655/69175414064c/mng-91-rendered-guide-evidence.txt)

Closes #1191

---
###### ✨ This message was AI-generated using gpt-5