### PR TITLE
Pin write-token GitHub Actions refs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - master
+
+permissions:
+  contents: read
+
 jobs:
   test_matrix:
     name: Generate Guide Test Matrix
@@ -14,7 +18,7 @@ jobs:
       matrix: ${{ steps.test_matrix_step.outputs.matrix }}
       has_tasks: ${{ steps.test_matrix_step.outputs.has_tasks }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Generate Guide Test Matrix
@@ -42,17 +46,17 @@ jobs:
     env:
       JDK_VERSION: ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/cache@v5.0.5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,6 +1,8 @@
 name: Test Guides Manually
 on:
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   test_matrix:
     name: Generate Guide Test Matrix
@@ -8,13 +10,13 @@ jobs:
     outputs:
       matrix: ${{ steps.test_matrix_step.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: '25'
-      - uses: actions/cache@v5.0.5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -40,17 +42,17 @@ jobs:
     env:
       JDK_VERSION: ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/cache@v5.0.5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,23 +3,27 @@ on:
   push:
     branches:
       - master
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
       JDK_VERSION:  '25'
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/cache@v5.0.5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: 25
@@ -37,7 +41,7 @@ jobs:
           version=`echo "${tmp_version[0]}.${tmp_version[1]}.x"`
           echo ::set-output name=guides_version::${version}
       - name: Publish to Github Pages
-        uses: micronaut-projects/github-pages-deploy-action@master
+        uses: micronaut-projects/github-pages-deploy-action@76d63aafbab7108d74e83be4e5b3b0501382e829 # master
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/python-scripts.yml
+++ b/.github/workflows/python-scripts.yml
@@ -18,9 +18,9 @@ jobs:
     name: Test Python Scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
       - name: Run Tests

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '0 5 * * 1-5'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   test_matrix:
     name: Generate Guide Test Matrix
@@ -10,13 +14,13 @@ jobs:
     outputs:
       matrix: ${{ steps.test_matrix_step.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: '25'
-      - uses: actions/cache@v5.0.5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -42,17 +46,17 @@ jobs:
     env:
       JDK_VERSION: ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/cache@v5.0.5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
## Summary

- Pin mutable GitHub Actions refs in guides workflows.
- Add least-privilege top-level permissions where the implementation branch changed workflow files.

## Verification From Paperclip DEV-508

- YAML parsing passed for changed workflows.
- Mutable-ref grep returned no matches for workflow action uses.

Paperclip issue: DEV-508

---
###### ✨ This message was AI-generated using gpt-5.5
