### PR TITLE
Add Groovy content negotiation guide sample

### DIFF
--- a/guides/micronaut-content-negotiation/groovy/src/main/groovy/example/micronaut/MessageController.groovy
+++ b/guides/micronaut-content-negotiation/groovy/src/main/groovy/example/micronaut/MessageController.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.views.ModelAndView
+
+@CompileStatic
+@Controller // <1>
+class MessageController {
+
+    @Produces(value = [MediaType.TEXT_HTML, MediaType.APPLICATION_JSON]) // <2>
+    @Get // <3>
+    HttpResponse<?> index(HttpRequest<?> request) { // <4>
+        Map<String, Object> model = [message: 'Hello World']
+        Object body = accepts(request, MediaType.TEXT_HTML_TYPE)
+                ? new ModelAndView<>('message.html', model)
+                : model
+        HttpResponse.ok(body)
+    }
+
+    private static boolean accepts(HttpRequest<?> request, MediaType mediaType) {
+        request.headers
+                .accept()
+                .any { it.name.contains(mediaType.name) }
+    }
+}

--- a/guides/micronaut-content-negotiation/groovy/src/test/groovy/example/micronaut/MessageControllerSpec.groovy
+++ b/guides/micronaut-content-negotiation/groovy/src/test/groovy/example/micronaut/MessageControllerSpec.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest // <1>
+class MessageControllerSpec extends Specification {
+
+    @Inject
+    @Client('/') // <2>
+    HttpClient httpClient
+
+    void contentNegotiation() {
+        given:
+        BlockingHttpClient client = httpClient.toBlocking()
+
+        expect:
+        '{"message":"Hello World"}' == client.retrieve(HttpRequest.GET('/')
+                .accept(MediaType.APPLICATION_JSON)) // <3>
+
+        and:
+        '''\
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<h1>Hello World</h1>
+</body>
+</html>
+''' == client.retrieve(HttpRequest.GET('/')
+                .accept(MediaType.TEXT_HTML))
+    }
+}

--- a/guides/micronaut-content-negotiation/metadata.json
+++ b/guides/micronaut-content-negotiation/metadata.json
@@ -5,7 +5,7 @@
   "tags": [],
   "categories": ["HTTP Server"],
   "publicationDate": "2023-12-10",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary

- Adds the Groovy `MessageController` sample for the content negotiation guide.
- Adds a Spock spec that verifies JSON and HTML responses.
- Updates guide metadata so the generated guide includes Java and Groovy variants.

## Verification

- `git diff --check origin/master...HEAD`
- `./gradlew micronautContentNegotiationRunTestScript --stacktrace`
- QA also verified `./gradlew micronautContentNegotiationBuild -x micronautContentNegotiationRunNativeTestScript --stacktrace`; the exact full native build path is blocked in the local environment by the recorded GraalVM reachability metadata schema mismatch, not by this branch.

## Release Targeting

Target branch: `master`.
Micronaut organization project: `5.0.1 Release`; QA noted the default branch advertises `5.0.0` but no open `5.0.0 Release` project exists.

Closes #1684

---
###### ✨ This message was AI-generated using gpt-5