### PR TITLE
Add Groovy version for micronaut-graphql-todo

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/JakartaPersistenceApi.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/JakartaPersistenceApi.java
@@ -1,21 +1,31 @@
 package io.micronaut.guides.feature;
 
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
+import io.micronaut.starter.feature.Feature;
 import jakarta.inject.Singleton;
 
 @Singleton
-public class JakartaPersistenceApi extends AbstractFeature {
-    public JakartaPersistenceApi() {
-        super("jakarta-persistence-api", "jakarta.persistence-api");
+public class JakartaPersistenceApi implements Feature {
+    private static final String NAME = "jakarta-persistence-api";
+    private static final String ARTIFACT_ID = "jakarta.persistence-api";
+
+    @Override
+    public @NonNull String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
     }
 
     @Override
     public void apply(GeneratorContext generatorContext) {
         generatorContext.addDependency(Dependency.builder()
-                .groupId("jakarta.persistence")
-                .artifactId("jakarta.persistence-api")
-                .version("3.2.0")
+                .lookupArtifactId(ARTIFACT_ID)
                 .compileOnly()
                 .build());
     }

--- a/buildSrc/src/main/java/io/micronaut/guides/feature/JakartaPersistenceApi.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/JakartaPersistenceApi.java
@@ -1,27 +1,22 @@
 package io.micronaut.guides.feature;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
 import io.micronaut.starter.build.dependencies.Dependency;
-import io.micronaut.starter.feature.Feature;
 import jakarta.inject.Singleton;
 
 @Singleton
-public class JakartaPersistenceApi implements Feature {
-
-    @Override
-    public @NonNull String getName() {
-        return "jakarta-persistence-api";
-    }
-
-    @Override
-    public boolean supports(ApplicationType applicationType) {
-        return true;
+public class JakartaPersistenceApi extends AbstractFeature {
+    public JakartaPersistenceApi() {
+        super("jakarta-persistence-api", "jakarta.persistence-api");
     }
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        generatorContext.addDependency(Dependency.builder().groupId("jakarta.persistence").artifactId("jakarta.persistence-api").compileOnly().build());
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("jakarta.persistence")
+                .artifactId("jakarta.persistence-api")
+                .version("3.2.0")
+                .compileOnly()
+                .build());
     }
 }

--- a/buildSrc/src/main/resources/pom.xml
+++ b/buildSrc/src/main/resources/pom.xml
@@ -203,5 +203,11 @@
             <artifactId>swagger-annotations</artifactId>
             <scope>compile</scope>
         </dependency>
+        <!-- Jakarta Persistence API -->
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.2.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/Author.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/Author.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+
+import jakarta.validation.constraints.NotNull
+
+import static io.micronaut.data.annotation.GeneratedValue.Type.AUTO
+
+@MappedEntity // <1>
+class Author {
+
+    @Id // <2>
+    @GeneratedValue(AUTO)
+    Long id
+
+    @NotNull
+    String username
+
+    Author(@NotNull String username) {
+        this.username = username
+    }
+}

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/AuthorDataFetcher.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/AuthorDataFetcher.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import jakarta.inject.Singleton
+import org.dataloader.DataLoader
+
+import java.util.concurrent.CompletionStage
+
+@Singleton // <1>
+class AuthorDataFetcher implements DataFetcher<CompletionStage<Author>> {
+
+    @Override
+    CompletionStage<Author> get(DataFetchingEnvironment environment) {
+        ToDo toDo = environment.getSource()
+        DataLoader<Long, Author> authorDataLoader = environment.getDataLoader('author') // <2>
+        authorDataLoader.load(toDo.authorId)
+    }
+}

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/AuthorDataLoader.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/AuthorDataLoader.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.scheduling.TaskExecutors
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.dataloader.MappedBatchLoader
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.ExecutorService
+import java.util.function.Supplier
+
+@Singleton // <1>
+class AuthorDataLoader implements MappedBatchLoader<Long, Author> {
+
+    private final AuthorRepository authorRepository
+    private final ExecutorService executor
+
+    AuthorDataLoader(
+        AuthorRepository authorRepository,
+        @Named(TaskExecutors.BLOCKING) ExecutorService executor // <2>
+    ) {
+        this.authorRepository = authorRepository
+        this.executor = executor
+    }
+
+    @Override
+    CompletionStage<Map<Long, Author>> load(Set<Long> keys) {
+        CompletableFuture.supplyAsync({
+            authorRepository
+                .findByIdIn(keys)
+                .collectEntries { Author author -> [(author.id): author] }
+        } as Supplier<Map<Long, Author>>, executor)
+    }
+}

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/AuthorRepository.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/AuthorRepository.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.repository.CrudRepository
+
+import static io.micronaut.data.model.query.builder.sql.Dialect.POSTGRES
+
+@JdbcRepository(dialect = POSTGRES) // <1>
+interface AuthorRepository extends CrudRepository<Author, Long> { // <2>
+
+    Optional<Author> findByUsername(String username) // <3>
+
+    Collection<Author> findByIdIn(Collection<Long> ids) // <4>
+
+    default Author findOrCreate(String username) { // <5>
+        findByUsername(username).orElseGet(() -> save(new Author(username)))
+    }
+}

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/CompleteToDoDataFetcher.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/CompleteToDoDataFetcher.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import jakarta.inject.Singleton
+
+@Singleton // <1>
+class CompleteToDoDataFetcher implements DataFetcher<Boolean> {
+
+    private final ToDoRepository toDoRepository
+
+    CompleteToDoDataFetcher(ToDoRepository toDoRepository) { // <2>
+        this.toDoRepository = toDoRepository
+    }
+
+    @Override
+    Boolean get(DataFetchingEnvironment env) {
+        long id = Long.parseLong(env.getArgument('id'))
+        toDoRepository
+            .findById(id) // <3>
+            .map(this::setCompletedAndUpdate)
+            .orElse(false)
+    }
+
+    private boolean setCompletedAndUpdate(ToDo todo) {
+        todo.completed = true // <4>
+        toDoRepository.update(todo) // <5>
+        true
+    }
+}

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/CreateToDoDataFetcher.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/CreateToDoDataFetcher.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import jakarta.inject.Singleton
+import jakarta.transaction.Transactional
+
+@Singleton // <1>
+class CreateToDoDataFetcher implements DataFetcher<ToDo> {
+
+    private final ToDoRepository toDoRepository
+    private final AuthorRepository authorRepository
+
+    CreateToDoDataFetcher(ToDoRepository toDoRepository, // <2>
+                          AuthorRepository authorRepository) {
+        this.toDoRepository = toDoRepository
+        this.authorRepository = authorRepository
+    }
+
+    @Override
+    @Transactional
+    ToDo get(DataFetchingEnvironment env) {
+        String title = env.getArgument('title')
+        String username = env.getArgument('author')
+
+        Author author = authorRepository.findOrCreate(username) // <3>
+
+        ToDo toDo = new ToDo(title, author.id)
+
+        toDoRepository.save(toDo) // <4>
+    }
+}

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/DataLoaderRegistryFactory.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/DataLoaderRegistryFactory.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.runtime.http.scope.RequestScope
+import org.dataloader.DataLoaderFactory
+import org.dataloader.DataLoaderRegistry
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+@Factory // <1>
+class DataLoaderRegistryFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataLoaderRegistryFactory)
+
+    @SuppressWarnings('unused')
+    @RequestScope // <2>
+    DataLoaderRegistry dataLoaderRegistry(AuthorDataLoader authorDataLoader) {
+        DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry()
+        dataLoaderRegistry.register(
+            'author',
+            DataLoaderFactory.newMappedDataLoader(authorDataLoader)
+        ) // <3>
+
+        LOG.trace('Created new data loader registry')
+
+        dataLoaderRegistry
+    }
+}

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/GraphQLFactory.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/GraphQLFactory.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import graphql.GraphQL
+import graphql.schema.GraphQLSchema
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import graphql.schema.idl.TypeDefinitionRegistry
+import graphql.schema.idl.errors.SchemaMissingError
+import io.micronaut.context.annotation.Factory
+import io.micronaut.core.io.ResourceResolver
+import jakarta.inject.Singleton
+
+@Factory // <1>
+class GraphQLFactory {
+
+    @Singleton // <2>
+    GraphQL graphQL(ResourceResolver resourceResolver,
+                    ToDosDataFetcher toDosDataFetcher,
+                    CreateToDoDataFetcher createToDoDataFetcher,
+                    CompleteToDoDataFetcher completeToDoDataFetcher,
+                    AuthorDataFetcher authorDataFetcher) {
+        SchemaParser schemaParser = new SchemaParser()
+        SchemaGenerator schemaGenerator = new SchemaGenerator()
+
+        InputStream schemaDefinition = resourceResolver
+            .getResourceAsStream('classpath:schema.graphqls')
+            .orElseThrow(() -> new SchemaMissingError())
+
+        TypeDefinitionRegistry typeRegistry = new TypeDefinitionRegistry()
+        typeRegistry.merge(schemaParser.parse(new BufferedReader(new InputStreamReader(schemaDefinition))))
+
+        RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+            .type('Query', typeWiring -> typeWiring // <3>
+                .dataFetcher('toDos', toDosDataFetcher))
+
+            .type('Mutation', typeWiring -> typeWiring // <4>
+                .dataFetcher('createToDo', createToDoDataFetcher)
+                .dataFetcher('completeToDo', completeToDoDataFetcher))
+
+            .type('ToDo', typeWiring -> typeWiring // <5>
+                .dataFetcher('author', authorDataFetcher))
+
+            .build()
+
+        GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring)
+
+        GraphQL.newGraphQL(graphQLSchema).build()
+    }
+}

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/ToDo.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/ToDo.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+
+import jakarta.validation.constraints.NotNull
+
+import static io.micronaut.data.annotation.GeneratedValue.Type.AUTO
+
+@MappedEntity // <1>
+class ToDo {
+
+    @Id // <2>
+    @GeneratedValue(AUTO)
+    Long id
+
+    @NotNull
+    String title
+
+    boolean completed
+
+    long authorId
+
+    ToDo(String title, long authorId) {
+        this.title = title
+        this.authorId = authorId
+    }
+}

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/ToDoRepository.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/ToDoRepository.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.repository.PageableRepository
+
+import static io.micronaut.data.model.query.builder.sql.Dialect.POSTGRES
+
+@JdbcRepository(dialect = POSTGRES) // <1>
+interface ToDoRepository extends PageableRepository<ToDo, Long> { // <2>
+}

