### PR TITLE
Add Kotlin variant for GraalPy guide

### DIFF
--- a/guides/micronaut-graalpy/kotlin/src/main/kotlin/example/micronaut/HelloController.kt
+++ b/guides/micronaut-graalpy/kotlin/src/main/kotlin/example/micronaut/HelloController.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+
+@Controller("/hello") // <1>
+class HelloController(private val hello: HelloModule) { // <2>
+
+    @Get // <3>
+    @Produces(MediaType.TEXT_PLAIN) // <4>
+    fun index(): String = hello.hello("World") // <5>
+}

--- a/guides/micronaut-graalpy/kotlin/src/main/kotlin/example/micronaut/HelloModule.kt
+++ b/guides/micronaut-graalpy/kotlin/src/main/kotlin/example/micronaut/HelloModule.kt
@@ -1,0 +1,8 @@
+package example.micronaut
+
+import io.micronaut.graal.graalpy.annotations.GraalPyModule
+
+@GraalPyModule("hello") // <1>
+interface HelloModule {
+    fun hello(txt: String): String // <2>
+}

--- a/guides/micronaut-graalpy/kotlin/src/main/resources/META-INF/native-image/proxy-config.json
+++ b/guides/micronaut-graalpy/kotlin/src/main/resources/META-INF/native-image/proxy-config.json
@@ -1,0 +1,3 @@
+[
+  ["example.micronaut.HelloModule"]
+]

--- a/guides/micronaut-graalpy/kotlin/src/main/resources/org.graalvm.python.vfs/src/hello.py
+++ b/guides/micronaut-graalpy/kotlin/src/main/resources/org.graalvm.python.vfs/src/hello.py
@@ -1,0 +1,2 @@
+def hello(txt): # <1>
+    return f"Hello {txt}"

--- a/guides/micronaut-graalpy/kotlin/src/test/kotlin/example/micronaut/HelloControllerTest.kt
+++ b/guides/micronaut-graalpy/kotlin/src/test/kotlin/example/micronaut/HelloControllerTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@MicronautTest // <1>
+class HelloControllerTest {
+
+    @Test
+    fun testHelloResponse(@Client("/") client: HttpClient) { // <2>
+        val response = client.toBlocking().retrieve(HttpRequest.GET<Any>("/hello")) // <3>
+        assertEquals("Hello World", response)
+    }
+}

--- a/guides/micronaut-graalpy/kotlin/src/test/kotlin/example/micronaut/HelloModuleTest.kt
+++ b/guides/micronaut-graalpy/kotlin/src/test/kotlin/example/micronaut/HelloModuleTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@MicronautTest(startApplication = false)
+class HelloModuleTest {
+
+    @Test
+    fun testHello(hello: HelloModule) {
+        assertEquals("Hello World", hello.hello("World"))
+    }
+}

--- a/guides/micronaut-graalpy/metadata.json
+++ b/guides/micronaut-graalpy/metadata.json
@@ -3,8 +3,8 @@
   "intro": "Learn how to create a Hello World Micronaut GraalPy application with a controller and a functional test.",
   "authors": ["Tomas Stupka"],
   "tags": ["junit"],
