### PR TITLE
Add Groovy version for micronaut-openpdf guide

### DIFF
--- a/guides/micronaut-openpdf/groovy/src/main/groovy/example/micronaut/PDFController.groovy
+++ b/guides/micronaut-openpdf/groovy/src/main/groovy/example/micronaut/PDFController.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.lowagie.text.Document
+import com.lowagie.text.Paragraph
+import com.lowagie.text.pdf.PdfWriter
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.core.io.Writable
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+
+import java.nio.charset.Charset
+
+@Controller('/pdf') // <1>
+class PDFController {
+
+    @ExecuteOn(TaskExecutors.BLOCKING) // <2>
+    @Get('/download') // <3>
+    HttpResponse<Writable> download() throws IOException { // <4>
+        downloadPdf('example.pdf')
+    }
+
+    private HttpResponse<Writable> downloadPdf(String filename) throws IOException {
+        HttpResponse.ok(pdfWritable())
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=$filename")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_PDF)
+    }
+
+    private Writable pdfWritable() {
+        new Writable() {
+            @Override
+            void writeTo(OutputStream outputStream, @Nullable Charset charset) throws IOException {
+                generatePDF(outputStream)
+            }
+
+            @Override
+            void writeTo(Writer out) {
+            }
+        }
+    }
+
+    private void generatePDF(OutputStream outputStream) {
+        Document document = new Document()
+        try {
+            PdfWriter.getInstance(document, outputStream)
+            document.open()
+            document.newPage()
+            document.add(new Paragraph('Hello World'))
+        } finally {
+            document.close()
+        }
+    }
+}

--- a/guides/micronaut-openpdf/groovy/src/test/groovy/example/micronaut/PDFControllerSpec.groovy
+++ b/guides/micronaut-openpdf/groovy/src/test/groovy/example/micronaut/PDFControllerSpec.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.lowagie.text.pdf.PdfReader
+import com.lowagie.text.pdf.parser.PdfTextExtractor
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Shared
+import spock.lang.Specification
+
+@MicronautTest // <1>
+class PDFControllerSpec extends Specification {
+
+    @Shared
+    @Inject
+    @Client('/')
+    HttpClient httpClient // <2>
+
+    void "test download"() throws IOException {
+        given:
+        BlockingHttpClient client = httpClient.toBlocking()
+
+        when:
+        HttpResponse<byte[]> pdfResponse = client.exchange('/pdf/download', byte[])
+
+        then:
+        noExceptionThrown()
+        pdfResponse.status() == HttpStatus.OK
+        pdfResponse.headers.get(HttpHeaders.CONTENT_TYPE) == MediaType.APPLICATION_PDF
+        pdfResponse.headers.get(HttpHeaders.CONTENT_DISPOSITION) == 'attachment; filename=example.pdf'
+        textAtPage(pdfResponse.body(), 1) == 'Hello World'
+    }
+
+    private static String textAtPage(PdfReader pdfReader, int pageNumber) throws IOException {
+        new PdfTextExtractor(pdfReader).getTextFromPage(pageNumber)
+    }
+
+    private static String textAtPage(byte[] pdfBytes, int pageNumber) throws IOException {
+        PdfReader pdfReader = new PdfReader(pdfBytes)
+        try {
+            textAtPage(pdfReader, pageNumber)
+        } finally {
+            pdfReader.close()
+        }
+    }
+}

--- a/guides/micronaut-openpdf/metadata.json
+++ b/guides/micronaut-openpdf/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["openpdf"],
   "categories": ["Beyond JSON"],
   "publicationDate": "2024-01-03",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary
- Add the Groovy OpenPDF controller sample for `guides/micronaut-openpdf`.
- Add a Spock spec that verifies the PDF download response, headers, and extracted text.
- Enable `GROOVY` in guide metadata while keeping the Kotlin variant out of this PR; Kotlin remains tracked separately by #1741 / MNG-404.

## Verification
- `git diff --check -- guides/micronaut-openpdf`
- `./gradlew micronautOpenpdfRunTestScript --stacktrace`
- `build/code/micronaut-openpdf/micronaut-openpdf-maven-groovy`: `./mvnw -q test spotless:check`
- `./gradlew micronautOpenpdfBuild --stacktrace` still fails in generated `micronaut-openpdf-gradle-java :nativeTestCompile` because the local GraalVM installation lacks reachability metadata schema support required by the configured metadata repository. This is the same local native toolchain limitation recorded by QA and occurs before Groovy-specific native work.

## Release Handoff
- Target branch: `master`
- Type label: `type: docs`
- Micronaut organization project: `5.0.1 Release` (#146)
- Project ambiguity note: `micronaut-guides` does not publish a normal module release consumed by the Platform BOM, so this board is based on the guide repository's current Micronaut 5.0.0 content line and the earliest open Platform release board.

## Routing Notes
- Required issue-creator reviewer request for `sdelamo` was attempted, but GitHub rejected it with HTTP 422: `Review cannot be requested from pull request author.`
- Live project association to `5.0.1 Release` could not be applied from this run: `gh` lacks the required `project` scope for `addProjectV2ItemById`, and the GitHub Sync plugin fallback tool endpoint returned HTTP 403. The selected board remains recorded above.

## PR Assets
No external PR asset is required for this source-only guide language-port change; rendered guide output and generated sample projects are reproducible from the checked source.

Fixes #1740

---
###### ✨ This message was AI-generated using gpt-5