### PR TITLE
Add Groovy variant for REST API test-first guide

### DIFF
--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/building-a-rest-api-spring-boot-vs-micronaut-test-first.adoc
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/building-a-rest-api-spring-boot-vs-micronaut-test-first.adoc
@@ -12,12 +12,12 @@ This guide is the first tutorial of https://guides.micronaut.io/latest/tag-build
 
 == Record
 
-The application you will build is a REST API for Software as a Service (SaaS) subscriptions. The application serializes and deserializes the following Java record from and to JSON.
+The application you will build is a REST API for Software as a Service (SaaS) subscriptions. The application serializes and deserializes the following type from and to JSON.
 
 source:SaasSubscription[app=springboot]
 
 Micronaut supports serialization with Jackson Databind or with https://micronaut-projects.github.io/micronaut-serialization/latest/guide/[Micronaut Serialization].
-If you use Micronaut Jackson Databind, the above record will be identical in Micronaut Framework and Spring Boot.
+If you use Micronaut Jackson Databind, the above type will be identical in Micronaut Framework and Spring Boot.
 
 === Micronaut Serialization
 If you use Micronaut Serialization, you must opt the class in to serialization, which you can do by annotating it with `@Serdeable`.
@@ -27,7 +27,7 @@ callout:serdeable[]
 
 == Expected JSON
 
-We want deserialization from a JSON object into the Java record:
+We want deserialization from a JSON object into the application type:
 
 testResource:expected.json[app=micronautframeworkjacksondatabind]
 
@@ -55,8 +55,13 @@ Micronaut application context startup is fast. In your tests, you will not emplo
 
 test:SaasSubscriptionJsonTest[app=micronautframeworkjacksondatabind]
 
-callout:micronaut-test-transactional-false[]
+callout:micronaut-test-start-application-false[]
+:exclude-for-languages:groovy
 callout:junit5-method-parameters-injection[]
+:exclude-for-languages:
+:exclude-for-languages:java
+callout:field-injection[]
+:exclude-for-languages:
 
 == Conclusion
 

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/building-a-rest-api-spring-boot-vs-micronaut-test-first.adoc
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/building-a-rest-api-spring-boot-vs-micronaut-test-first.adoc
@@ -10,7 +10,7 @@ This guide compares how to test serialization in Micronaut Framework and Spring 
 
 This guide is the first tutorial of https://guides.micronaut.io/latest/tag-building_a_rest_api.html[Building a REST API] - a series of tutorials comparing how to develop a REST API with Micronaut Framework and Spring Boot.
 