-  "languages": ["JAVA"],
-  "buildTools": ["MAVEN"],
+  "languages": ["JAVA", "KOTLIN"],
+  "buildTools": ["MAVEN", "GRADLE"],
   "categories": ["GraalPy"],
   "publicationDate": "2024-07-01",
   "apps": [

--- a/guides/micronaut-graalpy/micronaut-graalpy.adoc
+++ b/guides/micronaut-graalpy/micronaut-graalpy.adoc
@@ -12,23 +12,23 @@ Part of the "Hello World" functionality will be provided by Python.
 Create a Python file with the following code:
 resource:org.graalvm.python.vfs/src/hello.py[]
 
-<1> The Python function we are going to call from Java
+<1> The Python function we are going to call from the Micronaut application.
 
 All files in the `src/main/resources/org.graalvm.python.vfs/` directory will be accessible to the GraalPy runtime environment.
 The `src` subdirectory is automatically added to the Python search path, making it the ideal location for custom Python files in your application.
 
-=== Java binding
+=== Application binding
 Python code can be accessed programmatically using the https://www.graalvm.org/sdk/javadoc/org/graalvm/polyglot/package-summary.html[GraalVM SDK Polyglot API],
 which enables you to embed Python into your applications.
 
-In order to make it work, we first need a Java interface providing the intended binding to Python.
+In order to make it work, we first need an interface providing the intended binding to Python.
 
-Create a Java interface with the following code:
+Create an interface with the following code:
 source:HelloModule[]
 <1> The https://micronaut-projects.github.io/micronaut-graal-languages/latest/api/io/micronaut/graal/graalpy/annotations/GraalPyModule.html[@GraalPyModule] annotation indicates that the bean created from the interface
-is intended to import the `hello.py` Python module into GraalPy and expose it to the Java code using
+is intended to import the `hello.py` Python module into GraalPy and expose it to the application code using
 the https://www.graalvm.org/truffle/javadoc/org/graalvm/polyglot/Value.html#target-type-mapping-heading[Target type mapping].
-<2> Java method matching the Python function `hello(txt)` in `hello.py`.
+<2> Method matching the Python function `hello(txt)` in `hello.py`.
 
 === Controller
 To create a microservice that responds with "Hello World" you also need a controller.

--- a/src/docs/common/snippets/common-graalpy-graalvm.adoc
+++ b/src/docs/common/snippets/common-graalpy-graalvm.adoc
@@ -59,6 +59,21 @@ resource:META-INF/native-image/proxy-config.json[]
 
 === Native Executable Generation
 
+:exclude-for-build:maven
+
+To generate a native executable using Gradle, run:
+
+[source, bash]
+----
+./gradlew nativeCompile
+----
+
+The native executable is created in the `build/native/nativeCompile` directory and can be run with `build/native/nativeCompile/micronautguide`.
+
+:exclude-for-build:
+
+:exclude-for-build:gradle
+
 To generate a native executable using Maven, run:
 
 [source, bash]
@@ -67,3 +82,7 @@ To generate a native executable using Maven, run:
 ----
 
 The native executable is created in the _target_ directory and can be run with `./target/micronautguide`.
+
+:exclude-for-build:
+
+:exclude-for-languages:


### PR DESCRIPTION
## Summary
- Add a Kotlin variant for `guides/micronaut-graalpy` using the supported Gradle path.
- Preserve the existing Maven Java output while adding Gradle Java and Gradle Kotlin generated variants.
- Update GraalPy guide prose and native executable instructions so Kotlin/Gradle readers do not see Java-only or Maven-only wording.

Fixes #1700

## Review Notes
- Approved target branch: `master`.
- Release target: default-branch 5.0.x line.
- Micronaut organization project selected during QA: `5.0.1 Release`.
- Ambiguity preserved from QA: no open `5.0.0 Release` board was available in the same-day project candidates even though repository version files signaled `5.0.0`.
- Project-link tooling note: local `gh` project lookup could not enumerate Micronaut org projects with the active `GITHUB_TOKEN` because the token lacks `read:org`; alternate local auth lacks `read:project`.
- Reviewer routing note: requesting the linked issue creator `sdelamo` failed because GitHub reports that review cannot be requested from the pull request author.

## Validation
- `git diff --check -- guides/micronaut-graalpy src/docs/common/snippets/common-graalpy-graalvm.adoc` passed.
- `./gradlew micronautGraalpyBuild --stacktrace` generated the expected projects and zips, then failed in local GraalPy runtime initialization for Gradle Java and Gradle Kotlin.
- `./gradlew micronautGraalpyRunTestScript --stacktrace` failed with the same `GraalPyContext` / `PythonResource.versionHash` signature across Maven Java, Gradle Java, and Gradle Kotlin.

The runtime failure is not Kotlin-specific and also affects the pre-existing Maven Java variant in this environment.

## PR Assets
- [Rendered micronaut-graalpy guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/e2a73a7bc89cfb46d843a0e6dc56a18663ca4614/assets/pr-1811/d33945c87da6/mng-363-rendered-micronaut-graalpy.html)

---
###### ✨ This message was AI-generated using gpt-5
