### PR TITLE
Add Kotlin content negotiation guide

### DIFF
--- a/guides/micronaut-content-negotiation/kotlin/src/main/kotlin/example/micronaut/MessageController.kt
+++ b/guides/micronaut-content-negotiation/kotlin/src/main/kotlin/example/micronaut/MessageController.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.views.ModelAndView
+
+@Controller // <1>
+class MessageController {
+
+    @Produces(value = [MediaType.TEXT_HTML, MediaType.APPLICATION_JSON]) // <2>
+    @Get // <3>
+    fun index(request: HttpRequest<*>): HttpResponse<*> { // <4>
+        val model = mapOf("message" to "Hello World")
+        val body = if (accepts(request, MediaType.TEXT_HTML_TYPE)) {
+            ModelAndView("message.html", model)
+        } else {
+            model
+        }
+        return HttpResponse.ok(body)
+    }
+
+    private fun accepts(request: HttpRequest<*>, mediaType: MediaType): Boolean =
+        request.headers
+            .accept()
+            .any { it.name.contains(mediaType.name) }
+}

--- a/guides/micronaut-content-negotiation/kotlin/src/test/kotlin/example/micronaut/MessageControllerTest.kt
+++ b/guides/micronaut-content-negotiation/kotlin/src/test/kotlin/example/micronaut/MessageControllerTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+@MicronautTest // <1>
+class MessageControllerTest(@Client("/") val httpClient: HttpClient) { // <2>
+
+    @Test
+    fun contentNegotiation() {
+        val client = httpClient.toBlocking()
+
+        val expectedJson = """{"message":"Hello World"}"""
+        val json = assertDoesNotThrow<String> {
+            client.retrieve(HttpRequest.GET<Any>("/")
+                .accept(MediaType.APPLICATION_JSON)) // <3>
+        }
+        assertEquals(expectedJson, json)
+
+        val expectedHtml = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <body>
+            <h1>Hello World</h1>
+            </body>
+            </html>
+        """.trimIndent() + "\n"
+        val html = assertDoesNotThrow<String> {
+            client.retrieve(HttpRequest.GET<Any>("/")
+                .accept(MediaType.TEXT_HTML))
+        }
+        assertEquals(expectedHtml, html)
+    }
+}

--- a/guides/micronaut-content-negotiation/metadata.json
+++ b/guides/micronaut-content-negotiation/metadata.json
@@ -5,7 +5,7 @@
   "tags": [],
   "categories": ["HTTP Server"],
   "publicationDate": "2023-12-10",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
Closes #1685.

## Summary

- Add the Kotlin sample controller and test for `micronaut-content-negotiation`.
- Update the guide metadata so the generated guide supports `JAVA` and `KOTLIN`.
- Preserve the existing Java guide behavior for JSON and HTML content negotiation.

## Release Targeting

- Target branch: `master`.
- Release target: default-branch `5.0.x` guide work.
- Micronaut organization project selected by QA: `5.0.1 Release`.
- Ambiguity: the default-branch version signal is `5.0.0`, but no open public `5.0.0 Release` project is available; `5.0.1 Release` is the best-fit open Micronaut Platform BOM release board.
- Project link status: the selected project exists, but applying the live PR project item failed because the available GitHub token lacks the `project` write scope required by `addProjectV2ItemById`. No project item is currently linked.

## Verification

- `git diff --check origin/master...HEAD`
- `./gradlew micronautContentNegotiationRunTestScript --stacktrace --rerun-tasks`
- `./gradlew micronautContentNegotiationBuild --stacktrace -x micronautContentNegotiationRunNativeTestScript --rerun-tasks`

Full native-inclusive validation was also attempted with `./gradlew micronautContentNegotiationBuild --stacktrace --rerun-tasks`. It generated docs, projects, zips, and index output, then failed only in `micronautContentNegotiationRunNativeTestScript` because the local GraalVM installation does not provide the reachability-metadata schema required by the configured metadata repository. The failure reproduces in both the pre-existing Java generated project and the new Kotlin generated project.

## Reviewer Routing

The linked GitHub issue creator is `sdelamo`. I attempted to request `sdelamo` as reviewer; GitHub rejected the direct reviewer request with `Review cannot be requested from pull request author.` No issue-creator reviewer request is pending because the PR author is also `sdelamo`.

## PR Assets

No external rendered asset is required for this source-only guide variant. The rendered guide path and generated projects were verified by the focused build commands above.

---
###### ✨ This message was AI-generated using gpt-5