### PR TITLE
Add Groovy version for micronaut-data-one-to-many

### DIFF
--- a/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/ContactComplete.groovy
+++ b/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/ContactComplete.groovy
@@ -1,0 +1,24 @@
+package example.micronaut
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.TupleConstructor
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+
+@EqualsAndHashCode
+@TupleConstructor
+@Introspected // <1>
+class ContactComplete {
+    @NonNull
+    Long id
+
+    @Nullable
+    String firstName
+
+    @Nullable
+    String lastName
+
+    @Nullable
+    Set<String> phones
+}

--- a/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/ContactEntity.groovy
+++ b/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/ContactEntity.groovy
@@ -1,0 +1,29 @@
+package example.micronaut
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.TupleConstructor
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.Relation
+
+@EqualsAndHashCode
+@TupleConstructor
+@MappedEntity("contact") // <1>
+class ContactEntity {
+    @Id // <2>
+    @GeneratedValue // <3>
+    @Nullable // <4>
+    Long id
+
+    @Nullable
+    String firstName
+
+    @Nullable
+    String lastName
+
+    @Nullable
+    @Relation(value = Relation.Kind.ONE_TO_MANY, mappedBy = "contact") // <5>
+    List<PhoneEntity> phones
+}

--- a/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/ContactPreview.groovy
+++ b/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/ContactPreview.groovy
@@ -1,0 +1,21 @@
+package example.micronaut
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.TupleConstructor
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+
+@EqualsAndHashCode
+@TupleConstructor
+@Introspected // <1>
+class ContactPreview {
+    @NonNull
+    Long id
+
+    @Nullable
+    String firstName
+
+    @Nullable
+    String lastName
+}

--- a/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/ContactRepository.groovy
+++ b/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/ContactRepository.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+
+@JdbcRepository(dialect = Dialect.H2) // <1>
+interface ContactRepository extends CrudRepository<ContactEntity, Long> { // <2>
+    @Join(value = "phones", type = Join.Type.LEFT_FETCH) // <3>
+    Optional<ContactEntity> getById(@NonNull Long id)
+
+    @Query("select id, first_name, last_name from contact where id = :id") // <4>
+    Optional<ContactPreview> findPreviewById(@NonNull Long id)
+
+    @Query('''
+select c.id, c.first_name, c.last_name, group_concat(p.phone) as phones
+ from contact c
+ left outer join phone p on c.id = p.contact_id
+ where c.id = :id
+ group by c.id''') // <5>
+    Optional<ContactComplete> findCompleteById(@NonNull Long id)
+}

--- a/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/PhoneEntity.groovy
+++ b/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/PhoneEntity.groovy
@@ -1,0 +1,27 @@
+package example.micronaut
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.TupleConstructor
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.Relation
+
+@EqualsAndHashCode
+@TupleConstructor
+@MappedEntity("phone") // <1>
+class PhoneEntity {
+    @Id // <2>
+    @GeneratedValue // <3>
+    @Nullable // <4>
+    Long id
+
+    @NonNull
+    String phone
+
+    @Nullable
+    @Relation(value = Relation.Kind.MANY_TO_ONE) // <5>
+    ContactEntity contact
+}

--- a/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/PhoneRepository.groovy
+++ b/guides/micronaut-data-one-to-many/groovy/src/main/groovy/example/micronaut/PhoneRepository.groovy
@@ -1,0 +1,11 @@
+package example.micronaut
+
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+
+@JdbcRepository(dialect = Dialect.H2) // <1>
+interface PhoneRepository extends CrudRepository<PhoneEntity, Long> { // <2>
+    void deleteByContact(@NonNull ContactEntity contact)
+}

