### PR TITLE
Replace LocalStack guide tests with Floci

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/TestResourcesJdbcOracleFree.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/TestResourcesJdbcOracleFree.java
@@ -1,0 +1,49 @@
+package io.micronaut.guides.feature;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.MavenCoordinate;
+import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.testresources.TestResourcesAdditionalModulesProvider;
+import io.micronaut.starter.options.BuildTool;
+import jakarta.inject.Singleton;
+
+import java.util.Collections;
+import java.util.List;
+
+@Singleton
+public class TestResourcesJdbcOracleFree implements Feature, TestResourcesAdditionalModulesProvider {
+
+    private static final String NAME = "test-resources-jdbc-oracle-free";
+    private static final MavenCoordinate DEPENDENCY = new MavenCoordinate(
+            "io.micronaut.testresources",
+            "micronaut-test-resources-jdbc-oracle-free",
+            null);
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+    }
+
+    @Override
+    public List<String> getTestResourcesAdditionalModules(GeneratorContext generatorContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<MavenCoordinate> getTestResourcesDependencies(GeneratorContext generatorContext) {
+        if (generatorContext.getBuildTool() == BuildTool.MAVEN) {
+            return List.of(DEPENDENCY);
+        }
+        return Collections.emptyList();
+    }
+}

--- a/buildSrc/src/main/java/io/micronaut/guides/feature/TestcontainersFloci.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/TestcontainersFloci.java
@@ -1,0 +1,12 @@
+package io.micronaut.guides.feature;
+
+import io.micronaut.starter.build.dependencies.Scope;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class TestcontainersFloci extends AbstractFeature {
+
+    public TestcontainersFloci() {
+        super("testcontainers-floci", Scope.TEST);
+    }
+}

--- a/buildSrc/src/main/resources/pom.xml
+++ b/buildSrc/src/main/resources/pom.xml
@@ -68,8 +68,9 @@
             <version>4.3.0</version>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers-localstack</artifactId>
+            <groupId>io.floci</groupId>
+            <artifactId>testcontainers-floci</artifactId>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/buildSrc/src/test/java/io/micronaut/guides/core/GuideProjectGeneratorTest.java
+++ b/buildSrc/src/test/java/io/micronaut/guides/core/GuideProjectGeneratorTest.java
@@ -160,5 +160,57 @@ class GuideProjectGeneratorTest {
         }
     }
 
+    @Test
+    void testGenerateOracleAtpMavenProjectWithOracleFreeTestResources() {
+        File outputDirectory = new File("build/tmp/test-oracle-atp-" + System.nanoTime());
+        outputDirectory.mkdir();
+        App app = new App(
+                "default",
+                "example.micronaut",
+                ApplicationType.DEFAULT,
+                "Micronaut",
+                List.of("data-jdbc", "flyway", "http-client", "oracle-cloud-atp"),
+                List.of("test-resources-jdbc-oracle-free"),
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null,
+                true
+        );
+        Guide guide = new Guide(
+                "Access an Oracle Autonomous Database",
+                "Learn how to access an Oracle Autonomous Database using the Micronaut framework.",
+                List.of("Burt Beckwith"),
+                List.of("Data Access"),
+                LocalDate.of(2021, 5, 17),
+                null,
+                null,
+                null,
+                false,
+                false,
+                "micronaut-oracle-autonomous-db.adoc",
+                List.of(Language.JAVA),
+                List.of("autonomous"),
+                List.of(BuildTool.MAVEN),
+                TestFramework.JUNIT,
+                List.of(),
+                "micronaut-oracle-autonomous-db",
+                true,
+                null,
+                Map.of(),
+                List.of(app)
+        );
+
+        assertDoesNotThrow(() -> guideProjectGenerator.generate(outputDirectory, guide));
+
+        File dest = Paths.get(outputDirectory.getAbsolutePath(), MacroUtils.getSourceDir(guide.slug(), new GuidesOption(BuildTool.MAVEN, Language.JAVA, TestFramework.JUNIT))).toFile();
+        String result = readFile(new File(dest, "pom.xml"));
+        assertTrue(result.contains("<testResourcesDependencies>"), result);
+        assertTrue(result.contains("<groupId>io.micronaut.testresources</groupId>"), result);
+        assertTrue(result.contains("<artifactId>micronaut-test-resources-jdbc-oracle-free</artifactId>"), result);
+    }
+
 
 }

--- a/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationSpecificEnvironmentTest.java
+++ b/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationSpecificEnvironmentTest.java
@@ -15,6 +15,7 @@
  */
 package example.micronaut;
 
+import io.floci.testcontainers.FlociContainer;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.NonNull;
@@ -26,14 +27,13 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
 import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 
+import java.net.URI;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -44,29 +44,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Property(name = "aws.distributed-configuration.search-active-environments", value = StringUtils.TRUE)
 class VatControllerDistributedConfigurationSpecificEnvironmentTest implements TestPropertyProvider {
 
-    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:latest");
-    private static LocalStackContainer localstack = new LocalStackContainer(localstackImage)
-            .withServices(LocalStackContainer.Service.SSM);
+    private static FlociContainer floci = new FlociContainer();
 
     @Override
     public @NonNull Map<String, String> getProperties() {
-        if (!localstack.isRunning()) {
-            localstack.start();
+        if (!floci.isRunning()) {
+            floci.start();
         }
         try (SsmClient ssmClient = SsmClient.builder()
-                .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.SSM))
-                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
+                .endpointOverride(URI.create(floci.getEndpoint()))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(floci.getAccessKey(), floci.getSecretKey())))
                 .build()
         ) {
-            ssmClient.putParameter(putParameterRequest("/config/micronautguide/vat/country/", "Spain"));
-            ssmClient.putParameter(putParameterRequest("/config/micronautguide/vat/rate/", "21"));
-            ssmClient.putParameter(putParameterRequest("/config/micronautguide_ch/vat/country/", "Switzerland"));
-            ssmClient.putParameter(putParameterRequest("/config/micronautguide_ch/vat/rate/", "7.7"));
+            ssmClient.putParameter(putParameterRequest("/config/micronautguide/vat/country", "Spain"));
+            ssmClient.putParameter(putParameterRequest("/config/micronautguide/vat/rate", "21"));
+            ssmClient.putParameter(putParameterRequest("/config/micronautguide_ch/vat/country", "Switzerland"));
+            ssmClient.putParameter(putParameterRequest("/config/micronautguide_ch/vat/rate", "7.7"));
         }
