### PR TITLE
Clarify CSRF scope in basic auth guide

### DIFF
--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth.adoc
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth.adoc
@@ -75,12 +75,15 @@ Two sample users will be able to authenticate: `sarah1` and `john-owns-no-subscr
 
 The following class configures Spring Security for the application:
 
+NOTE: This tutorial disables CSRF only for stateless APIs used by non-browser clients.
+If a Basic Auth endpoint can be called from a browser, keep CSRF protection enabled or use a credential strategy that browsers do not attach automatically because browsers can send cached Basic Auth credentials on cross-site requests.
+
 source:SecurityConfig[app=springboot]
 
 callout:spring-boot-configuration[]
 <2> Create a bean of type `PasswordEncoder`
 <3> Create a bean of type `SecurityFilterChain` to configure Spring Security's filter chain.
-<4> All HTTP requests to `/subscriptions/**` endpoints are required to be authenticated using HTTP Basic Authentication security (username and password). They do not require CSRF security.
+<4> All HTTP requests to `/subscriptions/**` endpoints require HTTP Basic Authentication. The sample disables CSRF only under the tutorial's stateless, non-browser-client assumption.
 <5> Create a bean of type `UserDetails`.
 <6> `InMemoryUserDetailsManager` is a test-only service that Spring Security provides as a way to provide user authentication and authorization information.
 

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth.adoc
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth.adoc
@@ -75,8 +75,11 @@ Two sample users will be able to authenticate: `sarah1` and `john-owns-no-subscr
 
 The following class configures Spring Security for the application:
 
-NOTE: This tutorial disables CSRF only for stateless APIs used by non-browser clients.
+[NOTE]
+====
+This tutorial disables CSRF only for stateless APIs used by non-browser clients.
 If a Basic Auth endpoint can be called from a browser, keep CSRF protection enabled or use a credential strategy that browsers do not attach automatically because browsers can send cached Basic Auth credentials on cross-site requests.
+====
 
 source:SecurityConfig[app=springboot]
 

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth/springboot/java/src/main/java/example/micronaut/SecurityConfig.java
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth/springboot/java/src/main/java/example/micronaut/SecurityConfig.java
@@ -44,6 +44,7 @@ class SecurityConfig {
         return http.authorizeHttpRequests(r -> r.requestMatchers("/subscriptions/**") // <4>
                         .hasRole(ROLE_SAAS_SUBSCRIPTION_OWNER))
                 .httpBasic(Customizer.withDefaults())
+                // Disable CSRF only for stateless APIs used by non-browser clients.
                 .csrf(AbstractHttpConfigurer::disable)
                 .build();
     }

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth/springboot/java/src/main/java/example/micronaut/SecurityConfig.java
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-security-basic-auth/springboot/java/src/main/java/example/micronaut/SecurityConfig.java
@@ -44,7 +44,8 @@ class SecurityConfig {
         return http.authorizeHttpRequests(r -> r.requestMatchers("/subscriptions/**") // <4>
                         .hasRole(ROLE_SAAS_SUBSCRIPTION_OWNER))
                 .httpBasic(Customizer.withDefaults())
-                // Disable CSRF only for stateless APIs used by non-browser clients.
+                // This sample disables CSRF for the whole app, which is only appropriate
+                // for the tutorial's stateless, non-browser client scenario.
                 .csrf(AbstractHttpConfigurer::disable)
                 .build();
     }


### PR DESCRIPTION
## Summary
- Clarifies that the Basic Auth guide disables CSRF only for stateless APIs used by non-browser clients.
- Adds a browser-accessible Basic Auth caveat recommending CSRF protection or credentials that browsers do not attach automatically.
- Adds an inline comment next to the Spring Boot Java CSRF disable call so the security boundary stays visible in copied sample code.

## Validation
- `git fetch origin master` and confirmed branch was even with `origin/master` before publishing.
- `git diff --check`
- `./gradlew buildingARestApiSpringBootVsMicronautSecurityBasicAuthGenerateDocs --rerun-tasks buildingARestApiSpringBootVsMicronautSecurityBasicAuthRunTestScript --stacktrace`

## Notes
- Open PR #1783 adds a Groovy sample for the same guide. The shared guide note in this PR will render above the Spring Boot `SecurityConfig` source block for generated guide variants after that PR merges.
- I also tried `./gradlew buildingARestApiSpringBootVsMicronautSecurityBasicAuthBuild --stacktrace`; it failed in the existing native test path on `SaasSubscriptionGetListControllerTest.shouldReturnAllSaasSubscriptionsWhenListIsRequested()` with JsonPath native reflection for `com.jayway.jsonpath.internal.function.text.Length.<init>()`. The non-native guide test script passed after the docs change.

Paperclip: DEV-996

---
###### ✨ This message was AI-generated using gpt-5
