### PR TITLE
Add Kotlin variant for GraalVM reflection guide

### DIFF
--- a/guides/micronaut-graalvm-reflection/metadata.json
+++ b/guides/micronaut-graalvm-reflection/metadata.json
@@ -4,7 +4,7 @@
   "authors": ["Sergio del Amo"],
   "categories": ["GraalVM"],
   "publicationDate": "2023-09-22",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "name": "reflectconfig",

--- a/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/main/kotlin/example/micronaut/GraalConfig.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/main/kotlin/example/micronaut/GraalConfig.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.annotation.ReflectionConfig
+import io.micronaut.core.annotation.ReflectionConfig.ReflectiveMethodConfig
+
+@ReflectionConfig( // <1>
+    type = StringReverser::class,
+    methods = [
+        ReflectiveMethodConfig(name = "reverse", parameterTypes = [String::class])
+    ]
+)
+@ReflectionConfig(
+    type = StringCapitalizer::class,
+    methods = [
+        ReflectiveMethodConfig(name = "capitalize", parameterTypes = [String::class])
+    ]
+)
+class GraalConfig

--- a/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/main/kotlin/example/micronaut/StringCapitalizer.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/main/kotlin/example/micronaut/StringCapitalizer.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+object StringCapitalizer {
+
+    @JvmStatic
+    fun capitalize(input: String): String = input.uppercase()
+}

--- a/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/main/kotlin/example/micronaut/StringReverser.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/main/kotlin/example/micronaut/StringReverser.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+object StringReverser {
+
+    @JvmStatic
+    fun reverse(input: String): String = input.reversed()
+}

--- a/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/main/kotlin/example/micronaut/StringTransformer.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/main/kotlin/example/micronaut/StringTransformer.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+import java.lang.reflect.InvocationTargetException
+
+@Singleton // <1>
+class StringTransformer {
+
+    fun transform(input: String?, className: String, methodName: String): String? =
+        try {
+            val clazz = Class.forName(className)
+            val method = clazz.getDeclaredMethod(methodName, String::class.java)
+            method.invoke(null, input).toString()
+        } catch (e: ClassNotFoundException) {
+            LOG.error("Class not found: {}", className)
+            input
+        } catch (e: NoSuchMethodException) {
+            LOG.error("Method not found: {}", methodName)
+            input
+        } catch (e: InvocationTargetException) {
+            LOG.error("InvocationTargetException: {}", e.message)
+            input
+        } catch (e: IllegalAccessException) {
+            LOG.error("IllegalAccessException: {}", e.message)
+            input
+        }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(StringTransformer::class.java)
+    }
+}

--- a/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/main/kotlin/example/micronaut/StringTransformerController.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/main/kotlin/example/micronaut/StringTransformerController.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.annotation.QueryValue
+
+@Controller("/transformer") // <1>
+class StringTransformerController(private val transformer: StringTransformer) { // <2>
+
+    @Produces(MediaType.TEXT_PLAIN) // <3>
+    @Get("/capitalize{?q}") // <4>
+    fun capitalize(@Nullable @QueryValue q: String?): String? { // <5>
+        val className = "example.micronaut.StringCapitalizer"
+        val methodName = "capitalize"
+        return transformer.transform(q, className, methodName)
+    }
+
+    @Produces(MediaType.TEXT_PLAIN) // <3>
+    @Get("/reverse{?q}") // <4>
+    fun reverse(@Nullable @QueryValue q: String?): String? { // <5>
+        val className = "example.micronaut.StringReverser"
+        val methodName = "reverse"
+        return transformer.transform(q, className, methodName)
+    }
+}

--- a/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/test/kotlin/example/micronaut/StringTransformerControllerTest.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfig/kotlin/src/test/kotlin/example/micronaut/StringTransformerControllerTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+@MicronautTest // <1>
+class StringTransformerControllerTest(@param:Client("/") private val httpClient: HttpClient) { // <2>
+
+    @Test
+    fun capitalize() {
+        val client = httpClient.toBlocking()
+        val uri = uri("capitalize")
+        assertEquals("HELLO", client.retrieve(HttpRequest.GET<Any>(uri)))
+    }
+
+    @Test
+    fun reverse() {
+        val client = httpClient.toBlocking()
+        val uri = uri("reverse")
+        assertEquals("olleh", client.retrieve(HttpRequest.GET<Any>(uri)))
+    }
+
+    private fun uri(path: String): URI =
+        UriBuilder.of("/transformer") // <3>
+            .path(path)
+            .queryParam("q", "hello")
+            .build()
+}

--- a/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/main/kotlin/example/micronaut/StringCapitalizer.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/main/kotlin/example/micronaut/StringCapitalizer.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+object StringCapitalizer {
+
+    @JvmStatic
+    fun capitalize(input: String): String = input.uppercase()
+}

--- a/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/main/kotlin/example/micronaut/StringReverser.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/main/kotlin/example/micronaut/StringReverser.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+object StringReverser {
+
+    @JvmStatic
+    fun reverse(input: String): String = input.reversed()
+}