--- a/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/ToDosDataFetcher.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/main/groovy/example/micronaut/ToDosDataFetcher.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import jakarta.inject.Singleton
+
+@Singleton // <1>
+class ToDosDataFetcher implements DataFetcher<Iterable<ToDo>> {
+
+    private final ToDoRepository toDoRepository
+
+    ToDosDataFetcher(ToDoRepository toDoRepository) { // <2>
+        this.toDoRepository = toDoRepository
+    }
+
+    @Override
+    Iterable<ToDo> get(DataFetchingEnvironment env) {
+        toDoRepository.findAll()
+    }
+}

--- a/guides/micronaut-graphql-todo/groovy/src/test/groovy/example/micronaut/GraphQLControllerSpec.groovy
+++ b/guides/micronaut-graphql-todo/groovy/src/test/groovy/example/micronaut/GraphQLControllerSpec.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Specification
+
+import jakarta.inject.Inject
+
+@MicronautTest // <1>
+class GraphQLControllerSpec extends Specification {
+
+    @Inject
+    @Client('/')
+    HttpClient client // <2>
+
+    void 'test GraphQL controller'() {
+        when:
+        List<Map> todos = getTodos()
+
+        then:
+        todos.empty
+
+        when:
+        Long id = createToDo('Test GraphQL', 'Tim Yates')
+
+        then:
+        id == 1
+
+        when:
+        todos = getTodos()
+
+        then:
+        todos.size() == 1
+        todos[0].title == 'Test GraphQL'
+        !Boolean.parseBoolean(todos[0].completed.toString())
+        todos[0].author.username == 'Tim Yates'
+
+        when:
+        Boolean completed = markAsCompleted(id)
+
+        then:
+        completed
+
+        when:
+        todos = getTodos()
+
+        then:
+        todos.size() == 1
+        todos[0].title == 'Test GraphQL'
+        Boolean.parseBoolean(todos[0].completed.toString())
+        todos[0].author.username == 'Tim Yates'
+    }
+
+    private HttpResponse<Map> fetch(String query) {
+        HttpRequest<String> request = HttpRequest.POST('/graphql', query)
+        HttpResponse<Map> response = client.toBlocking().exchange(request, Argument.of(Map))
+        assert response.status() == HttpStatus.OK
+        assert response.body()
+        response
+    }
+
+    private List<Map> getTodos() {
+        String query = '{"query":"query { toDos { title, completed, author { id, username } } }"}'
+        HttpResponse<Map> response = fetch(query)
+        ((Map) response.body().data).toDos as List<Map>
+    }
+
+    private Long createToDo(String title, String author) {
+        String query = """{"query": "mutation { createToDo(title: \\"$title\\", author: \\"$author\\") { id } }" }"""
+        HttpResponse<Map> response = fetch(query)
+        ((Map) ((Map) response.body().data).createToDo).id.toString().toLong()
+    }
+
+    private Boolean markAsCompleted(Long id) {
+        String query = """{"query": "mutation { completeToDo(id: \\"$id\\") }" }"""
+        HttpResponse<Map> response = fetch(query)
+        ((Map) response.body().data).completeToDo as Boolean
+    }
+}

