### PR TITLE
Add Groovy version for Hibernate Reactive guide

### DIFF
--- a/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/ApplicationConfiguration.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/ApplicationConfiguration.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+interface ApplicationConfiguration {
+    int getMax()
+}

--- a/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/ApplicationConfigurationProperties.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/ApplicationConfigurationProperties.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.ConfigurationProperties
+
+@CompileStatic
+@ConfigurationProperties('application') // <1>
+class ApplicationConfigurationProperties implements ApplicationConfiguration {
+
+    private final int DEFAULT_MAX = 10
+
+    int max = DEFAULT_MAX
+}

--- a/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/GenreController.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/GenreController.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import example.micronaut.domain.Genre
+import groovy.transform.CompileStatic
+import io.micronaut.core.async.annotation.SingleResult
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Delete
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Put
+import io.micronaut.http.annotation.Status
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+
+import jakarta.persistence.PersistenceException
+import jakarta.validation.Valid
+
+import static io.micronaut.http.HttpHeaders.LOCATION
+
+@CompileStatic
+@Controller('/genres')  // <1>
+class GenreController {
+
+    private final GenreRepository genreRepository
+
+    GenreController(GenreRepository genreRepository) { // <2>
+        this.genreRepository = genreRepository
+    }
+
+    @Get('/{id}') // <3>
+    @SingleResult
+    Publisher<Genre> show(Long id) {
+        Mono.from(genreRepository.findById(id))
+                .flatMap(genre -> genre.present ? Mono.just(genre.get()) : Mono.<Genre>empty()) // <4>
+    }
+
+    @Put // <5>
+    Publisher<HttpResponse<?>> update(@Body @Valid GenreUpdateCommand command) { // <6>
+        Mono.from(genreRepository.update(command.id, command.name))
+                .map(ignored -> HttpResponse
+                        .noContent()
+                        .header(LOCATION, location(command.id).path)) // <7>
+    }
+
+    @Get(value = '/list{?args*}') // <8>
+    Publisher<Genre> list(@Valid SortingAndOrderArguments args) {
+        genreRepository.findAll(args)
+    }
+
+    @Post // <9>
+    @SingleResult
+    Publisher<MutableHttpResponse<Genre>> save(@Body @Valid GenreSaveCommand cmd) {
+        Mono.from(genreRepository.save(cmd.name))
+                .map(genre -> HttpResponse
+                        .created(genre)
+                        .headers(headers -> headers.location(location(genre.id))))
+    }
+
+    @Post('/ex') // <10>
+    @SingleResult
+    Publisher<MutableHttpResponse<Genre>> saveExceptions(@Body @Valid GenreSaveCommand cmd) {
+        Mono.from(genreRepository.saveWithException(cmd.name))
+                .map(genre -> HttpResponse
+                        .created(genre)
+                        .headers(headers -> headers.location(location(genre.id))))
+                .onErrorReturn(PersistenceException, HttpResponse.noContent())
+    }
+
+    @Delete('/{id}') // <11>
+    @Status(HttpStatus.NO_CONTENT) // <12>
+    HttpResponse<?> delete(Long id) {
+        genreRepository.deleteById(id)
+        HttpResponse.noContent()
+    }
+
+    private URI location(Long id) {
+        URI.create('/genres/' + id)
+    }
+}

--- a/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/GenreRepository.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/GenreRepository.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import example.micronaut.domain.Genre
+import io.micronaut.core.annotation.NonNull
+import org.reactivestreams.Publisher
+
+import jakarta.validation.constraints.NotBlank
+
+interface GenreRepository {
+
+    Publisher<Optional<Genre>> findById(long id)
+
+    Publisher<Genre> save(@NotBlank String name)
+
+    Publisher<Genre> saveWithException(@NotBlank String name)
+
+    void deleteById(long id)
+
+    Publisher<Genre> findAll(@NonNull SortingAndOrderArguments args)
+
+    Publisher<Integer> update(long id, @NotBlank String name)
+}