-        return Map.of("aws.access-key-id", localstack.getAccessKey(),
-                "aws.secret-key", localstack.getSecretKey(),
-                "aws.region", localstack.getRegion(),
-                "aws.services.ssm.endpoint-override", localstack.getEndpointOverride(LocalStackContainer.Service.SSM).toString());
+        return Map.of("aws.access-key-id", floci.getAccessKey(),
+                "aws.secret-key", floci.getSecretKey(),
+                "aws.region", floci.getRegion(),
+                "aws.services.ssm.endpoint-override", floci.getEndpoint());
     }
 
     private PutParameterRequest putParameterRequest(String name, String value) {

--- a/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationSpecificEnvironmentTest.java
+++ b/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationSpecificEnvironmentTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
 import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
@@ -55,6 +56,7 @@ class VatControllerDistributedConfigurationSpecificEnvironmentTest implements Te
         }
         try (SsmClient ssmClient = SsmClient.builder()
                 .endpointOverride(URI.create(floci.getEndpoint()))
+                .region(Region.of(floci.getRegion()))
                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(floci.getAccessKey(), floci.getSecretKey())))
                 .build()
         ) {

--- a/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationSpecificEnvironmentTest.java
+++ b/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationSpecificEnvironmentTest.java
@@ -27,6 +27,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.ssm.SsmClient;
@@ -44,7 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Property(name = "aws.distributed-configuration.search-active-environments", value = StringUtils.TRUE)
 class VatControllerDistributedConfigurationSpecificEnvironmentTest implements TestPropertyProvider {
 
-    private static FlociContainer floci = new FlociContainer();
+    private static final DockerImageName FLOCI_IMAGE = DockerImageName.parse("floci/floci:1.5.18");
+    private static FlociContainer floci = new FlociContainer(FLOCI_IMAGE);
 
     @Override
     public @NonNull Map<String, String> getProperties() {

--- a/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationTest.java
+++ b/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
 import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
@@ -51,6 +52,7 @@ class VatControllerDistributedConfigurationTest implements TestPropertyProvider 
         }
         try (SsmClient ssmClient = SsmClient.builder()
                 .endpointOverride(URI.create(floci.getEndpoint()))
+                .region(Region.of(floci.getRegion()))
                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(floci.getAccessKey(), floci.getSecretKey())))
                 .build()
         ) {

--- a/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationTest.java
+++ b/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationTest.java
@@ -25,6 +25,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.ssm.SsmClient;
@@ -40,7 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
 class VatControllerDistributedConfigurationTest implements TestPropertyProvider { // <3>
 
-    private static FlociContainer floci = new FlociContainer();
+    private static final DockerImageName FLOCI_IMAGE = DockerImageName.parse("floci/floci:1.5.18");
+    private static FlociContainer floci = new FlociContainer(FLOCI_IMAGE);
 
     @Override
     public @NonNull Map<String, String> getProperties() {

--- a/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationTest.java
+++ b/guides/micronaut-aws-parameter-store/java/src/test/java/example/micronaut/VatControllerDistributedConfigurationTest.java
@@ -15,6 +15,7 @@
  */
 package example.micronaut;
 
+import io.floci.testcontainers.FlociContainer;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.client.BlockingHttpClient;
@@ -24,14 +25,13 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.ParameterType;
 import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 
+import java.net.URI;
 import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,35 +40,33 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
 class VatControllerDistributedConfigurationTest implements TestPropertyProvider { // <3>
 
-    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:latest");
-    private static LocalStackContainer localstack = new LocalStackContainer(localstackImage)
-            .withServices(LocalStackContainer.Service.SSM);
+    private static FlociContainer floci = new FlociContainer();
 
     @Override
     public @NonNull Map<String, String> getProperties() {
-        if (!localstack.isRunning()) {
-            localstack.start();
+        if (!floci.isRunning()) {
+            floci.start();
         }
         try (SsmClient ssmClient = SsmClient.builder()
-                .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.SSM))
-                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
+                .endpointOverride(URI.create(floci.getEndpoint()))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(floci.getAccessKey(), floci.getSecretKey())))
                 .build()
         ) {
             ssmClient.putParameter(PutParameterRequest.builder()
-                    .name("/config/micronautguide/vat/country/")
+                    .name("/config/micronautguide/vat/country")
                     .type(ParameterType.STRING)
                     .value("Spain")
                     .build());
             ssmClient.putParameter(PutParameterRequest.builder()
-                    .name("/config/micronautguide/vat/rate/")
+                    .name("/config/micronautguide/vat/rate")
                     .type(ParameterType.STRING)
                     .value("21")
                     .build());
         }
-        return Map.of("aws.access-key-id", localstack.getAccessKey(),
-                "aws.secret-key", localstack.getSecretKey(),
-                "aws.region", localstack.getRegion(),
-                "aws.services.ssm.endpoint-override", localstack.getEndpointOverride(LocalStackContainer.Service.SSM).toString());
+        return Map.of("aws.access-key-id", floci.getAccessKey(),
+                "aws.secret-key", floci.getSecretKey(),
+                "aws.region", floci.getRegion(),
+                "aws.services.ssm.endpoint-override", floci.getEndpoint());
     }
 
     @Test

--- a/guides/micronaut-aws-parameter-store/metadata.json
+++ b/guides/micronaut-aws-parameter-store/metadata.json
@@ -12,7 +12,7 @@
     {
       "name": "default",
       "features": ["aws-parameter-store"],
-      "javaFeatures": [ "localstack"]
+      "javaFeatures": [ "testcontainers", "testcontainers-floci"]
     }
   ]
 }

