### PR TITLE
Add Groovy variant for REST API GET guide

### DIFF
--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/metadata.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/metadata.json
@@ -5,21 +5,25 @@
   "tags": ["spring-boot"],
   "categories": ["Boot to Micronaut Building a REST API"],
   "publicationDate": "2024-04-25",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "buildTools": ["GRADLE"],
   "apps": [
     {
       "framework": "Spring Boot",
       "name": "springboot",
-      "features": ["spring-boot-starter-web"]
+      "features": ["spring-boot-starter-web"],
+      "invisibleFeatures": ["springboot-gradle-plugin"],
+      "testFramework": "JUNIT"
     },
     {
       "name": "micronautframework",
-      "features": ["json-path", "assertj"]
+      "features": ["json-path"],
+      "javaFeatures": ["assertj"]
     },
     {
       "name": "micronautframeworkjacksondatabind",
-      "features": ["json-path", "assertj", "jackson-databind"]
+      "features": ["json-path", "jackson-databind"],
+      "javaFeatures": ["assertj"]
     }
   ]
 }

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
@@ -1,0 +1,14 @@
+package example.micronaut
+
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+import io.micronaut.serde.annotation.Serdeable
+
+@Canonical
+@CompileStatic
+@Serdeable // <1>
+class SaasSubscription {
+    Long id
+    String name
+    Integer cents
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/groovy/src/main/groovy/example/micronaut/SaasSubscriptionController.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/groovy/src/main/groovy/example/micronaut/SaasSubscriptionController.groovy
@@ -1,0 +1,21 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+
+@CompileStatic
+@Controller("/subscriptions") // <1>
+class SaasSubscriptionController {
+
+    @Get("/{id}") // <2>
+    HttpResponse<SaasSubscription> findById(@PathVariable Long id) { // <3>
+        if (id == 99L) {
+            SaasSubscription subscription = new SaasSubscription(99L, "Advanced", 2900)
+            return HttpResponse.ok(subscription)
+        }
+        HttpResponse.notFound() // <4>
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/groovy/src/test/groovy/example/micronaut/SaasSubscriptionControllerGetSpec.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/groovy/src/test/groovy/example/micronaut/SaasSubscriptionControllerGetSpec.groovy
@@ -1,0 +1,51 @@
+package example.micronaut
+
+import com.jayway.jsonpath.DocumentContext
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest // <1>
+class SaasSubscriptionControllerGetSpec extends Specification {
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient // <2>
+
+    void shouldReturnASaasSubscriptionWhenDataIsSaved() {
+        when:
+        def client = httpClient.toBlocking()
+        HttpResponse<String> response = client.exchange("/subscriptions/99", String)
+
+        then:
+        response.status.code == HttpStatus.OK.code
+
+        DocumentContext documentContext = JsonPath.parse(response.body())
+        Number id = documentContext.read('$.id')
+        String name = documentContext.read('$.name')
+        Integer cents = documentContext.read('$.cents')
+
+        id == 99
+        name == "Advanced"
+        cents == 2900
+    }
+
+    void shouldNotReturnASaasSubscriptionWithAnUnknownId() {
+        given:
+        def client = httpClient.toBlocking()
+
+        when:
+        client.exchange("/subscriptions/1000", String)
+
+        then:
+        HttpClientResponseException exception = thrown() // <3>
+        exception.status.code == HttpStatus.NOT_FOUND.code
+        exception.response.body.empty
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
@@ -1,0 +1,61 @@
+package example.micronaut
+
+import com.jayway.jsonpath.DocumentContext
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false) // <1>
+class SaasSubscriptionJsonSpec extends Specification {
+
+    @Inject
+    JsonMapper json
+
+    @Inject
+    ResourceLoader resourceLoader
+
+    void saasSubscriptionSerializationTest() {
+        given:
+        SaasSubscription subscription = new SaasSubscription(99L, "Professional", 4900)
+        String expected = getResourceAsString("expected.json")
+
+        when:
+        String result = json.writeValueAsString(subscription)
+        DocumentContext documentContext = JsonPath.parse(result)
+        Number id = documentContext.read('$.id')
+        String name = documentContext.read('$.name')
+        Number cents = documentContext.read('$.cents')
+
+        then:
+        result.replaceAll(/\s/, "") == expected.replaceAll(/\s/, "")
+        id == 99
+        name == "Professional"
+        cents == 4900
+    }
+
+    void saasSubscriptionDeserializationTest() {
+        given:
+        String expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+           """
+
+        expect:
+        json.readValue(expected, SaasSubscription) == new SaasSubscription(100L, "Advanced", 2900)
+        json.readValue(expected, SaasSubscription).id == 100
+        json.readValue(expected, SaasSubscription).name == "Advanced"
+        json.readValue(expected, SaasSubscription).cents == 2900
+    }
+
+    private String getResourceAsString(String resourceName) {
+        resourceLoader.getResourceAsStream(resourceName)
+                .map { stream -> stream.withCloseable { it.getText("UTF-8") } }
+                .orElse("")
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/groovy/src/test/resources/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframework/groovy/src/test/resources/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
@@ -1,0 +1,14 @@
+package example.micronaut
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+
+@Canonical
+@CompileStatic
+@JsonPropertyOrder(["id", "name", "cents"])
+class SaasSubscription {
+    Long id
+    String name
+    Integer cents
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/groovy/src/main/groovy/example/micronaut/SaasSubscriptionController.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/groovy/src/main/groovy/example/micronaut/SaasSubscriptionController.groovy
@@ -1,0 +1,19 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+
+@CompileStatic
+@Controller("/subscriptions") // <1>
+class SaasSubscriptionController {
+
+    @Get("/{id}") // <2>
+    SaasSubscription findById(@PathVariable Long id) { // <3>
+        if (id == 99L) {
+            return new SaasSubscription(99L, "Advanced", 2900)
+        }
+        null // <4>
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/groovy/src/test/groovy/example/micronaut/SaasSubscriptionControllerGetSpec.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/groovy/src/test/groovy/example/micronaut/SaasSubscriptionControllerGetSpec.groovy
@@ -1,0 +1,51 @@
+package example.micronaut
+
+import com.jayway.jsonpath.DocumentContext
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class SaasSubscriptionControllerGetSpec extends Specification {
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient
+
+    void shouldReturnASaasSubscriptionWhenDataIsSaved() {
+        when:
+        def client = httpClient.toBlocking()
+        HttpResponse<String> response = client.exchange("/subscriptions/99", String)
+
+        then:
+        response.status.code == HttpStatus.OK.code
+
+        DocumentContext documentContext = JsonPath.parse(response.body())
+        Number id = documentContext.read('$.id')
+        String name = documentContext.read('$.name')
+        Integer cents = documentContext.read('$.cents')
+
+        id == 99
+        name == "Advanced"
+        cents == 2900
+    }
+
+    void shouldNotReturnASaasSubscriptionWithAnUnknownId() {
+        given:
+        def client = httpClient.toBlocking()
+
+        when:
+        client.exchange("/subscriptions/1000", String)
+
+        then:
+        HttpClientResponseException exception = thrown()
+        exception.status.code == HttpStatus.NOT_FOUND.code
+        exception.response.body.present
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
@@ -1,0 +1,61 @@
+package example.micronaut
+
+import com.jayway.jsonpath.DocumentContext
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false) // <1>
+class SaasSubscriptionJsonSpec extends Specification {
+
+    @Inject
+    JsonMapper json
+
+    @Inject
+    ResourceLoader resourceLoader
+
+    void saasSubscriptionSerializationTest() {
+        given:
+        SaasSubscription subscription = new SaasSubscription(99L, "Professional", 4900)
+        String expected = getResourceAsString("expected.json")
+
+        when:
+        String result = json.writeValueAsString(subscription)
+        DocumentContext documentContext = JsonPath.parse(result)
+        Number id = documentContext.read('$.id')
+        String name = documentContext.read('$.name')
+        Number cents = documentContext.read('$.cents')
+
+        then:
+        result.replaceAll(/\s/, "") == expected.replaceAll(/\s/, "")
+        id == 99
+        name == "Professional"
+        cents == 4900
+    }
+
+    void saasSubscriptionDeserializationTest() {
+        given:
+        String expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+           """
+
+        expect:
+        json.readValue(expected, SaasSubscription) == new SaasSubscription(100L, "Advanced", 2900)
+        json.readValue(expected, SaasSubscription).id == 100
+        json.readValue(expected, SaasSubscription).name == "Advanced"
+        json.readValue(expected, SaasSubscription).cents == 2900
+    }
+
+    private String getResourceAsString(String resourceName) {
+        resourceLoader.getResourceAsStream(resourceName)
+                .map { stream -> stream.withCloseable { it.getText("UTF-8") } }
+                .orElse("")
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/groovy/src/test/resources/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/micronautframeworkjacksondatabind/groovy/src/test/resources/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
@@ -1,0 +1,14 @@
+package example.micronaut
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+
+@Canonical
+@CompileStatic
+@JsonPropertyOrder(["id", "name", "cents"])
+class SaasSubscription {
+    Long id
+    String name
+    Integer cents
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/groovy/src/main/groovy/example/micronaut/SaasSubscriptionController.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/groovy/src/main/groovy/example/micronaut/SaasSubscriptionController.groovy
@@ -1,0 +1,23 @@
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@CompileStatic
+@RestController // <1>
+@RequestMapping("/subscriptions") // <2>
+class SaasSubscriptionController {
+
+    @GetMapping("/{id}") // <3>
+    private ResponseEntity<SaasSubscription> findById(@PathVariable("id") Long id) { // <4>
+        if (id == 99L) {
+            SaasSubscription subscription = new SaasSubscription(99L, "Advanced", 2900)
+            return ResponseEntity.ok(subscription)
+        }
+        ResponseEntity.notFound().build()
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/groovy/src/test/groovy/example/micronaut/SaasSubscriptionControllerGetSpec.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/groovy/src/test/groovy/example/micronaut/SaasSubscriptionControllerGetSpec.groovy
@@ -1,0 +1,46 @@
+package example.micronaut
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.web.servlet.client.RestTestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // <1>
+class SaasSubscriptionControllerGetSpec {
+
+    @LocalServerPort // <2>
+    int port
+
+    RestTestClient restTestClient // <3>
+
+    @BeforeEach
+    void setUp() {
+        restTestClient = RestTestClient.bindToServer()
+                .baseUrl("http://localhost:$port")
+                .build()
+    }
+
+    @Test
+    void shouldReturnASaasSubscriptionWhenDataIsSaved() {
+        def response = restTestClient.get()
+                .uri("/subscriptions/99")
+                .exchange()
+
+        response.expectStatus().isOk()
+        def body = response.expectBody()
+        body.jsonPath('$.id').isEqualTo(99)
+        body.jsonPath('$.name').isEqualTo("Advanced")
+        body.jsonPath('$.cents').isEqualTo(2900)
+    }
+
+    @Test
+    void shouldNotReturnASaasSubscriptionWithAnUnknownId() {
+        def response = restTestClient.get()
+                .uri("/subscriptions/1000")
+                .exchange()
+
+        response.expectStatus().isNotFound()
+        response.expectBody().isEmpty()
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
@@ -1,0 +1,48 @@
+package example.micronaut
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.json.JsonTest
+import org.springframework.boot.test.json.JacksonTester
+
+import static org.assertj.core.api.Assertions.assertThat
+
+@JsonTest // <1>
+class SaasSubscriptionJsonSpec {
+
+    @Autowired // <2>
+    JacksonTester<SaasSubscription> json // <3>
+
+    @Test
+    void saasSubscriptionSerializationTest() {
+        SaasSubscription subscription = new SaasSubscription(99L, "Professional", 4900)
+
+        assertThat(json.write(subscription)).isStrictlyEqualToJson("expected.json")
+        assertThat(json.write(subscription)).hasJsonPathNumberValue("@.id")
+        assertThat(json.write(subscription)).extractingJsonPathNumberValue("@.id")
+                .isEqualTo(99)
+        assertThat(json.write(subscription)).hasJsonPathStringValue("@.name")
+        assertThat(json.write(subscription)).extractingJsonPathStringValue("@.name")
+                .isEqualTo("Professional")
+        assertThat(json.write(subscription)).hasJsonPathNumberValue("@.cents")
+        assertThat(json.write(subscription)).extractingJsonPathNumberValue("@.cents")
+                .isEqualTo(4900)
+    }
+
+    @Test
+    void saasSubscriptionDeserializationTest() {
+        String expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+           """
+
+        assertThat(json.parseObject(expected))
+                .isEqualTo(new SaasSubscription(100L, "Advanced", 2900))
+        assertThat(json.parseObject(expected).id).isEqualTo(100)
+        assertThat(json.parseObject(expected).name).isEqualTo("Advanced")
+        assertThat(json.parseObject(expected).cents).isEqualTo(2900)
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/groovy/src/test/resources/example/micronaut/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-implemeting-get/springboot/groovy/src/test/resources/example/micronaut/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}


### PR DESCRIPTION
## Summary

- Adds the Groovy variant for `building-a-rest-api-spring-boot-vs-micronaut-implemeting-get`.
- Adds Groovy source, controller tests, JSON tests, and fixtures for `springboot`, `micronautframework`, and `micronautframeworkjacksondatabind`.
- Updates guide metadata to publish `JAVA` and `GROOVY`, keeping Spring Boot Groovy on JUnit and Micronaut Groovy on Spock.

Closes #1669

## Verification

- `git diff --check origin/master...HEAD`
- `./gradlew buildingARestApiSpringBootVsMicronautImplemetingGetGenerateProjects --stacktrace`
- `./gradlew buildingARestApiSpringBootVsMicronautImplemetingGetRunTestScript --stacktrace`
- GitHub Actions: `Generate Guide Test Matrix`, `Running buildingARestApiSpringBootVsMicronautImplemetingGetBuild with Java 25`, and `license/cla` all passed.

`./gradlew buildingARestApiSpringBootVsMicronautImplemetingGetBuild --stacktrace` was previously exercised by implementation and QA; it reaches generated projects/docs/zips and then fails only in Java generated native tests because the local GraalVM installation cannot consume the configured reachability metadata repository schema. The GitHub Actions guide build for this PR passed.

## Review Threads

Copilot opened two comments about Spring Boot Groovy JUnit tests using a `Spec` suffix. Both were replied to and resolved after verifying the generated Spring Boot Groovy test XML contains passing test suites for `SaasSubscriptionControllerGetSpec` and `SaasSubscriptionJsonSpec`.

## Release Routing

- Target branch: `master`
- Type label: `type: docs`
- Recommended Micronaut organization project: `5.0.1 Release`
- Ambiguity: QA found no open `5.0.0 Release`, milestone, or RC board for this repository; `5.0.1 Release` is the earliest open public Micronaut Platform BOM release board matching this default-branch docs/source work.
- Live project association: not applied in this run because `gh` lacks the required GitHub ProjectV2 `project` OAuth scope and the Paperclip plugin-tool execute route returned `Board access required`.

## Reviewer Routing

The linked GitHub issue creator is `sdelamo`. GitHub rejected requesting `sdelamo` as reviewer because that account is also the pull request author.

## PR Assets

No external rendered asset is attached. The change is source/sample-code only; generated-project behavior is covered by the commands above and by passing GitHub Actions.

---
###### ✨ This message was AI-generated using gpt-5