--- a/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/GenreRepositoryImpl.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/GenreRepositoryImpl.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import example.micronaut.domain.Genre
+import groovy.transform.CompileStatic
+import jakarta.inject.Singleton
+import org.hibernate.SessionFactory
+import org.hibernate.reactive.stage.Stage
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+import jakarta.persistence.PersistenceException
+import java.util.concurrent.CompletionStage
+
+@CompileStatic
+@Singleton // <1>
+class GenreRepositoryImpl implements GenreRepository {
+
+    private static final List<String> VALID_PROPERTY_NAMES = ['id', 'name']
+
+    private final ApplicationConfiguration applicationConfiguration
+    private final Stage.SessionFactory sessionFactory
+
+    GenreRepositoryImpl(
+            ApplicationConfiguration applicationConfiguration, // <2>
+            SessionFactory sessionFactory // <3>
+    ) {
+        this.applicationConfiguration = applicationConfiguration
+        this.sessionFactory = sessionFactory.unwrap(Stage.SessionFactory)
+    }
+
+    @Override
+    Publisher<Optional<Genre>> findById(long id) {
+        Mono.fromCompletionStage(sessionFactory.withTransaction(session -> // <4>
+                find(session, id)
+        ))
+    }
+
+    CompletionStage<Optional<Genre>> find(Stage.Session session, Long id) {
+        session.find(Genre, id).thenApply(genre -> Optional.ofNullable(genre))
+    }
+
+    @Override
+    Publisher<Genre> save(String name) {
+        Mono.fromCompletionStage(sessionFactory.withTransaction(session -> {
+            Genre entity = new Genre(name)
+            session.persist(entity).thenApply(ignored -> entity)
+        }))
+    }
+
+    @Override
+    Publisher<Genre> saveWithException(String name) {
+        Mono.fromCompletionStage(sessionFactory.withTransaction(session -> {
+            Genre entity = new Genre(name)
+            session.persist(entity).thenApply(ignored -> {
+                throw new PersistenceException()
+            })
+        }))
+    }
+
+    @Override
+    void deleteById(long id) {
+        sessionFactory.withTransaction(session -> session.find(Genre, id).thenApply(session::remove))
+    }
+
+    @Override
+    Publisher<Genre> findAll(SortingAndOrderArguments args) {
+        String qlString = createQuery(args)
+        Mono.fromCompletionStage(sessionFactory.withTransaction(session -> {
+            Stage.SelectionQuery<Genre> query = session.createQuery(qlString, Genre)
+            query.maxResults = args.max == null ? applicationConfiguration.max : args.max
+            if (args.offset != null) {
+                query.firstResult = args.offset
+            }
+            query.resultList
+        }))
+                .flatMapMany(Flux::fromIterable)
+    }
+
+    private String createQuery(SortingAndOrderArguments args) {
+        String qlString = 'SELECT g FROM Genre as g'
+        String order = args.order
+        String sort = args.sort
+        if (order != null && sort != null && VALID_PROPERTY_NAMES.contains(sort)) {
+            qlString += ' ORDER BY g.' + sort + ' ' + order.toLowerCase()
+        }
+        qlString
+    }
+
+    @Override
+    Publisher<Integer> update(long id, String name) {
+        Mono.fromCompletionStage(sessionFactory.withTransaction(session -> session.createQuery('UPDATE Genre g SET name = :name where id = :id')
+                .setParameter('name', name)
+                .setParameter('id', id)
+                .executeUpdate()))
+    }
+}

--- a/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/GenreSaveCommand.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/GenreSaveCommand.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.serde.annotation.Serdeable
+
+import jakarta.validation.constraints.NotBlank
+
+@CompileStatic
+@Serdeable // <1>
+class GenreSaveCommand {
+
+    @NotBlank
+    String name
+
+    GenreSaveCommand(String name) {
+        this.name = name
+    }
+}

--- a/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/GenreUpdateCommand.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/GenreUpdateCommand.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.serde.annotation.Serdeable
+
+import jakarta.validation.constraints.NotBlank
+
+@CompileStatic
+@Serdeable
+class GenreUpdateCommand {
+
+    long id
+
+    @NotBlank
+    String name
+
+    GenreUpdateCommand(long id, String name) {
+        this.id = id
+        this.name = name
+    }
+}

--- a/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/SortingAndOrderArguments.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/SortingAndOrderArguments.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.serde.annotation.Serdeable
+
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.PositiveOrZero
+
+@CompileStatic
+@Serdeable
+class SortingAndOrderArguments {
+
+    @Nullable
+    @PositiveOrZero // <1>
+    Integer offset
+
+    @Nullable
+    @Positive // <1>
+    Integer max
+
+    @Nullable
+    @Pattern(regexp = 'id|name')  // <1>
+    String sort
+
+    @Nullable
+    @Pattern(regexp = 'asc|ASC|desc|DESC')  // <1>
+    String order
+}

