### PR TITLE
Add Kotlin version for micronaut-jpa-hibernate

### DIFF
--- a/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/ApplicationConfiguration.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/ApplicationConfiguration.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+interface ApplicationConfiguration {
+    val max: Int
+}

--- a/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/ApplicationConfigurationProperties.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/ApplicationConfigurationProperties.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.ConfigurationProperties
+
+@ConfigurationProperties("application") // <1>
+class ApplicationConfigurationProperties : ApplicationConfiguration {
+    private val defaultMax = 10
+
+    override var max: Int = defaultMax
+}

--- a/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/GenreController.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/GenreController.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import example.micronaut.domain.Genre
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Delete
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Put
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import jakarta.persistence.PersistenceException
+import jakarta.validation.Valid
+import java.net.URI
+
+@ExecuteOn(TaskExecutors.BLOCKING) // <1>
+@Controller("/genres") // <2>
+open class GenreController(private val genreRepository: GenreRepository) { // <3>
+
+    @Get("/{id}") // <4>
+    fun show(id: Long): Genre? {
+        return genreRepository.findById(id) // <5>
+    }
+
+    @Put // <6>
+    open fun update(@Valid @Body command: GenreUpdateCommand): HttpResponse<*> { // <7>
+        genreRepository.update(command.id, command.name)
+
+        return HttpResponse
+            .noContent<Any>()
+            .header(HttpHeaders.LOCATION, location(command.id).path) // <8>
+    }
+
+    @Get(value = "/list{?args*}") // <9>
+    open fun list(@Valid args: SortingAndOrderArguments): List<Genre> {
+        return genreRepository.findAll(args)
+    }
+
+    @Post // <10>
+    open fun save(@Valid @Body cmd: GenreSaveCommand): HttpResponse<Genre> {
+        val genre = genreRepository.save(cmd.name)
+
+        return HttpResponse
+            .created(genre)
+            .headers { headers -> headers.location(location(genre.id!!)) }
+    }
+
+    @Post("/ex") // <11>
+    open fun saveExceptions(@Valid @Body cmd: GenreSaveCommand): HttpResponse<Genre> {
+        return try {
+            val genre = genreRepository.saveWithException(cmd.name)
+            HttpResponse
+                .created(genre)
+                .headers { headers -> headers.location(location(genre.id!!)) }
+        } catch (e: PersistenceException) {
+            HttpResponse.noContent()
+        }
+    }
+
+    @Delete("/{id}") // <12>
+    open fun delete(id: Long): HttpResponse<*> {
+        genreRepository.deleteById(id)
+        return HttpResponse.noContent<Any>()
+    }
+
+    private fun location(id: Long): URI {
+        return URI.create("/genres/$id")
+    }
+}

--- a/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/GenreRepository.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/GenreRepository.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import example.micronaut.domain.Genre
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+interface GenreRepository {
+
+    fun findById(id: Long): Genre?
+
+    fun save(@NotBlank name: String): Genre
+
+    fun saveWithException(@NotBlank name: String): Genre
+
+    fun deleteById(id: Long)
+
+    fun findAll(@NotNull args: SortingAndOrderArguments): List<Genre>
+
+    fun update(id: Long, @NotBlank name: String): Int
+}

--- a/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/GenreRepositoryImpl.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/GenreRepositoryImpl.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import example.micronaut.domain.Genre
+import io.micronaut.transaction.annotation.ReadOnly
+import io.micronaut.transaction.annotation.Transactional
+import jakarta.inject.Singleton
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceException
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+@Singleton // <1>
+open class GenreRepositoryImpl(
+    private val entityManager: EntityManager, // <2>
+    private val applicationConfiguration: ApplicationConfiguration
+) : GenreRepository {
+
+    private val validPropertyNames = listOf("id", "name")
+
+    @ReadOnly // <3>
+    override fun findById(id: Long): Genre? {
+        return entityManager.find(Genre::class.java, id)
+    }
+
+    @Transactional // <4>
+    override fun save(@NotBlank name: String): Genre {
+        val genre = Genre(name = name)
+        entityManager.persist(genre)
+        return genre
+    }
+
+    @Transactional // <4>
+    override fun deleteById(id: Long) {
+        findById(id)?.let { entityManager.remove(it) }
+    }
+
+    @ReadOnly // <3>
+    override fun findAll(@NotNull args: SortingAndOrderArguments): List<Genre> {
+        var qlString = "SELECT g FROM Genre as g"
+        val order = args.order
+        val sort = args.sort
+        if (order != null && sort != null && validPropertyNames.contains(sort)) {
+            qlString += " ORDER BY g.$sort ${order.lowercase()}"
+        }
+        val query = entityManager.createQuery(qlString, Genre::class.java)
+        query.maxResults = args.max ?: applicationConfiguration.max
+        args.offset?.let { query.firstResult = it }
+        return query.resultList
+    }
+
+    @Transactional // <4>
+    override fun update(id: Long, @NotBlank name: String): Int {
+        return entityManager.createQuery("UPDATE Genre g SET name = :name where id = :id")
+            .setParameter("name", name)
+            .setParameter("id", id)
+            .executeUpdate()
+    }
+
+    @Transactional // <4>
+    override fun saveWithException(@NotBlank name: String): Genre {
+        save(name)
+        throw PersistenceException()
+    }
+}

