### PR TITLE
Add Kotlin version for micronaut-data-one-to-many

### DIFF
--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactComplete.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactComplete.kt
@@ -1,0 +1,11 @@
+package example.micronaut
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected // <1>
+data class ContactComplete(
+    val id: Long,
+    val firstName: String?,
+    val lastName: String?,
+    val phones: Set<String>?
+)

--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactComplete.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactComplete.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import io.micronaut.core.annotation.Introspected

--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactEntity.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactEntity.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import io.micronaut.core.annotation.Nullable

--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactEntity.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactEntity.kt
@@ -1,0 +1,22 @@
+package example.micronaut
+
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.Relation
+
+@MappedEntity("contact") // <1>
+data class ContactEntity(
+    @field:Id // <2>
+    @field:GeneratedValue // <3>
+    @field:Nullable // <4>
+    val id: Long? = null,
+
+    val firstName: String?,
+
+    val lastName: String?,
+
+    @field:Relation(value = Relation.Kind.ONE_TO_MANY, mappedBy = "contact") // <5>
+    val phones: List<PhoneEntity>?
+)

--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactPreview.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactPreview.kt
@@ -1,0 +1,10 @@
+package example.micronaut
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected // <1>
+data class ContactPreview(
+    val id: Long,
+    val firstName: String?,
+    val lastName: String?
+)

--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactPreview.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactPreview.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import io.micronaut.core.annotation.Introspected

--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactRepository.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/ContactRepository.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.Join
+import io.micronaut.data.annotation.Query
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+import java.util.Optional
+
+@JdbcRepository(dialect = Dialect.H2) // <1>
+interface ContactRepository : CrudRepository<ContactEntity, Long> { // <2>
+    @Join(value = "phones", type = Join.Type.LEFT_FETCH) // <3>
+    fun getById(id: Long): Optional<ContactEntity>
+
+    @Query("select id, first_name, last_name from contact where id = :id") // <4>
+    fun findPreviewById(id: Long): Optional<ContactPreview>
+
+    @Query(
+        """
+select c.id, c.first_name, c.last_name, group_concat(p.phone) as phones
+ from contact c
+ left outer join phone p on c.id = p.contact_id
+ where c.id = :id
+ group by c.id"""
+    ) // <5>
+    fun findCompleteById(id: Long): Optional<ContactComplete>
+}

--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/PhoneEntity.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/PhoneEntity.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import io.micronaut.core.annotation.Nullable

--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/PhoneEntity.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/PhoneEntity.kt
@@ -1,0 +1,20 @@
+package example.micronaut
+
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.Relation
+
+@MappedEntity("phone") // <1>
+data class PhoneEntity(
+    @field:Id // <2>
+    @field:GeneratedValue // <3>
+    @field:Nullable // <4>
+    val id: Long? = null,
+
+    val phone: String,
+
+    @field:Relation(value = Relation.Kind.MANY_TO_ONE) // <5>
+    val contact: ContactEntity?
+)

--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/PhoneRepository.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/PhoneRepository.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut
 
 import io.micronaut.data.jdbc.annotation.JdbcRepository

--- a/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/PhoneRepository.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/main/kotlin/example/micronaut/PhoneRepository.kt
@@ -1,0 +1,10 @@
+package example.micronaut
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+
+@JdbcRepository(dialect = Dialect.H2) // <1>
+interface PhoneRepository : CrudRepository<PhoneEntity, Long> { // <2>
+    fun deleteByContact(contact: ContactEntity)
+}