--- a/guides/micronaut-graphql-todo/metadata.json
+++ b/guides/micronaut-graphql-todo/metadata.json
@@ -5,11 +5,12 @@
   "categories": ["GraphQL"],
   "tags": ["flyway", "micronaut-data", "jdbc", "graphql"],
   "publicationDate": "2022-03-10",
-  "languages": ["JAVA", "KOTLIN"],
+  "languages": ["JAVA", "GROOVY", "KOTLIN"],
   "apps": [
     {
       "name": "default",
       "features": ["graphql", "data-jdbc", "flyway", "postgres", "validation"],
+      "invisibleFeatures": ["jakarta-persistence-api"],
       "javaFeatures": ["graalvm"],
       "kotlinFeatures": ["graalvm"]
     }


### PR DESCRIPTION
## Summary
- Add the Groovy implementation and Spock test for `micronaut-graphql-todo`.
- Add `GROOVY` to the guide metadata.
- Add compile-only Jakarta Persistence API support for generated guide projects that need it.

## Release And Project
- Target branch: `master`.
- Release target: docs/sample-code patch-compatible change.
- Selected Micronaut organization project: `5.0.1 Release`.
- Ambiguity note: `micronaut-guides` has no stable repository release or SemVer tags, and `origin/master` still reports `5.0.0`; QA selected `5.0.1 Release` as the earliest open Micronaut Platform BOM board that can consume a 5.0.x guides change.
- Project association: not applied because the active `GITHUB_TOKEN` lacks the GitHub Projects v2 write scope. GitHub returned: `addProjectV2ItemById requires one of the following scopes: ['project']`; the token has `read:project` but not `project`.

## Reviewer Routing
- Linked GitHub issue creator: `sdelamo`.
- Reviewer request result: not applied because GitHub rejected requesting review from the PR author. GitHub returned: `Review cannot be requested from pull request author. (HTTP 422)`.

## Validation
- Passed: `git diff --check origin/master...HEAD`.
- Passed locally: `./gradlew --no-daemon micronautGraphqlTodoRunTestScript --stacktrace`.
- GitHub checks passed: `Generate Guide Test Matrix` and `Running micronautGraphqlTodoBuild with Java 25`.
- Attempted locally: `./gradlew --no-daemon micronautGraphqlTodoBuild --stacktrace`; generated docs/zips and ran app tests, then failed in the existing Java/Kotlin native-test compile path because the local GraalVM installation does not provide the reachability-metadata schema support required by the configured native-build-tools repository. No Groovy variant failure was observed.

Closes #1703

---
###### ✨ This message was AI-generated using gpt-5