### PR TITLE
Add Kotlin variant for AWS Lambda request stream GraalVM guide

### DIFF
--- a/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-base/java/src/main/java/example/micronaut/RequestFunction.java
+++ b/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-base/java/src/main/java/example/micronaut/RequestFunction.java
@@ -20,8 +20,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import io.micronaut.function.FunctionBean;
 import io.micronaut.json.JsonMapper;
 import jakarta.inject.Inject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -30,14 +28,11 @@ import java.util.function.Function;
 @FunctionBean("requestfunction") // <1>
 public class RequestFunction implements Function<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> { // <2>
 
-    private static final Logger LOG = LoggerFactory.getLogger(RequestFunction.class);
-
     @Inject // <3>
     JsonMapper jsonMapper;
 
     @Override
     public APIGatewayProxyResponseEvent apply(APIGatewayProxyRequestEvent requestEvent) {
-        LOG.info("request {}", requestEvent);
         APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
         try {
             String json = new String(jsonMapper.writeValueAsBytes(Collections.singletonMap("message", "Hello World")));
@@ -46,7 +41,6 @@ public class RequestFunction implements Function<APIGatewayProxyRequestEvent, AP
         } catch (IOException e) {
             response.setStatusCode(500);
         }
-        LOG.info("response {}", response);
         return response;
     }
 }

--- a/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-base/kotlin/src/main/kotlin/example/micronaut/FunctionRequestHandler.kt
+++ b/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-base/kotlin/src/main/kotlin/example/micronaut/FunctionRequestHandler.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.env.Environment
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.function.aws.MicronautRequestStreamHandler
+
+@Introspected
+class FunctionRequestHandler : MicronautRequestStreamHandler() { // <1>
+
+    override fun resolveFunctionName(env: Environment): String = "requestfunction" // <2>
+}

--- a/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-base/kotlin/src/main/kotlin/example/micronaut/RequestFunction.kt
+++ b/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-base/kotlin/src/main/kotlin/example/micronaut/RequestFunction.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+import io.micronaut.function.FunctionBean
+import io.micronaut.json.JsonMapper
+import jakarta.inject.Inject
+import java.io.IOException
+import java.util.function.Function
+
+@FunctionBean("requestfunction") // <1>
+class RequestFunction : Function<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> { // <2>
+
+    @Inject // <3>
+    lateinit var jsonMapper: JsonMapper
+
+    override fun apply(requestEvent: APIGatewayProxyRequestEvent): APIGatewayProxyResponseEvent {
+        val response = APIGatewayProxyResponseEvent()
+        try {
+            val json = String(jsonMapper.writeValueAsBytes(mapOf("message" to "Hello World")))
+            response.statusCode = 200
+            response.body = json
+        } catch (e: IOException) {
+            response.statusCode = 500
+        }
+        return response
+    }
+}

--- a/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-base/kotlin/src/test/kotlin/example/micronaut/FunctionRequestHandlerTest.kt
+++ b/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-base/kotlin/src/test/kotlin/example/micronaut/FunctionRequestHandlerTest.kt
@@ -61,7 +61,9 @@ class FunctionRequestHandlerTest {
         @AfterAll
         @JvmStatic
         fun stopServer() {
-            handler.applicationContext.close() // <2>
+            if (::handler.isInitialized) {
+                handler.applicationContext.close() // <2>
+            }
         }
     }
 }