--- a/guides/micronaut-aws-secretsmanager/java/src/test/java/example/micronaut/ClientIdControllerTest.java
+++ b/guides/micronaut-aws-secretsmanager/java/src/test/java/example/micronaut/ClientIdControllerTest.java
@@ -25,6 +25,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
@@ -41,7 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
 class ClientIdControllerTest implements TestPropertyProvider { // <3>
 
-    private static FlociContainer floci = new FlociContainer();
+    private static final DockerImageName FLOCI_IMAGE = DockerImageName.parse("floci/floci:1.5.18");
+    private static FlociContainer floci = new FlociContainer(FLOCI_IMAGE);
 
     @Override
     public @NonNull Map<String, String> getProperties() {

--- a/guides/micronaut-aws-secretsmanager/java/src/test/java/example/micronaut/ClientIdControllerTest.java
+++ b/guides/micronaut-aws-secretsmanager/java/src/test/java/example/micronaut/ClientIdControllerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 
@@ -52,6 +53,7 @@ class ClientIdControllerTest implements TestPropertyProvider { // <3>
         }
         try (SecretsManagerClient secretsManager = SecretsManagerClient.builder()
                 .endpointOverride(URI.create(floci.getEndpoint()))
+                .region(Region.of(floci.getRegion()))
                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(floci.getAccessKey(), floci.getSecretKey())))
                 .build()
         ) {

--- a/guides/micronaut-aws-secretsmanager/java/src/test/java/example/micronaut/ClientIdControllerTest.java
+++ b/guides/micronaut-aws-secretsmanager/java/src/test/java/example/micronaut/ClientIdControllerTest.java
@@ -15,6 +15,7 @@
  */
 package example.micronaut;
 
+import io.floci.testcontainers.FlociContainer;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.client.BlockingHttpClient;
@@ -24,13 +25,12 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.micronaut.test.support.TestPropertyProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 
+import java.net.URI;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -41,18 +41,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
 class ClientIdControllerTest implements TestPropertyProvider { // <3>
 
-    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:latest");
-    private static LocalStackContainer localstack = new LocalStackContainer(localstackImage)
-            .withServices(LocalStackContainer.Service.SECRETSMANAGER);
+    private static FlociContainer floci = new FlociContainer();
 
     @Override
     public @NonNull Map<String, String> getProperties() {
-        if (!localstack.isRunning()) {
-            localstack.start();
+        if (!floci.isRunning()) {
+            floci.start();
         }
         try (SecretsManagerClient secretsManager = SecretsManagerClient.builder()
-                .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.SECRETSMANAGER))
-                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
+                .endpointOverride(URI.create(floci.getEndpoint()))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(floci.getAccessKey(), floci.getSecretKey())))
                 .build()
         ) {
             secretsManager.createSecret(CreateSecretRequest.builder()
@@ -60,10 +58,10 @@ class ClientIdControllerTest implements TestPropertyProvider { // <3>
                     .secretString("{\"micronaut.security.oauth2.clients.companyauthserver.client-id\":\"XXX\",\"micronaut.security.oauth2.clients.companyauthserver.client-secret\":\"YYY\"}")
                     .build());
         }
-        return Map.of("aws.access-key-id", localstack.getAccessKey(),
-                "aws.secret-key", localstack.getSecretKey(),
-                "aws.region", localstack.getRegion(),
-                "aws.services.secretsmanager.endpoint-override", localstack.getEndpointOverride(LocalStackContainer.Service.SECRETSMANAGER).toString());
+        return Map.of("aws.access-key-id", floci.getAccessKey(),
+                "aws.secret-key", floci.getSecretKey(),
+                "aws.region", floci.getRegion(),
+                "aws.services.secretsmanager.endpoint-override", floci.getEndpoint());
     }
 
     @Test

--- a/guides/micronaut-aws-secretsmanager/metadata.json
+++ b/guides/micronaut-aws-secretsmanager/metadata.json
@@ -11,7 +11,7 @@
     {
       "name": "default",
       "features": ["security-oauth2", "aws-secrets-manager"],
-      "javaFeatures": [ "graalvm", "localstack"],
+      "javaFeatures": [ "graalvm", "testcontainers", "testcontainers-floci"],
       "kotlinFeatures": ["graalvm"]
     }
   ]