--- a/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/main/kotlin/example/micronaut/StringTransformer.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/main/kotlin/example/micronaut/StringTransformer.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+import java.lang.reflect.InvocationTargetException
+
+@Singleton // <1>
+class StringTransformer {
+
+    fun transform(input: String?, className: String, methodName: String): String? =
+        try {
+            val clazz = Class.forName(className)
+            val method = clazz.getDeclaredMethod(methodName, String::class.java)
+            method.invoke(null, input).toString()
+        } catch (e: ClassNotFoundException) {
+            LOG.error("Class not found: {}", className)
+            input
+        } catch (e: NoSuchMethodException) {
+            LOG.error("Method not found: {}", methodName)
+            input
+        } catch (e: InvocationTargetException) {
+            LOG.error("InvocationTargetException: {}", e.message)
+            input
+        } catch (e: IllegalAccessException) {
+            LOG.error("IllegalAccessException: {}", e.message)
+            input
+        }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(StringTransformer::class.java)
+    }
+}

--- a/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/main/kotlin/example/micronaut/StringTransformerController.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/main/kotlin/example/micronaut/StringTransformerController.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.annotation.QueryValue
+
+@Controller("/transformer") // <1>
+class StringTransformerController(private val transformer: StringTransformer) { // <2>
+
+    @Produces(MediaType.TEXT_PLAIN) // <3>
+    @Get("/capitalize{?q}") // <4>
+    fun capitalize(@Nullable @QueryValue q: String?): String? { // <5>
+        val className = "example.micronaut.StringCapitalizer"
+        val methodName = "capitalize"
+        return transformer.transform(q, className, methodName)
+    }
+
+    @Produces(MediaType.TEXT_PLAIN) // <3>
+    @Get("/reverse{?q}") // <4>
+    fun reverse(@Nullable @QueryValue q: String?): String? { // <5>
+        val className = "example.micronaut.StringReverser"
+        val methodName = "reverse"
+        return transformer.transform(q, className, methodName)
+    }
+}

--- a/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/main/resources/META-INF/native-image/example.micronaut.micronautguide/reflect-config.json
+++ b/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/main/resources/META-INF/native-image/example.micronaut.micronautguide/reflect-config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name":"example.micronaut.StringCapitalizer",
+    "methods":[{"name":"capitalize","parameterTypes":["java.lang.String"] }]
+  },
+  {
+    "name":"example.micronaut.StringReverser",
+    "methods":[{"name":"reverse","parameterTypes":["java.lang.String"] }]
+  }
+]

--- a/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/test/kotlin/example/micronaut/StringTransformerControllerTest.kt
+++ b/guides/micronaut-graalvm-reflection/reflectconfigjson/kotlin/src/test/kotlin/example/micronaut/StringTransformerControllerTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+@MicronautTest // <1>
+class StringTransformerControllerTest(@param:Client("/") private val httpClient: HttpClient) { // <2>
+
+    @Test
+    fun capitalize() {
+        val client = httpClient.toBlocking()
+        val uri = uri("capitalize")
+        assertEquals("HELLO", client.retrieve(HttpRequest.GET<Any>(uri)))
+    }
+
+    @Test
+    fun reverse() {
+        val client = httpClient.toBlocking()
+        val uri = uri("reverse")
+        assertEquals("olleh", client.retrieve(HttpRequest.GET<Any>(uri)))
+    }
+
+    private fun uri(path: String): URI =
+        UriBuilder.of("/transformer") // <3>
+            .path(path)
+            .queryParam("q", "hello")
+            .build()
+}

--- a/guides/micronaut-graalvm-reflection/reflectiveaccess/kotlin/src/main/kotlin/example/micronaut/StringCapitalizer.kt
+++ b/guides/micronaut-graalvm-reflection/reflectiveaccess/kotlin/src/main/kotlin/example/micronaut/StringCapitalizer.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.annotation.ReflectiveAccess
+
+object StringCapitalizer {
+
+    @ReflectiveAccess // <1>
+    @JvmStatic
+    fun capitalize(input: String): String = input.uppercase()
+}

--- a/guides/micronaut-graalvm-reflection/reflectiveaccess/kotlin/src/main/kotlin/example/micronaut/StringReverser.kt
+++ b/guides/micronaut-graalvm-reflection/reflectiveaccess/kotlin/src/main/kotlin/example/micronaut/StringReverser.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.annotation.ReflectiveAccess
+
+object StringReverser {
+
+    @ReflectiveAccess // <1>
+    @JvmStatic
+    fun reverse(input: String): String = input.reversed()
+}