-== Record
+== Domain Type
 
 The application you will build is a REST API for Software as a Service (SaaS) subscriptions. The application serializes and deserializes the following type from and to JSON.
 

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/metadata.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/metadata.json
@@ -5,21 +5,25 @@
   "tags": ["spring-boot"],
   "categories": ["Boot to Micronaut Building a REST API"],
   "publicationDate": "2024-04-24",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "buildTools": ["GRADLE"],
   "apps": [
     {
       "framework": "Spring Boot",
       "name": "springboot",
-      "features": ["spring-boot-starter-web"]
+      "features": ["spring-boot-starter-web"],
+      "invisibleFeatures": ["springboot-gradle-plugin"],
+      "testFramework": "JUNIT"
     },
     {
       "name": "micronautframeworkjacksondatabind",
-      "features": ["json-path", "assertj", "jackson-databind"]
+      "features": ["json-path", "jackson-databind"],
+      "javaFeatures": ["assertj"]
     },
     {
       "name": "micronautframeworkserde",
-      "features": ["json-path", "assertj"]
+      "features": ["json-path"],
+      "javaFeatures": ["assertj"]
     }
   ]
 }

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
@@ -1,0 +1,14 @@
+package example.micronaut
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+
+@Canonical
+@CompileStatic
+@JsonPropertyOrder(["id", "name", "cents"])
+class SaasSubscription {
+    Long id
+    String name
+    Integer cents
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
@@ -1,0 +1,61 @@
+package example.micronaut
+
+import com.jayway.jsonpath.DocumentContext
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false) // <1>
+class SaasSubscriptionJsonSpec extends Specification {
+
+    @Inject // <2>
+    JsonMapper json
+
+    @Inject
+    ResourceLoader resourceLoader
+
+    void saasSubscriptionSerializationTest() {
+        given:
+        SaasSubscription subscription = new SaasSubscription(99L, "Professional", 4900)
+        String expected = getResourceAsString("expected.json")
+
+        when:
+        String result = json.writeValueAsString(subscription)
+        DocumentContext documentContext = JsonPath.parse(result)
+        Number id = documentContext.read('$.id')
+        String name = documentContext.read('$.name')
+        Number cents = documentContext.read('$.cents')
+
+        then:
+        result.replaceAll(/\s/, "") == expected.replaceAll(/\s/, "")
+        id == 99
+        name == "Professional"
+        cents == 4900
+    }
+
+    void saasSubscriptionDeserializationTest() {
+        given:
+        String expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+           """
+
+        expect:
+        json.readValue(expected, SaasSubscription) == new SaasSubscription(100L, "Advanced", 2900)
+        json.readValue(expected, SaasSubscription).id == 100
+        json.readValue(expected, SaasSubscription).name == "Advanced"
+        json.readValue(expected, SaasSubscription).cents == 2900
+    }
+
+    private String getResourceAsString(String resourceName) {
+        resourceLoader.getResourceAsStream(resourceName)
+                .map { stream -> stream.withCloseable { it.getText("UTF-8") } }
+                .orElse("")
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/groovy/src/test/resources/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/groovy/src/test/resources/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
@@ -1,0 +1,14 @@
+package example.micronaut
+
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+import io.micronaut.serde.annotation.Serdeable
+
+@Canonical
+@CompileStatic
+@Serdeable // <1>
+class SaasSubscription {
+    Long id
+    String name
+    Integer cents
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
@@ -1,0 +1,61 @@
+package example.micronaut
+
+import com.jayway.jsonpath.DocumentContext
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false) // <1>
+class SaasSubscriptionJsonSpec extends Specification {
+
+    @Inject // <2>
+    JsonMapper json
+
+    @Inject
+    ResourceLoader resourceLoader
+
+    void saasSubscriptionSerializationTest() {
+        given:
+        SaasSubscription subscription = new SaasSubscription(99L, "Professional", 4900)
+        String expected = getResourceAsString("expected.json")
+
+        when:
+        String result = json.writeValueAsString(subscription)
+        DocumentContext documentContext = JsonPath.parse(result)
+        Number id = documentContext.read('$.id')
+        String name = documentContext.read('$.name')
+        Number cents = documentContext.read('$.cents')
+
+        then:
+        result.replaceAll(/\s/, "") == expected.replaceAll(/\s/, "")
+        id == 99
+        name == "Professional"
+        cents == 4900
+    }
+
+    void saasSubscriptionDeserializationTest() {
+        given:
+        String expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+           """
+
+        expect:
+        json.readValue(expected, SaasSubscription) == new SaasSubscription(100L, "Advanced", 2900)
+        json.readValue(expected, SaasSubscription).id == 100
+        json.readValue(expected, SaasSubscription).name == "Advanced"
+        json.readValue(expected, SaasSubscription).cents == 2900
+    }
+
+    private String getResourceAsString(String resourceName) {
+        resourceLoader.getResourceAsStream(resourceName)
+                .map { stream -> stream.withCloseable { it.getText("UTF-8") } }
+                .orElse("")
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/groovy/src/test/resources/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/groovy/src/test/resources/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/groovy/src/main/groovy/example/micronaut/SaasSubscription.groovy
@@ -1,0 +1,14 @@
+package example.micronaut
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+
+@Canonical
+@CompileStatic
+@JsonPropertyOrder(["id", "name", "cents"])
+class SaasSubscription {
+    Long id
+    String name
+    Integer cents
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/groovy/src/test/groovy/example/micronaut/SaasSubscriptionJsonSpec.groovy
@@ -1,0 +1,48 @@
+package example.micronaut
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.json.JsonTest
+import org.springframework.boot.test.json.JacksonTester
+
+import static org.assertj.core.api.Assertions.assertThat
+
+@JsonTest // <1>
+class SaasSubscriptionJsonSpec {
+
+    @Autowired // <2>
+    JacksonTester<SaasSubscription> json // <3>
+
+    @Test
+    void saasSubscriptionSerializationTest() {
+        SaasSubscription subscription = new SaasSubscription(99L, "Professional", 4900)
+
+        assertThat(json.write(subscription)).isStrictlyEqualToJson("expected.json")
+        assertThat(json.write(subscription)).hasJsonPathNumberValue("@.id")
+        assertThat(json.write(subscription)).extractingJsonPathNumberValue("@.id")
+                .isEqualTo(99)
+        assertThat(json.write(subscription)).hasJsonPathStringValue("@.name")
+        assertThat(json.write(subscription)).extractingJsonPathStringValue("@.name")
+                .isEqualTo("Professional")
+        assertThat(json.write(subscription)).hasJsonPathNumberValue("@.cents")
+        assertThat(json.write(subscription)).extractingJsonPathNumberValue("@.cents")
+                .isEqualTo(4900)
+    }
+
+    @Test
+    void saasSubscriptionDeserializationTest() {
+        String expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+           """
+
+        assertThat(json.parseObject(expected))
+                .isEqualTo(new SaasSubscription(100L, "Advanced", 2900))
+        assertThat(json.parseObject(expected).id).isEqualTo(100)
+        assertThat(json.parseObject(expected).name).isEqualTo("Advanced")
+        assertThat(json.parseObject(expected).cents).isEqualTo(2900)
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/groovy/src/test/resources/example/micronaut/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/groovy/src/test/resources/example/micronaut/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}


### PR DESCRIPTION
## Summary
- Add Groovy samples for the Spring Boot, Micronaut Jackson Databind, and Micronaut Serialization apps in the REST API test-first guide.
- Add `GROOVY` to guide metadata and keep Spring Boot/JUnit plus Micronaut/Spock generated test behavior aligned with the Java variant.
- Update guide wording and callouts so Java method-parameter injection and Groovy field injection render correctly.
- Rename the shared guide section from `Record` to `Domain Type` so the text remains accurate for Groovy classes.

## Verification
- `git diff --check origin/master...HEAD`
- `./gradlew buildingARestApiSpringBootVsMicronautTestFirstRunTestScript --rerun-tasks --stacktrace`
- Direct generated Groovy sample checks: `./gradlew clean test --stacktrace` in `springboot`, `micronautframeworkjacksondatabind`, and `micronautframeworkserde` generated Groovy projects.
- GitHub Actions: `Generate Guide Test Matrix`, `Running buildingARestApiSpringBootVsMicronautTestFirstBuild with Java 25`, and `license/cla` passed on the PR head.

## Release Metadata
- Target branch: `master`
- Release target: default-branch `5.0.0` docs/source line
- Micronaut organization project: `5.0.1 Release`
- Ambiguity: no open `5.0.0 Release` project was available, so `5.0.1 Release` is the selected earliest open Micronaut Platform BOM release board.
- Project link status: not applied by this run because GitHub rejected the Projects v2 add mutation with missing `project` token scope. The selected board is still recorded here for maintainer visibility.
- Type label: `type: docs`

## PR Assets
- None required. This changes guide source/sample code only; generated build output is not committed.

Closes #1675

---
###### ✨ This message was AI-generated using gpt-5