### PR TITLE
Add Kotlin variant for many-to-many Oracle guide

### DIFF
--- a/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/Role.kt
+++ b/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/Role.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import jakarta.validation.constraints.NotBlank
+
+@MappedEntity // <1>
+data class Role(
+    @field:Id // <2>
+    @field:GeneratedValue // <3>
+    val id: Long? = null,
+
+    @field:NotBlank // <4>
+    val authority: String
+)

--- a/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/User.kt
+++ b/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/User.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.annotation.Introspected
+import jakarta.validation.constraints.NotBlank
+
+@Introspected // <1>
+data class User(
+    @field:NotBlank
+    val id: Long,
+
+    @field:NotBlank
+    val username: String,
+
+    val authorities: List<String>?
+)

--- a/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/User.kt
+++ b/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/User.kt
@@ -17,10 +17,11 @@ package example.micronaut
 
 import io.micronaut.core.annotation.Introspected
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
 @Introspected // <1>
 data class User(
-    @field:NotBlank
+    @field:NotNull
     val id: Long,
 
     @field:NotBlank

--- a/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/UserEntity.kt
+++ b/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/UserEntity.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import jakarta.validation.constraints.NotBlank
+
+@MappedEntity("users") // <1>
+data class UserEntity(
+    @field:Id // <2>
+    @field:GeneratedValue // <3>
+    val id: Long? = null,
+
+    @field:NotBlank // <4>
+    val username: String
+)

--- a/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/UserRole.kt
+++ b/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/UserRole.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.EmbeddedId
+import io.micronaut.data.annotation.MappedEntity
+
+@MappedEntity // <1>
+data class UserRole(
+    @field:EmbeddedId // <2>
+    val id: UserRoleId
+) {
+    constructor(user: UserEntity, role: Role) : this(UserRoleId(user, role))
+}

--- a/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/UserRoleId.kt
+++ b/guides/micronaut-data-many-to-many-base/kotlin/src/main/kotlin/example/micronaut/UserRoleId.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.Embeddable
+import io.micronaut.data.annotation.Relation
+
+@Embeddable // <1>
+data class UserRoleId(
+    @field:Relation(value = Relation.Kind.MANY_TO_ONE) // <2>
+    val user: UserEntity,
+
+    @field:Relation(value = Relation.Kind.MANY_TO_ONE) // <2>
+    val role: Role
+)

--- a/guides/micronaut-data-many-to-many-base/kotlin/src/main/resources/db/liquibase-changelog.xml
+++ b/guides/micronaut-data-many-to-many-base/kotlin/src/main/resources/db/liquibase-changelog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <include file="changelog/01-schema.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/guides/micronaut-data-many-to-many-base/kotlin/src/test/kotlin/example/micronaut/ManyToManyTest.kt
+++ b/guides/micronaut-data-many-to-many-base/kotlin/src/test/kotlin/example/micronaut/ManyToManyTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest

--- a/guides/micronaut-data-many-to-many-base/kotlin/src/test/kotlin/example/micronaut/ManyToManyTest.kt
+++ b/guides/micronaut-data-many-to-many-base/kotlin/src/test/kotlin/example/micronaut/ManyToManyTest.kt
@@ -1,0 +1,57 @@
+package example.micronaut
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+@MicronautTest(startApplication = false) // <1>
+class ManyToManyTest {
+
+    @Test
+    fun testManyToManyPersistence(
+        roleRepo: RoleJdbcRepository,
+        userRepo: UserJdbcRepository,
+        userRoleRepo: UserRoleJdbcRepository
+    ) {
+        val roleUser = roleRepo.save(ROLE_USER)
+        val roleAdmin = roleRepo.save(ROLE_ADMIN)
+
+        assertFalse(userRepo.findByUsername(U_SERGIO).isPresent)
+        val sergio = userRepo.save(U_SERGIO)
+        assertUser(userRepo.findByUsername(U_SERGIO).orElse(null), U_SERGIO, null)
+        userRoleRepo.save(UserRole(sergio, roleUser))
+        userRoleRepo.save(UserRole(sergio, roleAdmin))
+        assertUser(userRepo.findByUsername(U_SERGIO).orElse(null), U_SERGIO, listOf(ROLE_ADMIN, ROLE_USER))
+
+        val tim = userRepo.save(U_TIM)
+        userRoleRepo.save(UserRole(tim, roleUser))
+        assertUser(userRepo.findByUsername(U_TIM).orElse(null), U_TIM, listOf(ROLE_USER))
+
+        userRoleRepo.delete(UserRole(tim, roleUser))
+        userRoleRepo.delete(UserRole(sergio, roleUser))
+        userRoleRepo.delete(UserRole(sergio, roleAdmin))
+
+        userRepo.delete(sergio)
+        userRepo.delete(tim)
+
+        roleRepo.deleteByAuthority(ROLE_ADMIN)
+        roleRepo.deleteByAuthority(ROLE_USER)
+    }
+
+    private fun assertUser(user: User?, expectedUsername: String, expectedAuthorities: List<String>?) {
+        assertNotNull(user)
+        val actual = user!!
+        assertNotNull(actual.id)
+        assertEquals(expectedUsername, actual.username)
+        assertEquals(expectedAuthorities, actual.authorities)
+    }
+
+    private companion object {
+        const val ROLE_USER = "ROLE_USER"
+        const val ROLE_ADMIN = "ROLE_ADMIN"
+        const val U_SERGIO = "sergio"
+        const val U_TIM = "tim"
+    }
+}

--- a/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/kotlin/example/micronaut/Role.kt
+++ b/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/kotlin/example/micronaut/Role.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import jakarta.validation.constraints.NotBlank
+
+@MappedEntity // <1>
+data class Role(
+    @field:Id // <2>
+    @field:GeneratedValue(GeneratedValue.Type.SEQUENCE) // <3>
+    val id: Long? = null,
+
+    @field:NotBlank // <4>
+    val authority: String
+)

--- a/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/kotlin/example/micronaut/RoleJdbcRepository.kt
+++ b/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/kotlin/example/micronaut/RoleJdbcRepository.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+import java.util.Optional
+
+@JdbcRepository(dialect = Dialect.ORACLE) // <1>
+interface RoleJdbcRepository : CrudRepository<Role, Long> { // <2>
+    fun save(authority: String): Role
+
+    fun findByAuthority(authority: String): Optional<Role>
+
+    fun deleteByAuthority(authority: String)
+}

--- a/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/kotlin/example/micronaut/UserEntity.kt
+++ b/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/kotlin/example/micronaut/UserEntity.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import jakarta.validation.constraints.NotBlank
+
+@MappedEntity("users") // <1>
+data class UserEntity(
+    @field:Id // <2>
+    @field:GeneratedValue(GeneratedValue.Type.SEQUENCE) // <3>
+    val id: Long? = null,
+
+    @field:NotBlank // <4>
+    val username: String
+)

--- a/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/kotlin/example/micronaut/UserJdbcRepository.kt
+++ b/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/kotlin/example/micronaut/UserJdbcRepository.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.Query
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+import java.util.Optional
+
+@JdbcRepository(dialect = Dialect.ORACLE) // <1>
+interface UserJdbcRepository : CrudRepository<UserEntity, Long> { // <2>
+    fun save(username: String): UserEntity
+
+    // <3>
+    @Query(
+        value = """
+            SELECT
+                u.id,
+                u.username,
+                LISTAGG(r.authority, ',') WITHIN GROUP (ORDER BY r.authority) AS authorities
+            FROM users u
+            LEFT JOIN user_role ur ON ur.user_id = u.id
+            LEFT JOIN role r ON r.id = ur.role_id
+            WHERE u.username = :username
+            GROUP BY u.id, u.username
+            """
+    )
+    fun findByUsername(username: String): Optional<User>
+}

--- a/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/kotlin/example/micronaut/UserRoleJdbcRepository.kt
+++ b/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/kotlin/example/micronaut/UserRoleJdbcRepository.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+
+@JdbcRepository(dialect = Dialect.ORACLE) // <1>
+interface UserRoleJdbcRepository : CrudRepository<UserRole, UserRoleId> { // <2>
+}

--- a/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/resources/application.properties
+++ b/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+micronaut.application.name=micronautguide
+#tag::liquibase[]
+liquibase.datasources.default.change-log=classpath\:db/liquibase-changelog.xml
+#end::liquibase[]
+#tag::datasource[]
+datasources.default.schema-generate=NONE
+# <1>
+datasources.default.driver-class-name=oracle.jdbc.OracleDriver
+# <2>
+datasources.default.db-type=oracle
+# <3>
+datasources.default.dialect=ORACLE
+#end::datasource[]

--- a/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/resources/db/changelog/01-schema.xml
+++ b/guides/micronaut-data-many-to-many-oracle/kotlin/src/main/resources/db/changelog/01-schema.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="01" author="username">
+      <createSequence sequenceName="users_seq" startValue="1" incrementBy="1"/>
+      <createSequence sequenceName="role_seq" startValue="1" incrementBy="1"/>
+
+      <createTable tableName="users">
+          <column name="id" type="BIGINT" autoIncrement="true">
+              <constraints primaryKey="true" primaryKeyName="pk_user" nullable="false"/>
+          </column>
+          <column name="username" type="VARCHAR(255)">
+              <constraints nullable="false" unique="true" uniqueConstraintName="uk_user_username"/>
+          </column>
+      </createTable>
+
+      <createTable tableName="role">
+          <column name="id" type="BIGINT" autoIncrement="true">
+              <constraints primaryKey="true" primaryKeyName="pk_role" nullable="false"/>
+          </column>
+          <column name="authority" type="VARCHAR(255)">
+              <constraints nullable="false" unique="true" uniqueConstraintName="uk_role_authority"/>
+          </column>
+      </createTable>
+
+      <createTable tableName="user_role">
+          <column name="user_id" type="BIGINT">
+              <constraints nullable="false"/>
+          </column>
+          <column name="role_id" type="BIGINT">
+              <constraints nullable="false"/>
+          </column>
+      </createTable>
+
+      <addPrimaryKey tableName="user_role" constraintName="pk_user_role" columnNames="user_id, role_id"/>
+
+      <addForeignKeyConstraint
+              baseTableName="user_role"
+              baseColumnNames="user_id"
+              constraintName="fk_user_role_user"
+              referencedTableName="users"
+              referencedColumnNames="id"
+              onDelete="CASCADE"/>
+
+      <addForeignKeyConstraint
+              baseTableName="user_role"
+              baseColumnNames="role_id"
+              constraintName="fk_user_role_role"
+              referencedTableName="role"
+              referencedColumnNames="id"
+              onDelete="CASCADE"/>
+  </changeSet>
+</databaseChangeLog>

--- a/guides/micronaut-data-many-to-many-oracle/metadata.json
+++ b/guides/micronaut-data-many-to-many-oracle/metadata.json
@@ -5,7 +5,7 @@
   "authors": ["Sergio del Amo"],
   "tags": [],
   "categories": ["Database Modeling"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "publicationDate": "2025-11-12",
   "apps": [
     {


### PR DESCRIPTION
## Summary
- Add the Kotlin sample implementation for the shared many-to-many base guide code.
- Add Oracle-specific Kotlin entities, JDBC repositories, datasource config, and Liquibase changelog resources.
- Add `KOTLIN` to the Oracle guide metadata so the Kotlin guide output is generated.
- Address review feedback by adding the missing Kotlin test license header and using `@NotNull` for the numeric `User.id` projection field.

Closes #1692

## Release Targeting
- Target branch: `master`.
- Release signal: `version.txt` is `5.0.0` on the target branch.
- Selected Micronaut organization project: `5.0.1 Release` (#146).
- Ambiguity note: the project selection is based on the default-branch `version.txt` signal because this repository has no stable release metadata/tag to compare.
- Project-link status: `5.0.1 Release` exists, but the authenticated GitHub token lacks the `project` scope required by `addProjectV2ItemById`, so no live project association could be applied in this run.

## Validation
- `git diff --check origin/master...HEAD` passed.
- `docker info` passed.
- `./gradlew micronautDataManyToManyOracleRunTestScript --stacktrace --rerun-tasks` passed for generated Gradle Java, Gradle Kotlin, and Maven Java Oracle tests after the review fixes.
- `./gradlew micronautDataManyToManyOracleBuild --stacktrace` failed in generated Java and Kotlin native-test compile before native image creation because the local GraalVM/native-build-tools reachability metadata schema is incompatible; the same failure occurs on the pre-existing Java generated project path as well as the new Kotlin generated project path.

## PR Assets
- Rendered docs were verified locally: the Kotlin read link appears in `build/dist/micronaut-data-many-to-many-oracle.html` and related tag pages. No binary PR asset is required for this sample-code/docs change.

---
###### ✨ This message was AI-generated using gpt-5