### PR TITLE
Add Kotlin variant for EclipseStore persistence guide

### DIFF
--- a/guides/micronaut-eclipsestore-persitence/kotlin/src/test/kotlin/example/micronaut/FruitValidationControllerTest.kt
+++ b/guides/micronaut-eclipsestore-persitence/kotlin/src/test/kotlin/example/micronaut/FruitValidationControllerTest.kt
@@ -25,11 +25,15 @@ import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
 @MicronautTest // <1>
-class FruitValidationControllerTest(
-    @Inject @Client("/") val httpClient: HttpClient // <2>
-) : BaseTest() {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FruitValidationControllerTest : BaseTest() {
+
+    @Inject
+    @field:Client("/")
+    lateinit var httpClient: HttpClient // <2>
 
     @Test
     fun fruitIsValidated() {

--- a/guides/micronaut-eclipsestore-persitence/metadata.json
+++ b/guides/micronaut-eclipsestore-persitence/metadata.json
@@ -6,7 +6,7 @@
   "categories": ["Data Access"],
   "publicationDate": "2023-11-22",
   "buildTools": ["GRADLE"],
-  "languages": ["JAVA", "GROOVY"],
+  "languages": ["JAVA", "GROOVY", "KOTLIN"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary
- Adds `KOTLIN` to the EclipseStore persistence guide language list so the existing Kotlin sample is generated and advertised.
- Aligns the Kotlin validation controller test with the guide's `BaseTest`/`TestPropertyProvider` lifecycle by using per-class test instances and field-injected HTTP client wiring.

## Release Target
- Target branch: `master`.
- Type label: `type: docs`.
- Micronaut organization project target: `5.0.1 Release` (#146).
- Live project link status: not applied. `gh project item-add 146 --owner micronaut-projects --url ...` returned `unknown owner type`; direct GraphQL `addProjectV2ItemById` was rejected with `INSUFFICIENT_SCOPES` because the token has `read:project` but the mutation requires `project`.
- Ambiguity note: `micronaut-guides` has no stable GitHub release/tag history and guide publication is not consumed by the Micronaut Platform BOM in the same way as a library module. The selected board is the best fit from `version.txt` and open Micronaut Platform release boards.

## Reviewer Routing
- Issue creator/reporter: `sdelamo`.
- Reviewer request status: not applied. GitHub rejected the request with `Review cannot be requested from pull request author.` The authenticated PR author is also `sdelamo`.

## Verification
- `git diff --check --cached -- guides/micronaut-eclipsestore-persitence/metadata.json guides/micronaut-eclipsestore-persitence/kotlin/src/test/kotlin/example/micronaut/FruitValidationControllerTest.kt`
- `./gradlew micronautEclipsestorePersitenceRunTestScript --stacktrace`
- `./gradlew micronautEclipsestorePersitenceBuild -x micronautEclipsestorePersitenceRunNativeTestScript --stacktrace`
- Confirmed generated Kotlin guide output exists under `build/dist/micronaut-eclipsestore-persitence-gradle-kotlin.html` and `build/dist/micronaut-eclipsestore-persitence-gradle-kotlin.zip`.

Closes #1699

---
###### ✨ This message was AI-generated using gpt-5