### PR TITLE
Add Kotlin version for REST API GET guide

### DIFF
--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/metadata.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["spring-boot"],
   "categories": ["Boot to Micronaut Building a REST API"],
   "publicationDate": "2024-04-25",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "buildTools": ["GRADLE"],
   "apps": [
     {

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
@@ -1,0 +1,6 @@
+package example.micronaut
+
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable // <1>
+data class SaasSubscription(val id: Long, val name: String, val cents: Int)

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import io.micronaut.serde.annotation.Serdeable

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
@@ -1,0 +1,19 @@
+package example.micronaut
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+
+@Controller("/subscriptions") // <1>
+class SaasSubscriptionController {
+
+    @Get("/{id}") // <2>
+    fun findById(@PathVariable id: Long): HttpResponse<SaasSubscription> { // <3>
+        if (id == 99L) {
+            val subscription = SaasSubscription(99L, "Advanced", 2900)
+            return HttpResponse.ok(subscription)
+        }
+        return HttpResponse.notFound() // <4>
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import io.micronaut.http.HttpResponse

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
@@ -1,0 +1,50 @@
+package example.micronaut
+
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+@MicronautTest // <1>
+class SaasSubscriptionControllerGetTest {
+
+    @Inject
+    @field:Client("/")
+    lateinit var httpClient: HttpClient // <2>
+
+    @Test
+    fun shouldReturnASaasSubscriptionWhenDataIsSaved() {
+        val client = httpClient.toBlocking()
+        val response: HttpResponse<String> = client.exchange("/subscriptions/99", String::class.java)
+        assertThat(response.status.code).isEqualTo(HttpStatus.OK.code)
+
+        val documentContext = JsonPath.parse(response.body())
+        val id = documentContext.read<Number>("$.id")
+        assertThat(id).isNotNull()
+        assertThat(id).isEqualTo(99)
+
+        val name = documentContext.read<String>("$.name")
+        assertThat(name).isNotNull()
+        assertThat(name).isEqualTo("Advanced")
+
+        val cents = documentContext.read<Int>("$.cents")
+        assertThat(cents).isEqualTo(2900)
+    }
+
+    @Test
+    fun shouldNotReturnASaasSubscriptionWithAnUnknownId() {
+        val client = httpClient.toBlocking()
+        val thrown = assertThrows(HttpClientResponseException::class.java) { // <3>
+            client.exchange("/subscriptions/1000", String::class.java)
+        }
+        assertThat(thrown.status.code).isEqualTo(HttpStatus.NOT_FOUND.code)
+        assertThat(thrown.response.getBody(String::class.java)).isEmpty()
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import com.jayway.jsonpath.JsonPath

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
@@ -1,0 +1,61 @@
+package example.micronaut
+
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+
+@MicronautTest(startApplication = false) // <1>
+class SaasSubscriptionJsonTest {
+
+    @Test
+    fun saasSubscriptionSerializationTest(json: JsonMapper, resourceLoader: ResourceLoader) { // <2>
+        val subscription = SaasSubscription(99L, "Professional", 4900)
+        val expected = getResourceAsString(resourceLoader, "expected.json")
+        val result = json.writeValueAsString(subscription)
+        assertThat(result).isEqualToIgnoringWhitespace(expected)
+
+        val documentContext = JsonPath.parse(result)
+        val id = documentContext.read<Number>("$.id")
+        assertThat(id)
+            .isNotNull()
+            .isEqualTo(99)
+
+        val name = documentContext.read<String>("$.name")
+        assertThat(name)
+            .isNotNull()
+            .isEqualTo("Professional")
+
+        val cents = documentContext.read<Number>("$.cents")
+        assertThat(cents)
+            .isNotNull()
+            .isEqualTo(4900)
+    }
+
+    @Test
+    fun saasSubscriptionDeserializationTest(json: JsonMapper) { // <2>
+        val expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+        """.trimIndent()
+        assertThat(json.readValue(expected, SaasSubscription::class.java))
+            .isEqualTo(SaasSubscription(100L, "Advanced", 2900))
+        val subscription = json.readValue(expected, SaasSubscription::class.java)!!
+        assertThat(subscription.id).isEqualTo(100)
+        assertThat(subscription.name).isEqualTo("Advanced")
+        assertThat(subscription.cents).isEqualTo(2900)
+    }
+
+    private fun getResourceAsString(resourceLoader: ResourceLoader, resourceName: String): String =
+        resourceLoader.getResourceAsStream(resourceName)
+            .map { inputStream ->
+                inputStream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+            }
+            .orElse("")
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import com.jayway.jsonpath.JsonPath

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/test/resources/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/kotlin/src/test/resources/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 data class SaasSubscription(val id: Long, val name: String, val cents: Int)

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
@@ -1,0 +1,3 @@
+package example.micronaut
+
+data class SaasSubscription(val id: Long, val name: String, val cents: Int)

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
@@ -1,0 +1,17 @@
+package example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+
+@Controller("/subscriptions") // <1>
+class SaasSubscriptionController {
+
+    @Get("/{id}") // <2>
+    fun findById(@PathVariable id: Long): SaasSubscription? { // <3>
+        if (id == 99L) {
+            return SaasSubscription(99L, "Advanced", 2900)
+        }
+        return null // <4>
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import io.micronaut.http.annotation.Controller

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
@@ -1,0 +1,50 @@
+package example.micronaut
+
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+@MicronautTest
+class SaasSubscriptionControllerGetTest {
+
+    @Inject
+    @field:Client("/")
+    lateinit var httpClient: HttpClient
+
+    @Test
+    fun shouldReturnASaasSubscriptionWhenDataIsSaved() {
+        val client = httpClient.toBlocking()
+        val response: HttpResponse<String> = client.exchange("/subscriptions/99", String::class.java)
+        assertThat(response.status.code).isEqualTo(HttpStatus.OK.code)
+
+        val documentContext = JsonPath.parse(response.body())
+        val id = documentContext.read<Number>("$.id")
+        assertThat(id).isNotNull()
+        assertThat(id).isEqualTo(99)
+
+        val name = documentContext.read<String>("$.name")
+        assertThat(name).isNotNull()
+        assertThat(name).isEqualTo("Advanced")
+
+        val cents = documentContext.read<Int>("$.cents")
+        assertThat(cents).isEqualTo(2900)
+    }
+
+    @Test
+    fun shouldNotReturnASaasSubscriptionWithAnUnknownId() {
+        val client = httpClient.toBlocking()
+        val thrown = assertThrows(HttpClientResponseException::class.java) {
+            client.exchange("/subscriptions/1000", String::class.java)
+        }
+        assertThat(thrown.status.code).isEqualTo(HttpStatus.NOT_FOUND.code)
+        assertThat(thrown.response.getBody(String::class.java)).isNotEmpty()
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import com.jayway.jsonpath.JsonPath

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
@@ -1,0 +1,61 @@
+package example.micronaut
+
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+
+@MicronautTest(startApplication = false) // <1>
+class SaasSubscriptionJsonTest {
+
+    @Test
+    fun saasSubscriptionSerializationTest(json: JsonMapper, resourceLoader: ResourceLoader) { // <2>
+        val subscription = SaasSubscription(99L, "Professional", 4900)
+        val expected = getResourceAsString(resourceLoader, "expected.json")
+        val result = json.writeValueAsString(subscription)
+        assertThat(result).isEqualToIgnoringWhitespace(expected)
+
+        val documentContext = JsonPath.parse(result)
+        val id = documentContext.read<Number>("$.id")
+        assertThat(id)
+            .isNotNull()
+            .isEqualTo(99)
+
+        val name = documentContext.read<String>("$.name")
+        assertThat(name)
+            .isNotNull()
+            .isEqualTo("Professional")
+
+        val cents = documentContext.read<Number>("$.cents")
+        assertThat(cents)
+            .isNotNull()
+            .isEqualTo(4900)
+    }
+
+    @Test
+    fun saasSubscriptionDeserializationTest(json: JsonMapper) { // <2>
+        val expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+        """.trimIndent()
+        assertThat(json.readValue(expected, SaasSubscription::class.java))
+            .isEqualTo(SaasSubscription(100L, "Advanced", 2900))
+        val subscription = json.readValue(expected, SaasSubscription::class.java)!!
+        assertThat(subscription.id).isEqualTo(100)
+        assertThat(subscription.name).isEqualTo("Advanced")
+        assertThat(subscription.cents).isEqualTo(2900)
+    }
+
+    private fun getResourceAsString(resourceLoader: ResourceLoader, resourceName: String): String =
+        resourceLoader.getResourceAsStream(resourceName)
+            .map { inputStream ->
+                inputStream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+            }
+            .orElse("")
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import com.jayway.jsonpath.JsonPath

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/test/resources/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/kotlin/src/test/resources/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 data class SaasSubscription(val id: Long, val name: String, val cents: Int)

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
@@ -1,0 +1,3 @@
+package example.micronaut
+
+data class SaasSubscription(val id: Long, val name: String, val cents: Int)

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import org.springframework.http.ResponseEntity

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/main/kotlin/example/micronaut/SaasSubscriptionController.kt
@@ -1,0 +1,21 @@
+package example.micronaut
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController // <1>
+@RequestMapping("/subscriptions") // <2>
+class SaasSubscriptionController {
+
+    @GetMapping("/{id}") // <3>
+    private fun findById(@PathVariable id: Long): ResponseEntity<SaasSubscription> { // <4>
+        if (id == 99L) {
+            val subscription = SaasSubscription(99L, "Advanced", 2900)
+            return ResponseEntity.ok(subscription)
+        }
+        return ResponseEntity.notFound().build()
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
@@ -1,0 +1,45 @@
+package example.micronaut
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.web.servlet.client.RestTestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // <1>
+class SaasSubscriptionControllerGetTest {
+
+    @LocalServerPort // <2>
+    var port = 0
+
+    private lateinit var restTestClient: RestTestClient // <3>
+
+    @BeforeEach
+    fun setUp() {
+        restTestClient = RestTestClient.bindToServer()
+            .baseUrl("http://localhost:$port")
+            .build()
+    }
+
+    @Test
+    fun shouldReturnASaasSubscriptionWhenDataIsSaved() {
+        val response = restTestClient.get()
+            .uri("/subscriptions/99")
+            .exchange()
+
+        response.expectStatus().isOk()
+        response.expectBody(SaasSubscription::class.java)
+            .value { subscription -> assertThat(subscription).isEqualTo(SaasSubscription(99L, "Advanced", 2900)) }
+    }
+
+    @Test
+    fun shouldNotReturnASaasSubscriptionWithAnUnknownId() {
+        val response = restTestClient.get()
+            .uri("/subscriptions/1000")
+            .exchange()
+
+        response.expectStatus().isNotFound()
+        response.expectBody().isEmpty()
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionControllerGetTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import org.assertj.core.api.Assertions.assertThat

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
@@ -1,0 +1,45 @@
+package example.micronaut
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.json.JsonTest
+import org.springframework.boot.test.json.JacksonTester
+
+@JsonTest // <1>
+class SaasSubscriptionJsonTest {
+
+    @Autowired // <2>
+    private lateinit var json: JacksonTester<SaasSubscription> // <3>
+
+    @Test
+    fun saasSubscriptionSerializationTest() {
+        val subscription = SaasSubscription(99L, "Professional", 4900)
+        assertThat(json.write(subscription)).isStrictlyEqualToJson("expected.json")
+        assertThat(json.write(subscription)).hasJsonPathNumberValue("@.id")
+        assertThat(json.write(subscription)).extractingJsonPathNumberValue("@.id")
+            .isEqualTo(99)
+        assertThat(json.write(subscription)).hasJsonPathStringValue("@.name")
+        assertThat(json.write(subscription)).extractingJsonPathStringValue("@.name")
+            .isEqualTo("Professional")
+        assertThat(json.write(subscription)).hasJsonPathNumberValue("@.cents")
+        assertThat(json.write(subscription)).extractingJsonPathNumberValue("@.cents")
+            .isEqualTo(4900)
+    }
+
+    @Test
+    fun saasSubscriptionDeserializationTest() {
+        val expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+        """.trimIndent()
+        assertThat(json.parse(expected))
+            .isEqualTo(SaasSubscription(100L, "Advanced", 2900))
+        assertThat(json.parseObject(expected).id).isEqualTo(100)
+        assertThat(json.parseObject(expected).name).isEqualTo("Advanced")
+        assertThat(json.parseObject(expected).cents).isEqualTo(2900)
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import org.assertj.core.api.Assertions.assertThat

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/test/resources/example/micronaut/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/kotlin/src/test/resources/example/micronaut/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}


### PR DESCRIPTION
## Summary

- Adds the Kotlin guide variant for the Spring Boot app and both Micronaut apps in `building-a-rest-api-spring-boot-vs-micronaut-implemeting-get`.
- Updates the guide metadata to publish `KOTLIN` while preserving `JAVA`.
- Adds Kotlin controller tests, JSON serialization tests, expected JSON resources, and standard Apache 2.0 headers for all new Kotlin files.

## Verification

- `git diff --check origin/master...HEAD`
- `./gradlew buildingARestApiSpringBootVsMicronautImplemetingGetRunTestScript --stacktrace`
- `./gradlew buildingARestApiSpringBootVsMicronautImplemetingGetIndex --rerun-tasks --stacktrace`
- `./gradlew buildingARestApiSpringBootVsMicronautImplemetingGetGenerateZips --stacktrace`

QA also reran the full guide build. It generated projects/docs/zips and failed only in the native-test runner because the local GraalVM installation rejects the configured reachability metadata schema; the same native-only failure affects pre-existing generated Java apps.

## PR Assets

- [Rendered guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/3449dfbc8084c56a4cd129d3f288b021916412f4/assets/pr-1790/9e6bc4070084/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get.html)
- Generated Kotlin sample ZIP upload attempted through the Paperclip GitHub Sync asset route, but the upload failed with `Plugin API request body is too large`.
- No guide-specific PDF generation task exists for this guide; the available guide tasks generated HTML and ZIP artifacts.

## Release Targeting

- Target branch: `master`
- Release/project note: default branch signals `5.0.0`, but no open public `5.0.0 Release` Micronaut organization project exists. QA selected `5.0.1 Release` as the earliest open public Micronaut Platform BOM release board for this Micronaut 5 docs/sample-code fix.
- Project link attempt: GitHub project lookup for `5.0.1 Release` succeeded, but adding the PR failed because the token lacks the `project` scope required by `addProjectV2ItemById`.

## Reviewer Routing

- Requested reviewer required by linked issue creator: `sdelamo`.
- GitHub rejected the reviewer request with HTTP 422: `Review cannot be requested from pull request author.`

Fixes #1670

---
###### ✨ This message was AI-generated using gpt-5