--- a/guides/micronaut-graalvm-reflection/reflectiveaccess/kotlin/src/main/kotlin/example/micronaut/StringTransformer.kt
+++ b/guides/micronaut-graalvm-reflection/reflectiveaccess/kotlin/src/main/kotlin/example/micronaut/StringTransformer.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+import java.lang.reflect.InvocationTargetException
+
+@Singleton // <1>
+class StringTransformer {
+
+    fun transform(input: String?, className: String, methodName: String): String? =
+        try {
+            val clazz = Class.forName(className)
+            val method = clazz.getDeclaredMethod(methodName, String::class.java)
+            method.invoke(null, input).toString()
+        } catch (e: ClassNotFoundException) {
+            LOG.error("Class not found: {}", className)
+            input
+        } catch (e: NoSuchMethodException) {
+            LOG.error("Method not found: {}", methodName)
+            input
+        } catch (e: InvocationTargetException) {
+            LOG.error("InvocationTargetException: {}", e.message)
+            input
+        } catch (e: IllegalAccessException) {
+            LOG.error("IllegalAccessException: {}", e.message)
+            input
+        }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(StringTransformer::class.java)
+    }
+}

--- a/guides/micronaut-graalvm-reflection/reflectiveaccess/kotlin/src/main/kotlin/example/micronaut/StringTransformerController.kt
+++ b/guides/micronaut-graalvm-reflection/reflectiveaccess/kotlin/src/main/kotlin/example/micronaut/StringTransformerController.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.annotation.QueryValue
+
+@Controller("/transformer") // <1>
+class StringTransformerController(private val transformer: StringTransformer) { // <2>
+
+    @Produces(MediaType.TEXT_PLAIN) // <3>
+    @Get("/capitalize{?q}") // <4>
+    fun capitalize(@Nullable @QueryValue q: String?): String? = // <5>
+        transformer.transform(q, "example.micronaut.StringCapitalizer", "capitalize")
+
+    @Produces(MediaType.TEXT_PLAIN) // <3>
+    @Get("/reverse{?q}") // <4>
+    fun reverse(@Nullable @QueryValue q: String?): String? = // <5>
+        transformer.transform(q, "example.micronaut.StringReverser", "reverse")
+}

--- a/guides/micronaut-graalvm-reflection/reflectiveaccess/kotlin/src/test/kotlin/example/micronaut/StringTransformerControllerTest.kt
+++ b/guides/micronaut-graalvm-reflection/reflectiveaccess/kotlin/src/test/kotlin/example/micronaut/StringTransformerControllerTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+@MicronautTest // <1>
+class StringTransformerControllerTest(@param:Client("/") private val httpClient: HttpClient) { // <2>
+
+    @Test
+    fun capitalize() {
+        val client = httpClient.toBlocking()
+        val uri = uri("capitalize")
+        assertEquals("HELLO", client.retrieve(HttpRequest.GET<Any>(uri)))
+    }
+
+    @Test
+    fun reverse() {
+        val client = httpClient.toBlocking()
+        val uri = uri("reverse")
+        assertEquals("olleh", client.retrieve(HttpRequest.GET<Any>(uri)))
+    }
+
+    private fun uri(path: String): URI =
+        UriBuilder.of("/transformer") // <3>
+            .path(path)
+            .queryParam("q", "hello")
+            .build()
+}


### PR DESCRIPTION
## Summary
- Add Kotlin sample variants for the `reflectconfig`, `reflectconfigjson`, and `reflectiveaccess` GraalVM reflection guide apps.
- Enable Kotlin in `guides/micronaut-graalvm-reflection/metadata.json` while preserving Java support.
- Preserve the three reflection strategies: JSON reflection metadata, `@ReflectionConfig`, and `@ReflectiveAccess`.

## Validation
- `./gradlew micronautGraalvmReflectionRunTestScript --stacktrace`
- `git diff --check -- guides/micronaut-graalvm-reflection`
- GitHub Actions: `Running micronautGraalvmReflectionBuild with Java 25` passed.
- Bytecode spot check confirmed Kotlin `object` methods are emitted as public static methods for the reflective calls.

QA recorded that `./gradlew micronautGraalvmReflectionBuild --stacktrace` is blocked locally by the GraalVM reachability metadata schema supported by the installed native-image tooling, and that the same failure affects the pre-existing Java variants. The hosted GitHub Actions guide build passed.

## Release Metadata
- Target branch: `master`
- Release target: patch-compatible docs/sample-code change
- Micronaut organization project recommendation: `5.0.1 Release`
- Ambiguity note: `micronaut-guides` does not publish normal SemVer repository releases, so this is the earliest-fit Micronaut Platform BOM release board selected during QA intake.
- PR assets: none required; this changes guide sample source and metadata only.

## Automation Notes
- Reviewer request for linked issue creator `sdelamo` was attempted and rejected by GitHub: `Review cannot be requested from pull request author.`
- Live organization project link for `5.0.1 Release` could not be applied with the available `GITHUB_TOKEN`: GraphQL `addProjectV2ItemById` requires the `project` scope, while the token has `admin:repo_hook`, `read:project`, `read:user`, `repo`, and `workflow`.

Fixes #1702

---
###### ✨ This message was AI-generated using gpt-5