--- a/guides/micronaut-data-one-to-many/kotlin/src/test/kotlin/example/micronaut/ContactRepositoryTest.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/test/kotlin/example/micronaut/ContactRepositoryTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@MicronautTest(startApplication = false, transactional = false) // <1>
+class ContactRepositoryTest {
+
+    @Inject
+    lateinit var contactRepository: ContactRepository // <2>
+
+    @Inject
+    lateinit var phoneRepository: PhoneRepository // <3>
+
+    @Test
+    fun testAssociationsQuerying() {
+        val firstName = "Sergio"
+        val lastName = "Sergio"
+        val contactCount = contactRepository.count()
+        val e = contactRepository.save(ContactEntity(null, firstName, lastName, null))
+        val contactId = e.id!!
+        assertEquals(1 + contactCount, contactRepository.count())
+
+        var preview = contactRepository.findPreviewById(contactId)
+        assertTrue(preview.isPresent)
+        assertEquals(ContactPreview(contactId, firstName, lastName), preview.get())
+
+        // Query with @Join
+        var contactEntity = contactRepository.getById(contactId)
+        assertTrue(contactEntity.isPresent)
+        var expected = ContactEntity(contactEntity.get().id, firstName, lastName, emptyList())
+        assertEquals(expected, contactEntity.get())
+
+        var complete = contactRepository.findCompleteById(contactId)
+        assertTrue(complete.isPresent)
+        assertEquals(ContactComplete(contactId, firstName, lastName, null), complete.get())
+
+        val americanPhone = "+14155552671"
+        val ukPhone = "+442071838750"
+        val phoneCount = phoneRepository.count()
+        val contactReference = ContactEntity(contactId, null, null, null)
+        val usPhoneEntity = phoneRepository.save(PhoneEntity(null, americanPhone, contactReference))
+        val ukPhoneEntity = phoneRepository.save(PhoneEntity(null, ukPhone, contactReference))
+        assertEquals(2 + phoneCount, phoneRepository.count())
+
+        // Projection without join with @Query
+        preview = contactRepository.findPreviewById(contactId)
+        assertTrue(preview.isPresent)
+        assertEquals(ContactPreview(contactId, firstName, lastName), preview.get())
+
+        // findById without @Join
+        contactEntity = contactRepository.findById(contactId)
+        assertTrue(contactEntity.isPresent)
+        assertEquals(ContactEntity(contactEntity.get().id, firstName, lastName, emptyList()), contactEntity.get())
+
+        // Query with @Join
+        contactEntity = contactRepository.getById(contactId)
+        assertTrue(contactEntity.isPresent)
+        expected = ContactEntity(
+            contactEntity.get().id,
+            firstName,
+            lastName,
+            listOf(
+                PhoneEntity(
+                    usPhoneEntity.id,
+                    usPhoneEntity.phone,
+                    ContactEntity(contactId, e.firstName, e.lastName, emptyList())
+                ),
+                PhoneEntity(
+                    ukPhoneEntity.id,
+                    ukPhoneEntity.phone,
+                    ContactEntity(contactId, e.firstName, e.lastName, emptyList())
+                )
+            )
+        )
+        assertEquals(expected, contactEntity.get())
+
+        // Projection with join with @Query
+        complete = contactRepository.findCompleteById(contactId)
+        assertTrue(complete.isPresent)
+        assertEquals(ContactComplete(contactId, firstName, lastName, setOf(americanPhone, ukPhone)), complete.get())
+
+        // cleanup
+        phoneRepository.deleteByContact(contactReference)
+        contactRepository.deleteById(contactId)
+        assertEquals(phoneCount, phoneRepository.count())
+        assertEquals(contactCount, contactRepository.count())
+    }
+}

--- a/guides/micronaut-data-one-to-many/kotlin/src/test/kotlin/example/micronaut/ContactRepositoryTest.kt
+++ b/guides/micronaut-data-one-to-many/kotlin/src/test/kotlin/example/micronaut/ContactRepositoryTest.kt
@@ -33,7 +33,7 @@ class ContactRepositoryTest {
     @Test
     fun testAssociationsQuerying() {
         val firstName = "Sergio"
-        val lastName = "Sergio"
+        val lastName = "del Amo"
         val contactCount = contactRepository.count()
         val e = contactRepository.save(ContactEntity(null, firstName, lastName, null))
         val contactId = e.id!!

--- a/guides/micronaut-data-one-to-many/metadata.json
+++ b/guides/micronaut-data-one-to-many/metadata.json
@@ -4,7 +4,7 @@
   "authors": ["Sergio del Amo"],
   "tags": [],
   "categories": ["Database Modeling"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "publicationDate": "2024-10-13",
   "apps": [
     {

--- a/guides/micronaut-data-one-to-many/micronaut-data-one-to-many.adoc
+++ b/guides/micronaut-data-one-to-many/micronaut-data-one-to-many.adoc
@@ -56,12 +56,12 @@ callout:relation[]
 
 == Projections
 
-Create one Java record to project a complete view, phones included, of the contact:
+Create one projection to show a complete view, phones included, of the contact:
 
 source:ContactComplete[]
 callout:introspected[]
 
-Create one Java record to preview a contact, no phones:
+Create one projection to preview a contact, no phones:
 
 source:ContactPreview[]
 callout:introspected[]


### PR DESCRIPTION
## Summary
- Add the Kotlin Micronaut Data JDBC one-to-many guide sample, including entities, projections, repositories, and JUnit coverage.
- Add `KOTLIN` to `guides/micronaut-data-one-to-many/metadata.json` and keep the PR scoped to Kotlin only.
- Make the projection prose language-neutral so the rendered Kotlin guide does not refer to Java records.
- Address initial review feedback by adding the standard license header to the new Kotlin files and using `del Amo` as the Kotlin test last name.

## Verification
- `git diff --check -- guides/micronaut-data-one-to-many`
- `./gradlew micronautDataOneToManyRunTestScript --stacktrace`
- `./gradlew micronautDataOneToManyBuild --stacktrace -x micronautDataOneToManyRunNativeTestScript`

QA previously ran the full `./gradlew micronautDataOneToManyBuild --stacktrace`; its only failure was the local GraalVM reachability metadata schema compatibility issue affecting the generated Java native test path as well as Kotlin.

## Release Targeting
- Target branch: `master`.
- Guide release line: `5.0.0` from `version.txt`.
- Selected Micronaut organization project: `5.0.1 Release` (#146). Ambiguity preserved from QA intake: there is no open `5.0.0 Release` project and this repo has no stable release tag history.
- Project association was attempted from this run, but the active `GITHUB_TOKEN` lacks the required `project` scope for `addProjectV2ItemById`.

## PR Assets
- [Rendered Kotlin guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/aa99df3ce368ed4b1b65c9e736d195038240a634/assets/pr-1806/88721524a5fc/micronaut-data-one-to-many-gradle-kotlin.html)

Closes #1694.

---
###### ✨ This message was AI-generated using GPT-5
