### PR TITLE
Add Kotlin CRaC hello world guide variant

### DIFF
--- a/guides/micronaut-crac-helloworld/kotlin/src/main/kotlin/example/micronaut/HelloWorldController.kt
+++ b/guides/micronaut-crac-helloworld/kotlin/src/main/kotlin/example/micronaut/HelloWorldController.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Controller // <1>
+class HelloWorldController {
+
+    @Get // <2>
+    fun index(): Map<String, String> = mapOf("message" to "Hello World")
+}

--- a/guides/micronaut-crac-helloworld/kotlin/src/main/kotlin/example/micronaut/LoggingResource.kt
+++ b/guides/micronaut-crac-helloworld/kotlin/src/main/kotlin/example/micronaut/LoggingResource.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.crac.OrderedResource
+import jakarta.inject.Singleton
+import org.crac.Context
+import org.crac.Resource
+import org.slf4j.LoggerFactory
+
+@Singleton // <1>
+class LoggingResource : OrderedResource {
+
+    override fun beforeCheckpoint(context: Context<out Resource>?) {
+        LOG.info("before checkpoint")
+    }
+
+    override fun afterRestore(context: Context<out Resource>?) {
+        LOG.info("after restore")
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(LoggingResource::class.java)
+    }
+}

--- a/guides/micronaut-crac-helloworld/kotlin/src/main/kotlin/example/micronaut/TimeController.kt
+++ b/guides/micronaut-crac-helloworld/kotlin/src/main/kotlin/example/micronaut/TimeController.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.runtime.context.scope.Refreshable
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Refreshable // <1>
+@Controller("/time") // <2>
+class TimeController {
+
+    private val time = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
+
+    @Get // <3>
+    fun index(): Map<String, Any> = mapOf("time" to time)
+}

--- a/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/CheckpointTestUtils.kt
+++ b/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/CheckpointTestUtils.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.crac.test.CheckpointSimulator
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+
+object CheckpointTestUtils {
+
+    fun test(testScenario: (BlockingHttpClient) -> Unit) {
+        ApplicationContext.run(EmbeddedServer::class.java).use { server ->
+            val checkpointSimulator = server.applicationContext.getBean(CheckpointSimulator::class.java)
+            testApp(server, testScenario)
+
+            checkpointSimulator.runBeforeCheckpoint()
+            server.stop()
+            checkpointSimulator.runAfterRestore()
+            server.start()
+            testApp(server, testScenario)
+        }
+    }
+
+    fun <T> testApp(embeddedServer: EmbeddedServer, clientConsumer: (BlockingHttpClient) -> T): T =
+        embeddedServer.applicationContext.createBean(HttpClient::class.java, embeddedServer.url).use { httpClient ->
+            clientConsumer(httpClient.toBlocking())
+        }
+}

--- a/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/Clock.kt
+++ b/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/Clock.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import jakarta.inject.Singleton
+import java.time.LocalDateTime
+
+@Singleton
+class Clock {
+
+    val now: LocalDateTime = LocalDateTime.now()
+}

--- a/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/EagerlyInitializedTest.kt
+++ b/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/EagerlyInitializedTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class EagerlyInitializedTest {
+
+    @Test
+    fun singletonsAreEagerlyInitialized() {
+        ApplicationContext.run().use { ctx ->
+            Thread.sleep(5_000)
+            assertTrue(ctx.getBean(Clock::class.java).now.isBefore(LocalDateTime.now().minusSeconds(3)))
+        }
+    }
+}

--- a/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/HelloWorldControllerTest.kt
+++ b/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/HelloWorldControllerTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.BlockingHttpClient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HelloWorldControllerTest {
+
+    @Test
+    fun emulateCheckpoint() {
+        CheckpointTestUtils.test(::testHelloWorld)
+    }
+
+    private fun testHelloWorld(client: BlockingHttpClient) {
+        val response = client.exchange(
+            HttpRequest.GET<Any>("/"),
+            Argument.mapOf(String::class.java, String::class.java)
+        )
+        assertEquals(HttpStatus.OK, response.status)
+        val bodyOptional = response.body
+        assertTrue(bodyOptional.isPresent)
+        assertEquals(mapOf("message" to "Hello World"), bodyOptional.get())
+    }
+}