--- a/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/GenreSaveCommand.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/GenreSaveCommand.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.validation.constraints.NotBlank
+
+@Serdeable // <1>
+data class GenreSaveCommand(@field:NotBlank var name: String)

--- a/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/GenreUpdateCommand.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/GenreUpdateCommand.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.validation.constraints.NotBlank
+
+@Serdeable
+data class GenreUpdateCommand(
+    var id: Long,
+    @field:NotBlank var name: String
+)

--- a/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/SortingAndOrderArguments.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/SortingAndOrderArguments.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.PositiveOrZero
+
+@Serdeable
+data class SortingAndOrderArguments(
+    @field:PositiveOrZero // <1>
+    var offset: Int? = null,
+
+    @field:Positive // <1>
+    var max: Int? = null,
+
+    @field:Pattern(regexp = "id|name") // <1>
+    var sort: String? = null,
+
+    @field:Pattern(regexp = "asc|ASC|desc|DESC") // <1>
+    var order: String? = null
+)

--- a/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/domain/Book.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/domain/Book.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut.domain
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+
+@Serdeable
+@Entity
+@Table(name = "book")
+class Book(
+    @field:NotNull
+    @Column(name = "isbn", nullable = false)
+    var isbn: String,
+
+    @field:NotNull
+    @Column(name = "name", nullable = false)
+    var name: String,
+
+    @ManyToOne
+    var genre: Genre?
+) {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    var id: Long? = null
+
+    override fun toString(): String {
+        return "Book{id=$id, name='$name', isbn='$isbn', genre=$genre}"
+    }
+}

--- a/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/domain/Genre.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/main/kotlin/example/micronaut/domain/Genre.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut.domain
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotNull
+
+@Serdeable
+@Entity
+@Table(name = "genre")
+class Genre(
+    @field:NotNull
+    @Column(name = "name", nullable = false, unique = true)
+    var name: String
+) {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    var id: Long? = null
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "genre")
+    var books: MutableSet<Book> = HashSet()
+
+    override fun toString(): String {
+        return "Genre{id=$id, name='$name'}"
+    }
+}

--- a/guides/micronaut-jpa-hibernate/kotlin/src/test/kotlin/example/micronaut/GenreControllerTest.kt
+++ b/guides/micronaut-jpa-hibernate/kotlin/src/test/kotlin/example/micronaut/GenreControllerTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import example.micronaut.domain.Genre
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@MicronautTest // <1>
+class GenreControllerTest {
+
+    private lateinit var blockingClient: BlockingHttpClient
+
+    @Inject
+    @field:Client("/")
+    lateinit var client: HttpClient // <2>
+
+    @BeforeEach
+    fun setup() {
+        blockingClient = client.toBlocking()
+    }
+
+    @Test
+    fun supplyAnInvalidOrderTriggersValidationFailure() {
+        val thrown = assertThrows(HttpClientResponseException::class.java) {
+            blockingClient.exchange<Any, Any>(HttpRequest.GET("/genres/list?order=foo"))
+        }
+
+        assertNotNull(thrown.response)
+        assertEquals(HttpStatus.BAD_REQUEST, thrown.status)
+    }
+
+    @Test
+    fun testFindNonExistingGenreReturns404() {
+        val thrown = assertThrows(HttpClientResponseException::class.java) {
+            blockingClient.exchange<Any, Any>(HttpRequest.GET("/genres/99"))
+        }
+
+        assertNotNull(thrown.response)
+        assertEquals(HttpStatus.NOT_FOUND, thrown.status)
+    }
+
+    @Test
+    fun testGenreCrudOperations() {
+        val genreIds = mutableListOf<Long?>()
+
+        val devOpsRequest = HttpRequest.POST("/genres", GenreSaveCommand("DevOps")) // <3>
+        var response: HttpResponse<Genre> = blockingClient.exchange(devOpsRequest, Genre::class.java)
+        genreIds.add(entityId(response))
+
+        assertEquals(HttpStatus.CREATED, response.status)
+
+        val microservicesRequest = HttpRequest.POST("/genres", GenreSaveCommand("Microservices")) // <3>
+        response = blockingClient.exchange(microservicesRequest, Genre::class.java)
+
+        assertEquals(HttpStatus.CREATED, response.status)
+
+        val id = entityId(response)
+        genreIds.add(id)
+        var getRequest = HttpRequest.GET<Any>("/genres/$id")
+
+        var genre = blockingClient.retrieve(getRequest, Genre::class.java) // <4>
+
+        assertEquals("Microservices", genre.name)
+
+        val updateRequest = HttpRequest.PUT("/genres", GenreUpdateCommand(id!!, "Micro-services"))
+        response = blockingClient.exchange(updateRequest, Genre::class.java) // <5>
+
+        assertEquals(HttpStatus.NO_CONTENT, response.status)
+
+        getRequest = HttpRequest.GET("/genres/$id")
+        genre = blockingClient.retrieve(getRequest, Genre::class.java)
+        assertEquals("Micro-services", genre.name)
+
+        getRequest = HttpRequest.GET("/genres/list")
+        var genres = blockingClient.retrieve(getRequest, Argument.listOf(Genre::class.java))
+
+        assertEquals(2, genres.size)
+
+        val exceptionRequest = HttpRequest.POST("/genres/ex", GenreSaveCommand("Microservices")) // <3>
+        response = blockingClient.exchange(exceptionRequest, Genre::class.java)
+
+        assertEquals(HttpStatus.NO_CONTENT, response.status)
+
+        getRequest = HttpRequest.GET("/genres/list")
+        genres = blockingClient.retrieve(getRequest, Argument.listOf(Genre::class.java))
+
+        assertEquals(2, genres.size)
+
+        getRequest = HttpRequest.GET("/genres/list?max=1")
+        genres = blockingClient.retrieve(getRequest, Argument.listOf(Genre::class.java))
+
+        assertEquals(1, genres.size)
+        assertEquals("DevOps", genres[0].name)
+
+        getRequest = HttpRequest.GET("/genres/list?max=1&order=desc&sort=name")
+        genres = blockingClient.retrieve(getRequest, Argument.listOf(Genre::class.java))
+
+        assertEquals(1, genres.size)
+        assertEquals("Micro-services", genres[0].name)
+
+        getRequest = HttpRequest.GET("/genres/list?max=1&offset=10")
+        genres = blockingClient.retrieve(getRequest, Argument.listOf(Genre::class.java))
+
+        assertEquals(0, genres.size)
+
+        // cleanup:
+        for (genreId in genreIds) {
+            val deleteRequest = HttpRequest.DELETE<Any>("/genres/$genreId")
+            response = blockingClient.exchange(deleteRequest, Genre::class.java)
+            assertEquals(HttpStatus.NO_CONTENT, response.status)
+        }
+    }
+
+    private fun entityId(response: HttpResponse<*>): Long? {
+        val path = "/genres/"
+        val value = response.header(HttpHeaders.LOCATION) ?: return null
+        val id = value.substringAfter(path)
+        if (id.isBlank()) {
+            return null
+        }
+        return id.toLong()
+    }
+}