--- a/guides/micronaut-data-one-to-many/groovy/src/test/groovy/example/micronaut/ContactRepositorySpec.groovy
+++ b/guides/micronaut-data-one-to-many/groovy/src/test/groovy/example/micronaut/ContactRepositorySpec.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false, transactional = false) // <1>
+class ContactRepositorySpec extends Specification {
+
+    @Inject
+    ContactRepository contactRepository // <2>
+
+    @Inject
+    PhoneRepository phoneRepository // <3>
+
+    void 'test associations querying'() {
+        given:
+        String firstName = 'Sergio'
+        String lastName = 'Sergio'
+        long contactCount = contactRepository.count()
+
+        when:
+        ContactEntity e = contactRepository.save(new ContactEntity(null, firstName, lastName, null))
+
+        then:
+        contactRepository.count() == 1 + contactCount
+
+        when:
+        Optional<ContactPreview> preview = contactRepository.findPreviewById(e.id)
+
+        then:
+        preview.present
+        preview.get() == new ContactPreview(e.id, firstName, lastName)
+
+        when: 'query with @Join'
+        Optional<ContactEntity> contactEntity = contactRepository.getById(e.id)
+
+        then:
+        contactEntity.present
+        contactEntity.get() == new ContactEntity(contactEntity.get().id, firstName, lastName, [])
+
+        when:
+        Optional<ContactComplete> complete = contactRepository.findCompleteById(e.id)
+
+        then:
+        complete.present
+        complete.get() == new ContactComplete(e.id, firstName, lastName, null)
+
+        when:
+        String americanPhone = '+14155552671'
+        String ukPhone = '+442071838750'
+        long phoneCount = phoneRepository.count()
+        ContactEntity contactReference = new ContactEntity(e.id, null, null, null)
+        PhoneEntity usPhoneEntity = phoneRepository.save(new PhoneEntity(null, americanPhone, contactReference))
+        PhoneEntity ukPhoneEntity = phoneRepository.save(new PhoneEntity(null, ukPhone, contactReference))
+
+        then:
+        phoneRepository.count() == 2 + phoneCount
+
+        when: 'projection without join with @Query'
+        preview = contactRepository.findPreviewById(e.id)
+
+        then:
+        preview.present
+        preview.get() == new ContactPreview(e.id, firstName, lastName)
+
+        when: 'findById without @Join'
+        contactEntity = contactRepository.findById(e.id)
+
+        then:
+        contactEntity.present
+        contactEntity.get() == new ContactEntity(contactEntity.get().id, firstName, lastName, null)
+
+        when: 'query with @Join'
+        contactEntity = contactRepository.getById(e.id)
+
+        then:
+        contactEntity.present
+        contactEntity.get() == new ContactEntity(contactEntity.get().id,
+                firstName,
+                lastName,
+                [
+                        new PhoneEntity(usPhoneEntity.id, usPhoneEntity.phone, new ContactEntity(e.id, e.firstName, e.lastName, [])),
+                        new PhoneEntity(ukPhoneEntity.id, ukPhoneEntity.phone, new ContactEntity(e.id, e.firstName, e.lastName, []))
+                ])
+
+        when: 'projection with join with @Query'
+        complete = contactRepository.findCompleteById(e.id)
+
+        then:
+        complete.present
+        complete.get() == new ContactComplete(e.id, firstName, lastName, [americanPhone, ukPhone] as Set)
+
+        cleanup:
+        phoneRepository.deleteByContact(contactReference)
+        contactRepository.deleteById(e.id)
+        assert phoneRepository.count() == phoneCount
+        assert contactRepository.count() == contactCount
+    }
+}

--- a/guides/micronaut-data-one-to-many/metadata.json
+++ b/guides/micronaut-data-one-to-many/metadata.json
@@ -4,7 +4,7 @@
   "authors": ["Sergio del Amo"],
   "tags": [],
   "categories": ["Database Modeling"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "publicationDate": "2024-10-13",
   "apps": [
     {

--- a/guides/micronaut-data-one-to-many/micronaut-data-one-to-many.adoc
+++ b/guides/micronaut-data-one-to-many/micronaut-data-one-to-many.adoc
@@ -56,12 +56,12 @@ callout:relation[]
 
 == Projections
 
-Create one Java record to project a complete view, phones included, of the contact:
+Create one projection to show a complete view, phones included, of the contact:
 
 source:ContactComplete[]
 callout:introspected[]
 
-Create one Java record to preview a contact, no phones:
+Create one projection to preview a contact, no phones:
 
 source:ContactPreview[]
 callout:introspected[]


### PR DESCRIPTION
## Summary
- Adds the Groovy sample implementation for `guides/micronaut-data-one-to-many`.
- Enables `GROOVY` in the guide metadata and keeps this PR scoped to the Groovy issue.
- Makes the projection section language-neutral so it renders correctly for Java and Groovy.

## Verification
- `git diff --cached --check -- guides/micronaut-data-one-to-many` passed before commit.
- `./gradlew micronautDataOneToManyRunTestScript --stacktrace` passed.
- `./gradlew micronautDataOneToManyBuild -x micronautDataOneToManyRunNativeTestScript --stacktrace` passed.
- `./gradlew micronautDataOneToManyBuild --stacktrace` was attempted and failed only in the existing Java native-test path because the local GraalVM installation does not provide the reachability metadata schema required by the configured metadata repository.

## PR Assets
No images, PDFs, screenshots, or generated binary artifacts changed, so there is no PR-visible asset upload for this docs/sample-code change.

## Release Targeting
Target branch: `master`.

Micronaut Platform organization project selected during QA intake: `5.0.1 Release` (#146). Ambiguity preserved: `micronaut-guides` has no stable repo-local GitHub release and `origin/master` still reports `5.0.0`, while Micronaut Platform `5.0.0` is already GA; `5.0.1 Release` is the earliest open Platform BOM project expected to consume this docs/sample-code change.

Closes #1693

---
###### ✨ This message was AI-generated using gpt-5