--- a/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/InfoEndpointTest.kt
+++ b/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/InfoEndpointTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.type.Argument
+import io.micronaut.core.util.StringUtils
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+@Property(name = "endpoints.info.enabled", value = StringUtils.TRUE)
+@Property(name = "endpoints.info.sensitive", value = StringUtils.FALSE)
+@MicronautTest
+class InfoEndpointTest {
+
+    @Test
+    fun cracInformationIsExposedInTheInfoEndpointExposed(@Client("/") client: HttpClient) {
+        val json = client.toBlocking().retrieve(
+            HttpRequest.GET<Any>("/info"),
+            Argument.mapOf(
+                Argument.of(String::class.java),
+                Argument.mapOf(String::class.java, Int::class.javaObjectType)
+            )
+        )
+        assertNotNull(json)
+        assertEquals(mapOf("crac" to mapOf("restore-time" to -1, "uptime-since-restore" to -1)), json)
+    }
+}

--- a/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/TimeControllerTest.kt
+++ b/guides/micronaut-crac-helloworld/kotlin/src/test/kotlin/example/micronaut/TimeControllerTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.crac.test.CheckpointSimulator
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TimeControllerTest {
+
+    @Test
+    fun emulateCheckpoint() {
+        ApplicationContext.run(EmbeddedServer::class.java).use { server ->
+            val checkpointSimulator = server.applicationContext.getBean(CheckpointSimulator::class.java)
+            val time = CheckpointTestUtils.testApp(server, ::testTime)
+            assertEquals(time, CheckpointTestUtils.testApp(server, ::testTime))
+            checkpointSimulator.runBeforeCheckpoint()
+            server.stop()
+            checkpointSimulator.runAfterRestore()
+            server.start()
+            assertNotEquals(time, CheckpointTestUtils.testApp(server, ::testTime))
+        }
+    }
+
+    private fun testTime(client: BlockingHttpClient): String {
+        val response = client.exchange(
+            HttpRequest.GET<Any>("/time"),
+            Argument.mapOf(String::class.java, String::class.java)
+        )
+        assertEquals(HttpStatus.OK, response.status)
+        val bodyOptional = response.body
+        assertTrue(bodyOptional.isPresent)
+        val body = bodyOptional.get()
+        assertEquals(1, body.keys.size)
+        assertTrue(body.containsKey("time"))
+        return body["time"]!!
+    }
+}

--- a/guides/micronaut-crac-helloworld/metadata.json
+++ b/guides/micronaut-crac-helloworld/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["endpoint-info"],
   "categories": ["Coordinated Restore at Checkpoint"],
   "publicationDate": "2023-11-22",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary

- Add the Kotlin sample implementation for `guides/micronaut-crac-helloworld`.
- Update guide metadata to publish the new Kotlin variant alongside Java.
- Preserve the Java guide behavior for CRaC lifecycle logging, `/`, `/time`, `/info` test coverage, checkpoint simulation, and eager singleton initialization.

## Verification

- `git diff --check origin/master...HEAD`
- `./gradlew micronautCracHelloworldRunTestScript --stacktrace --rerun-tasks`

QA also reran `./gradlew micronautCracHelloworldBuild --stacktrace`; it generated the guide/projects/zips, then failed only in `:micronautCracHelloworldRunNativeTestScript` at native-image compile because the local GraalVM installation does not provide the reachability-metadata schema expected by the configured metadata repository. That local toolchain failure affected both the existing Java generated project and the new Kotlin generated project. GitHub CI for `Running micronautCracHelloworldBuild with Java 25` passed on this PR.

## Release Target

Target branch: `master`. Release target: 5.0.x guide line. Selected Micronaut organization project: `5.0.1 Release`.

Ambiguity note: repository version files signal `5.0.0`, but the visible `5.0.0 Release` organization project is closed; `5.0.1 Release` is the selected open project for this default-branch guide update.

## Handoff Notes

- Reviewer routing: the linked GitHub issue creator/reporter is `sdelamo`; GitHub rejected the reviewer request with `Review cannot be requested from pull request author. (HTTP 422)` because this PR was created by `sdelamo`.
- Project linkage: the selected organization project is `5.0.1 Release`, but the live PR project link could not be applied. GitHub rejected `addProjectV2ItemById` because the active `GITHUB_TOKEN` lacks the `project` scope; the Paperclip GitHub plugin tool namespace was not exposed in this Codex runtime, so there was no alternate project-linking path available.

Closes #1687.

---
###### ✨ This message was AI-generated using gpt-5