--- a/guides/micronaut-jpa-hibernate/metadata.json
+++ b/guides/micronaut-jpa-hibernate/metadata.json
@@ -5,7 +5,7 @@
   "tags": [],
   "categories": ["Data JPA"],
   "publicationDate": "2018-09-01",
-  "languages": ["JAVA", "GROOVY"],
+  "languages": ["JAVA", "GROOVY", "KOTLIN"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary
- Adds `KOTLIN` to the `micronaut-jpa-hibernate` guide metadata.
- Adds the Kotlin JPA/Hibernate sample implementation and JUnit 5 controller test under `guides/micronaut-jpa-hibernate/kotlin/`.
- Keeps the implementation aligned with the existing Java and Groovy guide variants.

## Verification
- `git diff --check -- guides/micronaut-jpa-hibernate/metadata.json guides/micronaut-jpa-hibernate/kotlin`
- `./gradlew micronautJpaHibernateRunTestScript --stacktrace`
- `./gradlew micronautJpaHibernateBuild -x micronautJpaHibernateRunNativeTestScript --stacktrace`

Full native guide validation was previously attempted during QA and failed only in `micronautJpaHibernateRunNativeTestScript` because the local GraalVM installation does not support the configured reachability metadata schema; QA confirmed the same mismatch affects generated Java before/alongside Kotlin.

## Release Metadata
- Target branch: `master`
- Release target: default branch `5.0.0` docs/source line
- Micronaut organization project selected during QA intake: `5.0.1 Release`
- Live project link: attempted for `5.0.1 Release`, but GitHub rejected the mutation because the active token lacks the `project` scope.
- Ambiguity note: no open `5.0.0 Release` board was available during intake, so `5.0.1 Release` was selected as the earliest open public Micronaut Platform BOM release board for default-branch guide work.
- Type label: `type: docs`

## Reviewer Routing
- Linked GitHub issue creator/reporter: `sdelamo`.
- Reviewer request attempted for `sdelamo`; GitHub rejected it with `Review cannot be requested from pull request author.`

## PR Assets
- [Generated Kotlin guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/0b275fa5cf46b55007d77be0517cd74e69a4572a/assets/pr-1812/f563fa706843/micronaut-jpa-hibernate-gradle-kotlin.html)
- Generated Kotlin guide ZIP upload attempted; Paperclip asset upload returned HTTP 413 for `micronaut-jpa-hibernate-gradle-kotlin.zip`.

Closes #1710

---
###### ✨ This message was AI-generated using gpt-5