--- a/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/domain/Book.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/domain/Book.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut.domain
+
+import groovy.transform.CompileStatic
+import io.micronaut.serde.annotation.Serdeable
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+
+import static jakarta.persistence.GenerationType.AUTO
+
+@CompileStatic
+@Serdeable
+@Entity
+@Table(name = 'book')
+class Book {
+
+    @Id
+    @GeneratedValue(strategy = AUTO)
+    Long id
+
+    @NotNull
+    @Column(name = 'name', nullable = false)
+    String name
+
+    @NotNull
+    @Column(name = 'isbn', nullable = false)
+    String isbn
+
+    @ManyToOne
+    Genre genre
+
+    Book() {}
+
+    Book(@NotNull String isbn,
+         @NotNull String name,
+         Genre genre) {
+        this.isbn = isbn
+        this.name = name
+        this.genre = genre
+    }
+
+    @Override
+    String toString() {
+        "Book{id=$id, name='$name', isbn='$isbn', genre=$genre}"
+    }
+}

--- a/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/domain/Genre.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/main/groovy/example/micronaut/domain/Genre.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut.domain
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import groovy.transform.CompileStatic
+import io.micronaut.serde.annotation.Serdeable
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+
+import static jakarta.persistence.GenerationType.AUTO
+
+@CompileStatic
+@Serdeable
+@Entity
+@Table(name = 'genre')
+class Genre {
+
+    @Id
+    @GeneratedValue(strategy = AUTO)
+    Long id
+
+    @NotNull
+    @Column(name = 'name', nullable = false, unique = true)
+    String name
+
+    @JsonIgnore
+    @OneToMany(mappedBy = 'genre')
+    Set<Book> books = []
+
+    Genre() {}
+
+    Genre(@NotNull String name) {
+        this.name = name
+    }
+
+    @Override
+    String toString() {
+        "Genre{id=$id, name='$name'}"
+    }
+}

--- a/guides/micronaut-hibernate-reactive/groovy/src/test/groovy/example/micronaut/GenreControllerSpec.groovy
+++ b/guides/micronaut-hibernate-reactive/groovy/src/test/groovy/example/micronaut/GenreControllerSpec.groovy
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import example.micronaut.domain.Genre
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+import static io.micronaut.http.HttpHeaders.LOCATION
+import static io.micronaut.http.HttpStatus.BAD_REQUEST
+import static io.micronaut.http.HttpStatus.CREATED
+import static io.micronaut.http.HttpStatus.NOT_FOUND
+import static io.micronaut.http.HttpStatus.NO_CONTENT
+
+@MicronautTest // <1>
+class GenreControllerSpec extends Specification {
+
+    private BlockingHttpClient blockingClient
+
+    @Inject
+    @Client('/')
+    HttpClient client // <2>
+
+    void setup() {
+        blockingClient = client.toBlocking()
+    }
+
+    void supplyAnInvalidOrderTriggersValidationFailure() {
+
+        when:
+        blockingClient.exchange(HttpRequest.GET('/genres/list?order=foo'))
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.response
+        BAD_REQUEST == e.status
+    }
+
+    void testFindNonExistingGenreReturns404() {
+        when:
+        blockingClient.exchange(HttpRequest.GET('/genres/99'))
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.response
+        NOT_FOUND == e.status
+    }
+
+    void testGenreCrudOperations() {
+
+        given:
+        List<Long> genreIds = []
+
+        when:
+        HttpRequest<?> request = HttpRequest.POST('/genres', new GenreSaveCommand('DevOps')) // <3>
+        HttpResponse<?> response = blockingClient.exchange(request)
+        genreIds << entityId(response)
+
+        then:
+        CREATED == response.status
+
+        when:
+        request = HttpRequest.POST('/genres', new GenreSaveCommand('Microservices')) // <3>
+        response = blockingClient.exchange(request)
+
+        then:
+        CREATED == response.status
+
+        when:
+        Long id = entityId(response)
+        genreIds << id
+        request = HttpRequest.GET('/genres/' + id)
+
+        Genre genre = blockingClient.retrieve(request, Genre) // <4>
+
+        then:
+        'Microservices' == genre.name
+
+        when:
+        request = HttpRequest.PUT('/genres', new GenreUpdateCommand(id, 'Micro-services'))
+        response = blockingClient.exchange(request)  // <5>
+
+        then:
+        NO_CONTENT == response.status
+
+        when:
+        request = HttpRequest.GET('/genres/' + id)
+        genre = blockingClient.retrieve(request, Genre)
+
+        then:
+        'Micro-services' == genre.name
+
+        when:
+        request = HttpRequest.GET('/genres/list')
+        List<Genre> genres = blockingClient.retrieve(request, Argument.of(List, Genre))
+
+        then:
+        2 == genres.size()
+
+        when:
+        request = HttpRequest.POST('/genres/ex', new GenreSaveCommand('Microservices')) // <3>
+        response = blockingClient.exchange(request)
+
+        then:
+        NO_CONTENT == response.status
+
+        when:
+        request = HttpRequest.GET('/genres/list')
+        genres = blockingClient.retrieve(request, Argument.of(List, Genre))
+
+        then:
+        2 == genres.size()
+
+        when:
+        request = HttpRequest.GET('/genres/list?max=1')
+        genres = blockingClient.retrieve(request, Argument.of(List, Genre))
+
+        then:
+        1 == genres.size()
+        'DevOps' == genres[0].name
+
+        when:
+        request = HttpRequest.GET('/genres/list?max=1&order=desc&sort=name')
+        genres = blockingClient.retrieve(request, Argument.of(List, Genre))
+
+        then:
+        1 == genres.size()
+        'Micro-services' == genres[0].name
+
+        when:
+        request = HttpRequest.GET('/genres/list?max=1&offset=10')
+        genres = blockingClient.retrieve(request, Argument.of(List, Genre))
+
+        then:
+        0 == genres.size()
+
+        cleanup:
+        for (Long genreId : genreIds) {
+            request = HttpRequest.DELETE('/genres/' + genreId)
+            response = blockingClient.exchange(request)
+            assert NO_CONTENT == response.status
+        }
+    }
+
+    private Long entityId(HttpResponse response) {
+        String path = '/genres/'
+        String value = response.header(LOCATION)
+        if (value == null) {
+            return null
+        }
+
+        int index = value.indexOf(path)
+        if (index != -1) {
+            return value.substring(index + path.length()) as long
+        }
+
+        null
+    }
+}

