### PR TITLE
Add Kotlin version for Spring Boot bean factory guide

### DIFF
--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/metadata.json
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["spring-boot"],
   "categories": ["Spring Boot"],
   "publicationDate": "2022-09-13",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "framework": "Spring Boot",

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/kotlin/src/main/kotlin/example/micronaut/Greeter.kt
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/kotlin/src/main/kotlin/example/micronaut/Greeter.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+interface Greeter {
+    fun greet(): String
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/kotlin/src/main/kotlin/example/micronaut/GreeterFactory.kt
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/kotlin/src/main/kotlin/example/micronaut/GreeterFactory.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+
+@Factory // <1>
+class GreeterFactory {
+
+    @Bean
+    fun helloGreeter(): Greeter = HelloGreeter()
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/kotlin/src/main/kotlin/example/micronaut/HelloGreeter.kt
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/kotlin/src/main/kotlin/example/micronaut/HelloGreeter.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+class HelloGreeter : Greeter {
+    override fun greet(): String = "Hello"
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/kotlin/src/test/kotlin/example/micronaut/GreeterTest.kt
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/kotlin/src/test/kotlin/example/micronaut/GreeterTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+@MicronautTest // <1>
+class GreeterTest {
+
+    @Inject // <2>
+    lateinit var greeter: Greeter
+
+    @Test
+    fun helloGreeterIsInjectedAsBeanOfTypeGreeter() {
+        assertNotNull(greeter)
+        assertEquals("Hello", greeter.greet())
+    }
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/kotlin/src/main/kotlin/example/micronaut/Greeter.kt
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/kotlin/src/main/kotlin/example/micronaut/Greeter.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+interface Greeter {
+    fun greet(): String
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/kotlin/src/main/kotlin/example/micronaut/GreeterFactory.kt
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/kotlin/src/main/kotlin/example/micronaut/GreeterFactory.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration // <1>
+class GreeterFactory {
+
+    @Bean
+    fun helloGreeter(): Greeter = HelloGreeter()
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/kotlin/src/main/kotlin/example/micronaut/HelloGreeter.kt
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/kotlin/src/main/kotlin/example/micronaut/HelloGreeter.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+class HelloGreeter : Greeter {
+    override fun greet(): String = "Hello"
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/kotlin/src/test/kotlin/example/micronaut/GreeterTest.kt
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/kotlin/src/test/kotlin/example/micronaut/GreeterTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest // <1>
+class GreeterTest {
+
+    @Autowired // <2>
+    private lateinit var greeter: Greeter
+
+    @Test
+    fun helloGreeterIsInjectedAsBeanOfTypeGreeter() {
+        assertNotNull(greeter)
+        assertEquals("Hello", greeter.greet())
+    }
+}


### PR DESCRIPTION
## Summary
- Add Kotlin sample source and tests for the Spring Boot application in the `@Configuration` / `@Bean` guide.
- Add Kotlin sample source and tests for the Micronaut application using `@Factory` / `@Bean`.
- Enable `KOTLIN` in the guide metadata.

## Verification
- `git diff --check -- guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory`
- `./gradlew springBootToMicronautAtConfigurationAtBeanAtFactoryRunTestScript --stacktrace`

QA also reran `./gradlew springBootToMicronautAtConfigurationAtBeanAtFactoryBuild --stacktrace`. It reaches native tests and then fails locally with a GraalVM/native-build-tools reachability metadata schema mismatch that also affects the generated Java native path, so this is recorded as a local native tooling caveat rather than a Kotlin implementation failure.

## Release And Project
- Target branch: `master`.
- Release target: default-branch guide version signal is `5.0.0`.
- Micronaut organization project selected upstream: `5.0.1 Release`; ambiguity preserved because no open public `5.0.0 Release` board was returned.

## PR Assets
- Not applicable for this source/sample-code-only change.

Fixes #1774

---
###### ✨ This message was AI-generated using gpt-5