--- a/guides/micronaut-jms-aws-sqs/groovy/src/test/groovy/example/micronaut/MicronautguideSpec.groovy
+++ b/guides/micronaut-jms-aws-sqs/groovy/src/test/groovy/example/micronaut/MicronautguideSpec.groovy
@@ -27,12 +27,13 @@ import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
+import org.testcontainers.utility.DockerImageName
 
 @MicronautTest // <1>
 class MicronautguideSpec extends Specification implements TestPropertyProvider { // <3>
     @AutoCleanup
     @Shared
-    private static FlociContainer floci = new FlociContainer()
+    private static FlociContainer floci = new FlociContainer(DockerImageName.parse("floci/floci:1.5.18"))
 
     @Override
     @NonNull

--- a/guides/micronaut-jms-aws-sqs/groovy/src/test/groovy/example/micronaut/MicronautguideSpec.groovy
+++ b/guides/micronaut-jms-aws-sqs/groovy/src/test/groovy/example/micronaut/MicronautguideSpec.groovy
@@ -15,6 +15,7 @@
  */
 package example.micronaut
 
+import io.floci.testcontainers.FlociContainer
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.client.HttpClient
@@ -22,8 +23,6 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
-import org.testcontainers.containers.localstack.LocalStackContainer
-import org.testcontainers.utility.DockerImageName
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -31,22 +30,20 @@ import spock.util.concurrent.PollingConditions
 
 @MicronautTest // <1>
 class MicronautguideSpec extends Specification implements TestPropertyProvider { // <3>
-    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:latest")
     @AutoCleanup
     @Shared
-    private static LocalStackContainer localstack = new LocalStackContainer(localstackImage)
-            .withServices(LocalStackContainer.Service.SQS)
+    private static FlociContainer floci = new FlociContainer()
 
     @Override
     @NonNull
     Map<String, String> getProperties() {
-        if (!localstack.isRunning()) {
-            localstack.start()
+        if (!floci.isRunning()) {
+            floci.start()
         }
-        Map.of("aws.access-key-id", localstack.accessKey,
-                "aws.secret-key", localstack.secretKey,
-                "aws.region", localstack.region,
-                "aws.services.sqs.endpoint-override", localstack.getEndpointOverride(LocalStackContainer.Service.SQS).toString())
+        Map.of("aws.access-key-id", floci.accessKey,
+                "aws.secret-key", floci.secretKey,
+                "aws.region", floci.region,
+                "aws.services.sqs.endpoint-override", floci.endpoint)
     }
 
     @Inject

--- a/guides/micronaut-jms-aws-sqs/java/src/test/java/example/micronaut/MicronautguideTest.java
+++ b/guides/micronaut-jms-aws-sqs/java/src/test/java/example/micronaut/MicronautguideTest.java
@@ -25,6 +25,7 @@ import io.micronaut.test.support.TestPropertyProvider;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.Collections;
 import java.util.Map;
@@ -37,7 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
 class MicronautguideTest implements TestPropertyProvider { // <3>
 
-    private static FlociContainer floci = new FlociContainer();
+    private static final DockerImageName FLOCI_IMAGE = DockerImageName.parse("floci/floci:1.5.18");
+    private static FlociContainer floci = new FlociContainer(FLOCI_IMAGE);
 
     @Override
     public @NonNull Map<String, String> getProperties() {

--- a/guides/micronaut-jms-aws-sqs/java/src/test/java/example/micronaut/MicronautguideTest.java
+++ b/guides/micronaut-jms-aws-sqs/java/src/test/java/example/micronaut/MicronautguideTest.java
@@ -15,6 +15,7 @@
  */
 package example.micronaut;
 
+import io.floci.testcontainers.FlociContainer;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
@@ -24,8 +25,6 @@ import io.micronaut.test.support.TestPropertyProvider;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.Collections;
 import java.util.Map;
@@ -38,19 +37,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
 class MicronautguideTest implements TestPropertyProvider { // <3>
 
-    private static DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:latest");
-    private static LocalStackContainer localstack = new LocalStackContainer(localstackImage)
-            .withServices(LocalStackContainer.Service.SQS);
+    private static FlociContainer floci = new FlociContainer();
 
     @Override
     public @NonNull Map<String, String> getProperties() {
-        if (!localstack.isRunning()) {
-            localstack.start();
+        if (!floci.isRunning()) {
+            floci.start();
         }
-        return Map.of("aws.access-key-id", localstack.getAccessKey(),
-                "aws.secret-key", localstack.getSecretKey(),
-                "aws.region", localstack.getRegion(),
-                "aws.services.sqs.endpoint-override", localstack.getEndpointOverride(LocalStackContainer.Service.SQS).toString());
+        return Map.of("aws.access-key-id", floci.getAccessKey(),
+                "aws.secret-key", floci.getSecretKey(),
+                "aws.region", floci.getRegion(),
+                "aws.services.sqs.endpoint-override", floci.getEndpoint());
     }
     @Inject
     @Client("/")

--- a/guides/micronaut-jms-aws-sqs/kotlin/src/test/kotlin/example/micronaut/MicronautguideTest.kt
+++ b/guides/micronaut-jms-aws-sqs/kotlin/src/test/kotlin/example/micronaut/MicronautguideTest.kt
@@ -15,6 +15,7 @@
  */
 package example.micronaut
 
+import io.floci.testcontainers.FlociContainer
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.client.HttpClient
@@ -27,8 +28,6 @@ import org.hamcrest.Matchers
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.localstack.LocalStackContainer
-import org.testcontainers.utility.DockerImageName
 
 @MicronautTest // <1>
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
@@ -42,15 +41,14 @@ internal class MicronautguideTest : TestPropertyProvider { // <3>
     lateinit var demoConsumer: DemoConsumer
 
     override fun getProperties(): @NonNull MutableMap<String, String> {
-        if (!localstack.isRunning) {
-            localstack.start()
+        if (!floci.isRunning) {
+            floci.start()
         }
         return mapOf(
-            "aws.access-key-id" to localstack.accessKey,
-            "aws.secret-key" to localstack.secretKey,
-            "aws.region" to localstack.region,
-            "aws.services.sqs.endpoint-override" to localstack.getEndpointOverride(LocalStackContainer.Service.SQS)
-                .toString()
+            "aws.access-key-id" to floci.accessKey,
+            "aws.secret-key" to floci.secretKey,
+            "aws.region" to floci.region,
+            "aws.services.sqs.endpoint-override" to floci.endpoint
         ).toMutableMap()
     }
 
@@ -63,8 +61,6 @@ internal class MicronautguideTest : TestPropertyProvider { // <3>
     }
 
     companion object {
-        private val localstackImage: DockerImageName = DockerImageName.parse("localstack/localstack:latest")
-        private val localstack: LocalStackContainer = LocalStackContainer(localstackImage)
-            .withServices(LocalStackContainer.Service.SQS)
+        private val floci: FlociContainer = FlociContainer()
     }
 }

--- a/guides/micronaut-jms-aws-sqs/kotlin/src/test/kotlin/example/micronaut/MicronautguideTest.kt
+++ b/guides/micronaut-jms-aws-sqs/kotlin/src/test/kotlin/example/micronaut/MicronautguideTest.kt
@@ -28,6 +28,7 @@ import org.hamcrest.Matchers
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.testcontainers.utility.DockerImageName
 
 @MicronautTest // <1>
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
@@ -61,6 +62,6 @@ internal class MicronautguideTest : TestPropertyProvider { // <3>
     }
 
     companion object {
-        private val floci: FlociContainer = FlociContainer()
+        private val floci: FlociContainer = FlociContainer(DockerImageName.parse("floci/floci:1.5.18"))
     }
 }

--- a/guides/micronaut-jms-aws-sqs/metadata.json
+++ b/guides/micronaut-jms-aws-sqs/metadata.json
@@ -10,7 +10,7 @@
   "apps": [
     {
       "name": "default",
-      "features": ["jms-sqs", "localstack"],
+      "features": ["jms-sqs", "testcontainers", "testcontainers-floci"],
       "javaFeatures": [ "awaitility"],
       "kotlinFeatures": [ "awaitility"],
       "excludeTest": ["DefaultTest"]

--- a/guides/micronaut-jms-aws-sqs/micronaut-jms-aws-sqs.adoc
+++ b/guides/micronaut-jms-aws-sqs/micronaut-jms-aws-sqs.adoc
@@ -52,16 +52,16 @@ callout:constructor-di[arg0=DemoProducer]
 
 == Testing
 
-common:localstack.adoc[]
+common:floci.adoc[]
 
-common:localstack-dependencies.adoc[]
+common:floci-dependencies.adoc[]
 
-First, we create a configuration properties object to encapsulate the configuration of the SQS client, which we will provide via LocalStack.
+First, we create a configuration properties object to encapsulate the configuration of the SQS client, which we will provide via Floci.
 
 test:SqsConfig[]
 callout:configuration-properties[]
 
-Create a `BeanCreatedEventListener` to override the SQS client endpoint with the LocalStack endpoint.
+Create a `BeanCreatedEventListener` to override the SQS client endpoint with the Floci endpoint.
 
 test:SqsClientBuilderListener[]
 callout:singleton[]
@@ -74,7 +74,7 @@ test:SqsClientCreatedEventListener[]
 callout:singleton[]
 callout:bean-created-event-listener[]
 
-Create a test using the https://java.testcontainers.org/modules/localstack/[Testcontainers LocalStack] module to start a LocalStack container and verify that the message has been sent and received.
+Create a test using the Floci Testcontainers module to start a Floci container and verify that the message has been sent and received.
 
 test:MicronautguideTest[]
 

--- a/guides/micronaut-object-storage-aws/java/src/test/java/example/micronaut/Floci.java
+++ b/guides/micronaut-object-storage-aws/java/src/test/java/example/micronaut/Floci.java
@@ -15,36 +15,33 @@
  */
 package example.micronaut;
 
+import io.floci.testcontainers.FlociContainer;
 import io.micronaut.core.util.CollectionUtils;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
 
-public class LocalStack {
-    private static final String TAG = "latest";
-    private static final String IMAGE = "localstack/localstack";
-    private static LocalStackContainer localstack;
+public class Floci {
+    private static FlociContainer floci;
 
-    private static LocalStackContainer getLocalStack() {
+    private static FlociContainer getFloci() {
         init();
-        return localstack;
+        return floci;
     }
 
     private static String getEndpoint() {
-        return getLocalStack().getEndpointOverride(LocalStackContainer.Service.S3).toString();
+        return getFloci().getEndpoint();
     }
 
     private static String secretAccessKey() {
-        return getLocalStack().getSecretKey();
+        return getFloci().getSecretKey();
     }
 
     private static String getRegion() {
-        return getLocalStack().getRegion();
+        return getFloci().getRegion();
     }
 
     private static String accessKeyId() {
-        return getLocalStack().getAccessKey();
+        return getFloci().getAccessKey();
     }
 
     public static Map<String, String> getProperties() {
@@ -52,20 +49,20 @@ public class LocalStack {
                 "aws.accessKeyId", accessKeyId(),
                 "aws.secretKey", secretAccessKey(),
                 "aws.region", getRegion(),
-                "aws.services.s3.endpoint-override", getEndpoint()
+                "aws.services.s3.endpoint-override", getEndpoint(),
+                "aws.services.s3.path-style-access-enabled", "true"
         );
     }
 
     public static void init() {
-        if (localstack == null) {
-            localstack = new LocalStackContainer(DockerImageName.parse(IMAGE + ":" + TAG))
-                    .withServices(LocalStackContainer.Service.S3);
-            localstack.start();
+        if (floci == null) {
+            floci = new FlociContainer();
+            floci.start();
         }
     }
     public static void close() {
-        if (localstack != null) {
-            localstack.close();
+        if (floci != null) {
+            floci.close();
         }
     }
 }

--- a/guides/micronaut-object-storage-aws/java/src/test/java/example/micronaut/Floci.java
+++ b/guides/micronaut-object-storage-aws/java/src/test/java/example/micronaut/Floci.java
@@ -17,10 +17,12 @@ package example.micronaut;
 
 import io.floci.testcontainers.FlociContainer;
 import io.micronaut.core.util.CollectionUtils;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
 
 public class Floci {
+    private static final DockerImageName FLOCI_IMAGE = DockerImageName.parse("floci/floci:1.5.18");
     private static FlociContainer floci;
 
     private static FlociContainer getFloci() {
@@ -56,7 +58,7 @@ public class Floci {
 
     public static void init() {
         if (floci == null) {
-            floci = new FlociContainer();
+            floci = new FlociContainer(FLOCI_IMAGE);
             floci.start();
         }
     }

--- a/guides/micronaut-object-storage-aws/java/src/test/java/example/micronaut/FlociExtension.java
+++ b/guides/micronaut-object-storage-aws/java/src/test/java/example/micronaut/FlociExtension.java
@@ -18,9 +18,9 @@ package example.micronaut;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class LocalStackExtension implements AfterAllCallback {
+public class FlociExtension implements AfterAllCallback {
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
-        LocalStack.close();
+        Floci.close();
     }
 }

--- a/guides/micronaut-object-storage-aws/java/src/test/java/example/micronaut/ProfilePicturesControllerTest.java
+++ b/guides/micronaut-object-storage-aws/java/src/test/java/example/micronaut/ProfilePicturesControllerTest.java
@@ -26,9 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
@@ -45,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Testcontainers(disabledWithoutDocker = true)
 @MicronautTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(LocalStackExtension.class)
+@ExtendWith(FlociExtension.class)
 class ProfilePicturesControllerTest extends AbstractProfilePicturesControllerTest implements TestPropertyProvider {
     public static final String BUCKET_NAME = "micronaut-guide-object-storage";
 
@@ -65,7 +63,7 @@ class ProfilePicturesControllerTest extends AbstractProfilePicturesControllerTes
     @Override
     @NonNull
     public Map<String, String> getProperties() {
-        return LocalStack.getProperties();
+        return Floci.getProperties();
     }
 
     @Override

--- a/guides/micronaut-object-storage-aws/metadata.json
+++ b/guides/micronaut-object-storage-aws/metadata.json
@@ -15,7 +15,7 @@
       "features": ["object-storage-aws"],
       "javaFeatures": ["graalvm"],
       "kotlinFeatures": ["graalvm"],
-      "invisibleFeatures": ["localstack"]
+      "invisibleFeatures": ["testcontainers", "testcontainers-floci"]
     }
   ]
 }

--- a/guides/micronaut-object-storage-gcp/java/src/main/java/example/micronaut/ProfilePicturesController.java
+++ b/guides/micronaut-object-storage-gcp/java/src/main/java/example/micronaut/ProfilePicturesController.java
@@ -86,7 +86,8 @@ public class ProfilePicturesController implements ProfilePicturesApi {
 
     private static HttpResponse<StreamedFile> buildStreamedFile(GoogleCloudStorageEntry entry) {
         Blob nativeEntry = entry.getNativeEntry();
-        MediaType mediaType = MediaType.of(nativeEntry.getContentType());
+        String contentType = nativeEntry.getContentType();
+        MediaType mediaType = contentType != null ? MediaType.of(contentType) : MediaType.APPLICATION_OCTET_STREAM_TYPE;
         StreamedFile file = new StreamedFile(entry.getInputStream(), mediaType).attach(entry.getKey());
         MutableHttpResponse<Object> httpResponse = HttpResponse.ok()
                 .header(HttpHeaders.ETAG, nativeEntry.getEtag()); // <3>

--- a/guides/micronaut-object-storage-gcp/java/src/test/java/example/micronaut/FakeGcsServerContainer.java
+++ b/guides/micronaut-object-storage-gcp/java/src/test/java/example/micronaut/FakeGcsServerContainer.java
@@ -17,10 +17,17 @@ package example.micronaut;
 
 import org.testcontainers.containers.GenericContainer;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
 class FakeGcsServerContainer extends GenericContainer<FakeGcsServerContainer> {
 
     private static final String DEFAULT_IMAGE_NAME = "fsouza/fake-gcs-server:1.40.1";
     private static final int DEFAULT_PORT = 4443;
+    private boolean externalUrlConfigured;
 
     public FakeGcsServerContainer() {
         super(DEFAULT_IMAGE_NAME);
@@ -28,10 +35,36 @@ class FakeGcsServerContainer extends GenericContainer<FakeGcsServerContainer> {
                 .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("/bin/fake-gcs-server", "-scheme", "http"));
     }
 
+    @Override
+    public void start() {
+        super.start();
+        configureExternalUrl();
+    }
+
     public String getUrl() {
         if (!isRunning()) {
             start();
         }
         return String.format("http://%s:%s", getHost(), getMappedPort(DEFAULT_PORT));
+    }
+
+    private void configureExternalUrl() {
+        if (externalUrlConfigured) {
+            return;
+        }
+        String url = getUrl();
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url + "/_internal/config"))
+                .header("Content-Type", "application/json")
+                .PUT(HttpRequest.BodyPublishers.ofString("{\"externalUrl\":\"" + url + "\"}"))
+                .build();
+        try {
+            HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.discarding());
+            externalUrlConfigured = true;
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to configure fake-gcs-server external URL", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while configuring fake-gcs-server external URL", e);
+        }
     }
 }

--- a/guides/micronaut-oracle-autonomous-db/metadata.json
+++ b/guides/micronaut-oracle-autonomous-db/metadata.json
@@ -11,6 +11,7 @@
       "excludeTest": ["DefaultTest"],
       "name": "default",
       "features": ["data-jdbc", "flyway", "http-client", "oracle-cloud-atp"],
+      "invisibleFeatures": ["test-resources-jdbc-oracle-free"],
       "javaFeatures": ["graalvm"],
       "kotlinFeatures": ["graalvm"]
   }]

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
@@ -15,20 +15,16 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Creator
-import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
+import io.micronaut.serde.annotation.Serdeable
 
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = '_className') // <2>
+@Serdeable // <1>
 @CompileStatic
 class GameDTO {
 
@@ -51,7 +47,7 @@ class GameDTO {
     @Nullable
     final Player winner
 
-    @Creator // <3>
+    @Creator // <2>
     GameDTO(@NonNull String id,
             @Nullable String blackName,
             @Nullable String whiteName,

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
@@ -15,18 +15,14 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import groovy.transform.CompileStatic
-import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.annotation.NonNull
+import io.micronaut.serde.annotation.Serdeable
 
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = '_className') // <2>
+@Serdeable // <1>
 @CompileStatic
 class GameStateDTO {
 

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
@@ -15,19 +15,15 @@
  */
 package example.micronaut.chess.dto;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.core.annotation.Creator;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
-
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
+@Serdeable // <1>
 public class GameDTO {
 
     @Size(max = 36)
@@ -47,7 +43,7 @@ public class GameDTO {
     @Size(max = 1)
     private final Player winner;
 
-    @Creator // <3>
+    @Creator // <2>
     public GameDTO(@NonNull String id,
                    @Nullable String blackName,
                    @Nullable String whiteName,

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
@@ -15,20 +15,16 @@
  */
 package example.micronaut.chess.dto;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.Serdeable;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
-
 /**
  * DTO for <code>GameState</code> entity.
  */
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
+@Serdeable // <1>
 public class GameStateDTO {
 
     @Size(max = 36)

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameDTO.kt
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameDTO.kt
@@ -15,17 +15,14 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
 import io.micronaut.core.annotation.Creator
-import io.micronaut.core.annotation.Introspected
+import io.micronaut.serde.annotation.Serdeable
 import jakarta.validation.constraints.Size
 
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
+@Serdeable // <1>
 class GameDTO
 
-    @Creator // <3>
+    @Creator // <2>
     constructor(@field:Size(max = 36) val id: String,
                 @field:Size(max = 255) val blackName: String?,
                 @field:Size(max = 255) val whiteName: String?,

--- a/guides/micronaut-oracle-cloud-streaming/chess-game/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameStateDTO.kt
+++ b/guides/micronaut-oracle-cloud-streaming/chess-game/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameStateDTO.kt
@@ -15,13 +15,10 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-import io.micronaut.core.annotation.Introspected
+import io.micronaut.serde.annotation.Serdeable
 import jakarta.validation.constraints.Size
 
-@Introspected // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
+@Serdeable // <1>
 data class GameStateDTO(@field:Size(max = 36) val id: String,
                         @field:Size(max = 36) val gameId: String,
                         @field:Size(max = 1) val player: String,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameDTO.groovy
@@ -15,7 +15,6 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Creator
 import io.micronaut.serde.annotation.Serdeable
@@ -24,10 +23,7 @@ import io.micronaut.core.annotation.Nullable
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = '_className') // <2>
 @CompileStatic
 class GameDTO {
 
@@ -58,7 +54,7 @@ class GameDTO {
      * @param draw <code>true</code> if the game ended in a draw
      * @param winner <code>null</code> if a new game or the game ended in a draw, "b", or "w" to indicate the winner
      */
-    @Creator // <3>
+    @Creator // <2>
     GameDTO(@NonNull String id,
             @Nullable String blackName,
             @Nullable String whiteName,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/groovy/src/main/groovy/example/micronaut/chess/dto/GameStateDTO.groovy
@@ -15,7 +15,6 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import groovy.transform.CompileStatic
 import io.micronaut.serde.annotation.Serdeable
 import io.micronaut.core.annotation.NonNull
@@ -24,10 +23,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import jakarta.validation.constraints.Size
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
-
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = '_className') // <2>
 @CompileStatic
 class GameStateDTO {
 

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameDTO.java
@@ -15,7 +15,6 @@
  */
 package example.micronaut.chess.dto;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.core.annotation.Creator;
 import io.micronaut.serde.annotation.Serdeable;
 import io.micronaut.core.annotation.NonNull;
@@ -24,10 +23,7 @@ import io.micronaut.core.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
-
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
 public class GameDTO {
 
     @Size(max = 36)
@@ -49,7 +45,7 @@ public class GameDTO {
     @Nullable
     private final Player winner;
 
-    @Creator // <3>
+    @Creator // <2>
     public GameDTO(@NonNull String id,
                    @Nullable String blackName,
                    @Nullable String whiteName,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/java/src/main/java/example/micronaut/chess/dto/GameStateDTO.java
@@ -15,17 +15,13 @@
  */
 package example.micronaut.chess.dto;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.micronaut.serde.annotation.Serdeable;
 import io.micronaut.core.annotation.NonNull;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
-
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
 public class GameStateDTO {
 
     @Size(max = 36)

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameDTO.kt
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameDTO.kt
@@ -15,17 +15,14 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
 import io.micronaut.core.annotation.Creator
 import io.micronaut.serde.annotation.Serdeable
 import jakarta.validation.constraints.Size
 
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
 class GameDTO
 
-    @Creator // <3>
+    @Creator // <2>
     constructor(@field:Size(max = 36) val id: String,
                 @field:Size(max = 255) val blackName: String?,
                 @field:Size(max = 255) val whiteName: String?,

--- a/guides/micronaut-oracle-cloud-streaming/chess-listener/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameStateDTO.kt
+++ b/guides/micronaut-oracle-cloud-streaming/chess-listener/kotlin/src/main/kotlin/example/micronaut/chess/dto/GameStateDTO.kt
@@ -15,13 +15,10 @@
  */
 package example.micronaut.chess.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
 import io.micronaut.serde.annotation.Serdeable
 import jakarta.validation.constraints.Size
 
 @Serdeable // <1>
-@JsonTypeInfo(use = NAME, property = "_className") // <2>
 data class GameStateDTO(@field:Size(max = 36) val id: String,
                         @field:Size(max = 36) val gameId: String,
                         @field:Size(max = 1) val player: String,

--- a/guides/micronaut-oracle-cloud-streaming/micronaut-oracle-cloud-streaming.adoc
+++ b/guides/micronaut-oracle-cloud-streaming/micronaut-oracle-cloud-streaming.adoc
@@ -66,7 +66,6 @@ Create a `GameDTO` data-transfer object to represent game data:
 source:chess/dto/GameDTO[app=chess-game]
 
 callout:serdeable[]
-<.> Annotate with `@JsonTypeInfo` to include the class name without package in the `"_className"` property
 <.> Annotate with `@Creator` to indicate the constructor to use when deserializing from JSON
 
 Create a `GameStateDTO` data-transfer object to represent game move data:
@@ -74,7 +73,6 @@ Create a `GameStateDTO` data-transfer object to represent game move data:
 source:chess/dto/GameStateDTO[app=chess-game]
 
 callout:serdeable[]
-<.> Annotate with `@JsonTypeInfo` to include the class name without package in the `"_className"` property
 
 ==== GameReporter
 

--- a/src/docs/common/snippets/common-floci-dependencies.adoc
+++ b/src/docs/common/snippets/common-floci-dependencies.adoc
@@ -1,13 +1,9 @@
-=== LocalStack Dependencies
+=== Floci Dependencies
 
-Add the following dependencies to your test classpath:
+To test with Floci, add the following dependencies:
 
 :dependencies:
-
 dependency:testcontainers-junit-jupiter[groupId=org.testcontainers,scope=test]
-dependency:testcontainers-localstack[groupId=org.testcontainers,scope=test]
+dependency:testcontainers-floci[groupId=io.floci,scope=test]
 dependency:testcontainers[groupId=org.testcontainers,scope=test]
-
 :dependencies:
-
-

--- a/src/docs/common/snippets/common-floci.adoc
+++ b/src/docs/common/snippets/common-floci.adoc
@@ -1,0 +1,1 @@
+To test, we will use https://github.com/floci-io/floci[Floci].

--- a/src/docs/common/snippets/common-floci.adoc
+++ b/src/docs/common/snippets/common-floci.adoc
@@ -1,1 +1,3 @@
 To test, we will use https://github.com/floci-io/floci[Floci].
+
+Floci tests run through Docker and Testcontainers. The Floci container mounts the Docker daemon socket at `/var/run/docker.sock`, so run these tests only in trusted local or trusted CI Docker environments.

--- a/src/docs/common/snippets/common-localstack.adoc
+++ b/src/docs/common/snippets/common-localstack.adoc
@@ -1,4 +1,0 @@
-To test, we will use https://www.localstack.cloud[LocalStack].
-____
-Develop and test your AWS applications locally to reduce development time and increase product velocity. Reduce unnecessary AWS spend and remove the complexity and risk of maintaining AWS dev accounts.
-____


### PR DESCRIPTION
## Summary

- Replace affected LocalStack guide tests and metadata with direct Floci Testcontainers usage.
- Add the guide-local `testcontainers-floci` feature for `io.floci:testcontainers-floci:2.8.0`.
- Pin sample tests to `floci/floci:1.5.18`, use container-provided endpoint/region/credentials, and document the Docker socket trust boundary.
- Keep S3 tests working with path-style access for the Floci endpoint.
- Follow through on required guide-matrix stability at this PR head by stabilizing the existing GCP object-storage fake-gcs-server test setup, Oracle Autonomous DB Maven test-resources generation, and Oracle streaming serialization samples.

## Release And Project

Target branch: `master`.

Micronaut organization project selected during QA intake: `5.0.1 Release` (#146). QA recorded the ambiguity that `version.txt` says `5.0.0`, but no open public `5.0.0 Release` board was visible.

Live project association could not be applied by automation: `gh pr edit --add-project "5.0.1 Release"` failed because the token lacks `read:org`, and direct `addProjectV2ItemById` failed because the token lacks `project`. The PR currently has no live project item.

## Verification

- GitHub Actions `Test Guides` run `26320520879` passed at head `79512e72de60a8dc79760fb0b38d1e461cec369a`: matrix generation plus testsGroup1, testsGroup2, testsGroup3, and testsGroup4.
- `license/cla` is successful.
- `docker info --format 'Docker {{.ServerVersion}} on {{.OperatingSystem}}; {{.NCPU}} CPUs; {{.MemTotal}} bytes memory'` -> Docker 29.4.3 on Docker Desktop in QA verification.
- `./gradlew micronautJmsAwsSqsBuild micronautAwsParameterStoreBuild micronautObjectStorageAwsBuild micronautAwsSecretsmanagerBuild micronautJmsAwsSqsRunTestScript micronautAwsParameterStoreRunTestScript micronautObjectStorageAwsRunTestScript micronautAwsSecretsmanagerRunTestScript -x micronautJmsAwsSqsRunNativeTestScript -x micronautAwsParameterStoreRunNativeTestScript -x micronautObjectStorageAwsRunNativeTestScript -x micronautAwsSecretsmanagerRunNativeTestScript --stacktrace` -> `BUILD SUCCESSFUL` in QA verification.
- `git diff --check origin/master...HEAD` -> no output.
- `rg -n "localstack|LocalStack|LOCALSTACK|testcontainers-localstack|LocalStackContainer|localstack/localstack" guides src/docs/common buildSrc/src/main/resources/pom.xml buildSrc/src/main/java/io/micronaut/guides/feature` -> no matches.
- `rg -n "new FlociContainer\(\)|FlociContainer\(\)|floci/floci:latest" guides src/docs/common buildSrc/src/main/resources/pom.xml buildSrc/src/main/java/io/micronaut/guides/feature` -> no matches.

Closes #1662

---
###### ✨ This message was AI-generated using gpt-5