--- a/guides/micronaut-hibernate-reactive/metadata.json
+++ b/guides/micronaut-hibernate-reactive/metadata.json
@@ -4,7 +4,7 @@
   "authors": ["Tim Yates","Roman Naglic"],
   "tags": ["database", "hibernate", "mysql", "reactive"],
   "categories": ["Data JPA"],
-  "languages": ["JAVA","KOTLIN"],
+  "languages": ["JAVA","GROOVY","KOTLIN"],
   "skipMavenTests": true,
   "publicationDate": "2022-08-04",
   "apps": [

--- a/guides/micronaut-hibernate-reactive/micronaut-hibernate-reactive.adoc
+++ b/guides/micronaut-hibernate-reactive/micronaut-hibernate-reactive.adoc
@@ -116,7 +116,9 @@ Create a test to verify the CRUD operations:
 test:GenreControllerTest[]
 
 callout:micronaut-test[]
+:exclude-for-languages:groovy
 callout:test-instance-per-class[]
+:exclude-for-languages:
 callout:http-client[]
 callout:http-request[]
 <.> If you care just about the object in the response, use `retrieve`.


### PR DESCRIPTION
## Summary
- Add the Groovy source and Spock test variant for `guides/micronaut-hibernate-reactive`.
- Add `GROOVY` to the guide metadata while preserving Java and Kotlin.
- Hide the JUnit test-instance callout for Groovy/Spock rendering.

Closes #1704

## Release Target
- Target branch: `master`.
- Type label: `type: docs`.
- Micronaut organization project selected by QA: `5.0.1 Release`.
- Ambiguity preserved: `micronaut-guides` has no stable release tags and `master:version.txt` still reports `5.0.0`, while Micronaut Platform `5.0.0` is already GA; `5.0.1 Release` is the earliest open Platform BOM board for a 5.0.x guides change.
- Project-link note: live ProjectV2 association could not be applied in this run because `gh` failed with missing `project` scope for `addProjectV2ItemById`, and the Paperclip plugin tool endpoint returned `403 {"error":"Board access required"}` before dispatch.
- Reviewer-routing note: GitHub rejected requesting `sdelamo` as reviewer with `Review cannot be requested from pull request author.` The PR author is `sdelamo` under the available token.

## Tests
- `./gradlew micronautHibernateReactiveGenerateProjects micronautHibernateReactiveGenerateDocs --stacktrace`
- `./gradlew micronautHibernateReactiveRunTestScript --stacktrace`
- Generated Maven Groovy sample: `./mvnw -q -DskipTests compile test-compile`
- `git diff --check -- guides/micronaut-hibernate-reactive`

`./gradlew micronautHibernateReactiveBuild --stacktrace` was also attempted. It generated the guide output, zips, and entered native tests, then failed in existing generated Java/Kotlin native-test compilation because the local GraalVM installation does not provide the reachability-metadata schema required by the configured native-build-tools metadata repository. The failure happened before any Groovy native-test path and is recorded as a local toolchain gap.

## PR Assets
N/A: this is a source-only guide variant update; generated Groovy Gradle/Maven outputs were validated locally.

---
###### ✨ This message was AI-generated using gpt-5