--- a/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-base/kotlin/src/test/kotlin/example/micronaut/FunctionRequestHandlerTest.kt
+++ b/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-base/kotlin/src/test/kotlin/example/micronaut/FunctionRequestHandlerTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import io.micronaut.json.JsonMapper
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+
+class FunctionRequestHandlerTest {
+
+    @Test
+    fun testHandler() {
+        val jsonMapper = handler.applicationContext.getBean(JsonMapper::class.java)
+        ByteArrayOutputStream().use { baos ->
+            createInputStreamRequest(jsonMapper).use { inputStream ->
+                handler.execute(inputStream, baos) // <3>
+                assertEquals(
+                    """{"statusCode":200,"body":"{\"message\":\"Hello World\"}"}""",
+                    baos.toString()
+                )
+            }
+        }
+    }
+
+    private fun createInputStreamRequest(jsonMapper: JsonMapper): InputStream =
+        ByteArrayInputStream(jsonMapper.writeValueAsBytes(createRequest()))
+
+    private fun createRequest(): APIGatewayProxyRequestEvent =
+        APIGatewayProxyRequestEvent()
+            .withHttpMethod("GET")
+            .withPath("/")
+
+    companion object {
+        private lateinit var handler: FunctionRequestHandler
+
+        @BeforeAll
+        @JvmStatic
+        fun setupServer() {
+            handler = FunctionRequestHandler() // <1>
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stopServer() {
+            handler.applicationContext.close() // <2>
+        }
+    }
+}

--- a/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm/kotlin/src/main/kotlin/example/micronaut/FunctionLambdaRuntime.kt
+++ b/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm/kotlin/src/main/kotlin/example/micronaut/FunctionLambdaRuntime.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+import io.micronaut.function.aws.runtime.AbstractRequestStreamHandlerMicronautLambdaRuntime
+import java.net.MalformedURLException
+
+class FunctionLambdaRuntime : AbstractRequestStreamHandlerMicronautLambdaRuntime<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>() {
+
+    override fun createRequestStreamHandler(vararg args: String): RequestStreamHandler? =
+        FunctionRequestHandler()
+
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            try {
+                FunctionLambdaRuntime().run(*args)
+            } catch (e: MalformedURLException) {
+                e.printStackTrace()
+            }
+        }
+    }
+}

--- a/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm/metadata.json
+++ b/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm/metadata.json
@@ -7,7 +7,7 @@
   "cloud": "AWS",
   "categories": ["AWS Lambda", "GraalVM"],
   "publicationDate": "2024-01-11",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "applicationType": "FUNCTION",

--- a/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm.adoc
+++ b/guides/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm.adoc
@@ -38,7 +38,7 @@ ____
 
 The application contains a class extending https://micronaut-projects.github.io/micronaut-aws/latest/api/io/micronaut/function/aws/MicronautRequestStreamHandler.html[MicronautRequestStreamHandler]
 
-Replace the generated `FunctionRequestHandler.java` with the following:
+Replace the generated `FunctionRequestHandler` with the following:
 
 source:FunctionRequestHandler[]
 


### PR DESCRIPTION
## Summary

- Adds the Kotlin request-stream handler sources and JUnit test for the shared AWS Lambda guide base.
- Adds the Kotlin GraalVM Lambda runtime source and enables `KOTLIN` in the GraalVM guide metadata.
- Makes the handler replacement sentence language-neutral and removes whole-object request/response logging from the shared Java sample.

## Verification

- `./gradlew --no-daemon micronautServerlessFunctionAwsLambdaRequestStreamHandlerGraalvmBuild --stacktrace -x micronautServerlessFunctionAwsLambdaRequestStreamHandlerGraalvmRunNativeTestScript`
- `env -u GITHUB_TOKEN -u PAPERCLIP_API_KEY -u PAPERCLIP_WAKE_PAYLOAD_JSON ./gradlew --no-daemon micronautServerlessFunctionAwsLambdaRequestStreamHandlerGraalvmRunTestScript --stacktrace`
- `git diff --cached --check`
- Checked rendered Kotlin guide output for Kotlin source titles and absence of stale `FunctionRequestHandler.java` wording.

## Release And Project

Target branch: `master`.

Release target: default branch currently tracks the `5.0.0` guide line. QA selected the Micronaut organization project `5.0.1 Release` because no open public `5.0.0 Release` project was visible; that ambiguity is intentionally preserved.

## PR Assets

- [Rendered Kotlin guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/a9a15f3bf668d134e4c0f4fcf61bad31f7e4c5a6/assets/pr-1785/cd5bffb9c58f/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm-gradle-k.html)
- [Rendered Kotlin guide PDF](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/bd6475e2487a96d730f6141158864f32dc1f0590/assets/pr-1785/b9256bb26061/micronaut-serverless-function-aws-lambda-request-stream-handler-graalvm-kotlin.pdf)

The PDF export was generated from the rendered Kotlin HTML for PR review and is attached as a PR-visible asset, not committed to the PR branch.

Closes #1758

---
###### ✨ This message was AI-generated using gpt-5
