### PR TITLE
Add Kotlin version of Micronaut DynamoDB guide

### DIFF
--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/Application.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/Application.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.ApplicationContextConfigurer
+import io.micronaut.context.annotation.ContextConfigurer
+import io.micronaut.context.env.Environment
+import io.micronaut.runtime.Micronaut.run
+
+@ContextConfigurer
+class DefaultEnvironmentConfigurer : ApplicationContextConfigurer {
+    override fun configure(builder: ApplicationContextBuilder) {
+        builder.defaultEnvironments(Environment.DEVELOPMENT)
+    }
+}
+
+fun main(args: Array<String>) {
+    run(*args)
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/Book.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/Book.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.validation.constraints.NotBlank
+
+@Serdeable // <1>
+data class Book(
+    @field:NotBlank // <2>
+    override val id: String,
+
+    @field:NotBlank // <2>
+    val isbn: String,
+
+    @field:NotBlank // <2>
+    val name: String
+) : Identified

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/BookRepository.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/BookRepository.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import jakarta.validation.constraints.NotBlank
+import java.util.Optional
+
+interface BookRepository {
+    fun findAll(): List<Book>
+
+    fun findById(@NotBlank id: String): Optional<Book>
+
+    fun delete(@NotBlank id: String)
+
+    fun save(
+        @NotBlank isbn: String,
+        @NotBlank name: String
+    ): String
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/BooksController.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/BooksController.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Delete
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Status
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import jakarta.validation.constraints.NotBlank
+import java.util.Optional
+
+@ExecuteOn(TaskExecutors.BLOCKING) // <1>
+@Controller("/books") // <2>
+open class BooksController(
+    private val bookRepository: BookRepository // <3>
+) {
+
+    @Get // <4>
+    open fun index(): List<Book> = bookRepository.findAll()
+
+    @Post // <5>
+    open fun save(
+        @Body("isbn") @NotBlank isbn: String, // <6>
+        @Body("name") @NotBlank name: String
+    ): HttpResponse<*> {
+        val id = bookRepository.save(isbn, name)
+        return HttpResponse.created<Any>(UriBuilder.of("/books").path(id).build())
+    }
+
+    @Get("/{id}") // <7>
+    open fun show(@PathVariable @NotBlank id: String): Optional<Book> = // <8>
+        bookRepository.findById(id)
+
+    @Delete("/{id}") // <9>
+    @Status(HttpStatus.NO_CONTENT) // <10>
+    open fun delete(@PathVariable @NotBlank id: String) {
+        bookRepository.delete(id)
+    }
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/CIAwsCredentialsProviderChainCondition.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/CIAwsCredentialsProviderChainCondition.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.condition.Condition
+import io.micronaut.context.condition.ConditionContext
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * @see <a href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/ec2-iam-roles.html">AWS Default credentials provider chain</a>
+ */
+class CIAwsCredentialsProviderChainCondition : Condition {
+
+    override fun matches(context: ConditionContext<*>): Boolean {
+        if (System.getenv("CI") == null) {
+            LOG.info("CI environment variable not present - Condition fulfilled")
+            return true
+        }
+        if (System.getProperty("aws.accessKeyId") != null && System.getProperty("aws.secretAccessKey") != null) {
+            LOG.info("system properties aws.accessKeyId and aws.secretAccessKey present - Condition fulfilled")
+            return true
+        }
+        if (System.getenv("AWS_ACCESS_KEY_ID") != null && System.getenv("AWS_SECRET_ACCESS_KEY") != null) {
+            LOG.info("environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY present - Condition fulfilled")
+            return true
+        }
+        if (System.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") != null) {
+            LOG.info("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI environment variable present - Condition fulfilled")
+            return true
+        }
+        val home = System.getenv("HOME")
+        val result = home != null && File("$home/.aws/credentials").exists()
+        if (result) {
+            LOG.info("~/.aws/credentials file exists - Condition fulfilled")
+        }
+        return result
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(CIAwsCredentialsProviderChainCondition::class.java)
+    }
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/CIAwsRegionProviderChainCondition.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/CIAwsRegionProviderChainCondition.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.condition.Condition
+import io.micronaut.context.condition.ConditionContext
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * @see <a href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html">Default region provider chain</a>
+ */
+class CIAwsRegionProviderChainCondition : Condition {
+
+    override fun matches(context: ConditionContext<*>): Boolean {
+        if (System.getenv("CI") == null) {
+            LOG.info("CI environment variable not present - Condition fulfilled")
+            return true
+        }
+        if (System.getProperty("aws.region") != null) {
+            LOG.info("aws.region system property present - Condition fulfilled")
+            return true
+        }
+        if (System.getenv("AWS_REGION") != null) {
+            LOG.info("AWS_REGION environment variable present - Condition fulfilled")
+            return true
+        }
+        val home = System.getenv("HOME")
+        val result = home != null && File("$home/.aws/config").exists()
+        if (result) {
+            LOG.info("~/.aws/config file exists - Condition fulfilled")
+        }
+        return result
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(CIAwsRegionProviderChainCondition::class.java)
+    }
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/DefaultBookRepository.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/DefaultBookRepository.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.util.CollectionUtils
+import jakarta.inject.Singleton
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse
+import java.util.Optional
+
+@Singleton // <1>
+open class DefaultBookRepository(
+    dynamoDbClient: DynamoDbClient,
+    dynamoConfiguration: DynamoConfiguration,
+    private val idGenerator: IdGenerator
+) : DynamoRepository<Book>(dynamoDbClient, dynamoConfiguration), BookRepository {
+
+    open override fun save(
+        @NotBlank isbn: String,
+        @NotBlank name: String
+    ): String {
+        val id = idGenerator.generate()
+        save(Book(id, isbn, name))
+        return id
+    }
+
+    protected open fun save(@NotNull @Valid book: Book) {
+        val itemResponse = dynamoDbClient.putItem(
+            PutItemRequest.builder()
+                .tableName(dynamoConfiguration.tableName)
+                .item(item(book))
+                .build()
+        )
+        if (LOG.isDebugEnabled) {
+            LOG.debug(itemResponse.toString())
+        }
+    }
+
+    open override fun findById(@NotBlank id: String): Optional<Book> =
+        findById(Book::class.java, id).map { bookOf(it) }
+
+    open override fun delete(@NotBlank id: String) {
+        delete(Book::class.java, id)
+    }
+
+    open override fun findAll(): List<Book> {
+        val result = mutableListOf<Book>()
+        var beforeId: String? = null
+        do {
+            val request = findAllQueryRequest(Book::class.java, beforeId, null)
+            val response = dynamoDbClient.query(request)
+            if (LOG.isTraceEnabled) {
+                LOG.trace(response.toString())
+            }
+            result.addAll(parseInResponse(response))
+            beforeId = lastEvaluatedId(response, Book::class.java).orElse(null)
+        } while (beforeId != null) // <2>
+        return result
+    }
+
+    private fun parseInResponse(response: QueryResponse): List<Book> {
+        val items = response.items()
+        val result = mutableListOf<Book>()
+        if (CollectionUtils.isNotEmpty(items)) {
+            for (item in items) {
+                result.add(bookOf(item))
+            }
+        }
+        return result
+    }
+
+    private fun bookOf(item: Map<String, AttributeValue>): Book =
+        Book(
+            item.getValue(ATTRIBUTE_ID).s(),
+            item.getValue(ATTRIBUTE_ISBN).s(),
+            item.getValue(ATTRIBUTE_NAME).s()
+        )
+
+    open override fun item(entity: Book): MutableMap<String, AttributeValue> {
+        val result = super.item(entity)
+        result[ATTRIBUTE_ID] = AttributeValue.builder().s(entity.id).build()
+        result[ATTRIBUTE_ISBN] = AttributeValue.builder().s(entity.isbn).build()
+        result[ATTRIBUTE_NAME] = AttributeValue.builder().s(entity.name).build()
+        return result
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(DefaultBookRepository::class.java)
+        private const val ATTRIBUTE_ID = "id"
+        private const val ATTRIBUTE_ISBN = "isbn"
+        private const val ATTRIBUTE_NAME = "name"
+    }
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/DevBootstrap.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/DevBootstrap.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.context.event.StartupEvent
+import jakarta.inject.Singleton
+
+@Requires(property = "dynamodb-local.host") // <1>
+@Requires(property = "dynamodb-local.port") // <1>
+@Requires(env = [Environment.DEVELOPMENT]) // <2>
+@Singleton // <3>
+class DevBootstrap(
+    private val dynamoRepository: DynamoRepository<out Identified>
+) : ApplicationEventListener<StartupEvent> {
+
+    override fun onApplicationEvent(event: StartupEvent) {
+        if (!dynamoRepository.existsTable()) {
+            dynamoRepository.createTable()
+        }
+    }
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/DynamoConfiguration.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/DynamoConfiguration.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.context.annotation.Requires
+import jakarta.validation.constraints.NotBlank
+
+@Requires(property = "dynamodb.table-name") // <1>
+@ConfigurationProperties("dynamodb") // <2>
+interface DynamoConfiguration {
+    @get:NotBlank
+    val tableName: String
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/DynamoDbClientBuilderListener.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/DynamoDbClientBuilderListener.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Value
+import io.micronaut.context.event.BeanCreatedEvent
+import io.micronaut.context.event.BeanCreatedEventListener
+import io.micronaut.context.exceptions.ConfigurationException
+import jakarta.inject.Singleton
+import software.amazon.awssdk.auth.credentials.AwsCredentials
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder
+import java.net.URI
+import java.net.URISyntaxException
+
+@Requires(property = "dynamodb-local.host") // <1>
+@Requires(property = "dynamodb-local.port") // <1>
+@Singleton // <2>
+class DynamoDbClientBuilderListener(
+    @Value("\${dynamodb-local.host}") host: String, // <4>
+    @Value("\${dynamodb-local.port}") port: String // <4>
+) : BeanCreatedEventListener<DynamoDbClientBuilder> { // <3>
+
+    private val endpoint: URI
+    private val accessKeyId = "fakeMyKeyId"
+    private val secretAccessKey = "fakeSecretAccessKey"
+
+    init {
+        endpoint = try {
+            URI("http://$host:$port")
+        } catch (e: URISyntaxException) {
+            throw ConfigurationException("dynamodb.endpoint not a valid URI")
+        }
+    }
+
+    override fun onCreated(event: BeanCreatedEvent<DynamoDbClientBuilder>): DynamoDbClientBuilder =
+        event.bean.endpointOverride(endpoint)
+            .credentialsProvider {
+                object : AwsCredentials {
+                    override fun accessKeyId(): String = accessKeyId
+
+                    override fun secretAccessKey(): String = secretAccessKey
+                }
+            }
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/DynamoRepository.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/DynamoRepository.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.BillingMode
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement
+import software.amazon.awssdk.services.dynamodb.model.KeyType
+import software.amazon.awssdk.services.dynamodb.model.Projection
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
+import java.util.Optional
+
+@Requires(condition = CIAwsRegionProviderChainCondition::class)
+@Requires(condition = CIAwsCredentialsProviderChainCondition::class)
+@Requires(beans = [DynamoConfiguration::class, DynamoDbClient::class])
+@Singleton
+@Primary
+open class DynamoRepository<T : Identified>(
+    protected val dynamoDbClient: DynamoDbClient,
+    protected val dynamoConfiguration: DynamoConfiguration
+) {
+
+    fun existsTable(): Boolean =
+        try {
+            dynamoDbClient.describeTable(
+                DescribeTableRequest.builder()
+                    .tableName(dynamoConfiguration.tableName)
+                    .build()
+            )
+            true
+        } catch (e: ResourceNotFoundException) {
+            false
+        }
+
+    fun createTable() {
+        dynamoDbClient.createTable(
+            CreateTableRequest.builder()
+                .attributeDefinitions(
+                    AttributeDefinition.builder()
+                        .attributeName(ATTRIBUTE_PK)
+                        .attributeType(ScalarAttributeType.S)
+                        .build(),
+                    AttributeDefinition.builder()
+                        .attributeName(ATTRIBUTE_SK)
+                        .attributeType(ScalarAttributeType.S)
+                        .build(),
+                    AttributeDefinition.builder()
+                        .attributeName(ATTRIBUTE_GSI_1_PK)
+                        .attributeType(ScalarAttributeType.S)
+                        .build(),
+                    AttributeDefinition.builder()
+                        .attributeName(ATTRIBUTE_GSI_1_SK)
+                        .attributeType(ScalarAttributeType.S)
+                        .build()
+                )
+                .keySchema(
+                    KeySchemaElement.builder()
+                        .attributeName(ATTRIBUTE_PK)
+                        .keyType(KeyType.HASH)
+                        .build(),
+                    KeySchemaElement.builder()
+                        .attributeName(ATTRIBUTE_SK)
+                        .keyType(KeyType.RANGE)
+                        .build()
+                )
+                .billingMode(BillingMode.PAY_PER_REQUEST)
+                .tableName(dynamoConfiguration.tableName)
+                .globalSecondaryIndexes(gsi1())
+                .build()
+        )
+    }
+
+    open fun findAllQueryRequest(
+        cls: Class<*>,
+        beforeId: String?,
+        limit: Int?
+    ): QueryRequest {
+        val builder = QueryRequest.builder()
+            .tableName(dynamoConfiguration.tableName)
+            .indexName(INDEX_GSI_1)
+            .scanIndexForward(false)
+        if (limit != null) {
+            builder.limit(limit)
+        }
+        return if (beforeId == null) {
+            builder.keyConditionExpression("#pk = :pk")
+                .expressionAttributeNames(mapOf("#pk" to ATTRIBUTE_GSI_1_PK))
+                .expressionAttributeValues(mapOf(":pk" to classAttributeValue(cls)))
+                .build()
+        } else {
+            builder.keyConditionExpression("#pk = :pk and #sk < :sk")
+                .expressionAttributeNames(mapOf("#pk" to ATTRIBUTE_GSI_1_PK, "#sk" to ATTRIBUTE_GSI_1_SK))
+                .expressionAttributeValues(mapOf(":pk" to classAttributeValue(cls), ":sk" to id(cls, beforeId)))
+                .build()
+        }
+    }
+
+    protected open fun delete(@NotNull cls: Class<*>, @NotBlank id: String) {
+        val pk = id(cls, id)
+        val deleteItemResponse = dynamoDbClient.deleteItem(
+            DeleteItemRequest.builder()
+                .tableName(dynamoConfiguration.tableName)
+                .key(mapOf(ATTRIBUTE_PK to pk, ATTRIBUTE_SK to pk))
+                .build()
+        )
+        if (LOG.isDebugEnabled) {
+            LOG.debug(deleteItemResponse.toString())
+        }
+    }
+
+    protected open fun findById(@NotNull cls: Class<*>, @NotBlank id: String): Optional<Map<String, AttributeValue>> {
+        val pk = id(cls, id)
+        val getItemResponse = dynamoDbClient.getItem(
+            GetItemRequest.builder()
+                .tableName(dynamoConfiguration.tableName)
+                .key(mapOf(ATTRIBUTE_PK to pk, ATTRIBUTE_SK to pk))
+                .build()
+        )
+        return if (!getItemResponse.hasItem()) Optional.empty() else Optional.of(getItemResponse.item())
+    }
+
+    protected open fun item(entity: T): MutableMap<String, AttributeValue> {
+        val item = mutableMapOf<String, AttributeValue>()
+        val pk = id(entity.javaClass, entity.id)
+        item[ATTRIBUTE_PK] = pk
+        item[ATTRIBUTE_SK] = pk
+        item[ATTRIBUTE_GSI_1_PK] = classAttributeValue(entity.javaClass)
+        item[ATTRIBUTE_GSI_1_SK] = pk
+        return item
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(DynamoRepository::class.java)
+        private const val HASH = "#"
+        private const val ATTRIBUTE_PK = "pk"
+        private const val ATTRIBUTE_SK = "sk"
+        private const val ATTRIBUTE_GSI_1_PK = "GSI1PK"
+        private const val ATTRIBUTE_GSI_1_SK = "GSI1SK"
+        private const val INDEX_GSI_1 = "GSI1"
+
+        fun lastEvaluatedId(response: QueryResponse, cls: Class<*>): Optional<String> {
+            if (response.hasLastEvaluatedKey()) {
+                val item = response.lastEvaluatedKey()
+                if (item != null && item.containsKey(ATTRIBUTE_PK)) {
+                    return id(cls, item.getValue(ATTRIBUTE_PK))
+                }
+            }
+            return Optional.empty()
+        }
+
+        private fun gsi1(): GlobalSecondaryIndex =
+            GlobalSecondaryIndex.builder()
+                .indexName(INDEX_GSI_1)
+                .keySchema(
+                    KeySchemaElement.builder()
+                        .attributeName(ATTRIBUTE_GSI_1_PK)
+                        .keyType(KeyType.HASH)
+                        .build(),
+                    KeySchemaElement.builder()
+                        .attributeName(ATTRIBUTE_GSI_1_SK)
+                        .keyType(KeyType.RANGE)
+                        .build()
+                )
+                .projection(
+                    Projection.builder()
+                        .projectionType(ProjectionType.ALL)
+                        .build()
+                )
+                .build()
+
+        private fun classAttributeValue(cls: Class<*>): AttributeValue =
+            AttributeValue.builder()
+                .s(cls.simpleName)
+                .build()
+
+        private fun id(cls: Class<*>, id: String): AttributeValue =
+            AttributeValue.builder()
+                .s(listOf(cls.simpleName.uppercase(), id).joinToString(HASH))
+                .build()
+
+        private fun id(cls: Class<*>, attributeValue: AttributeValue): Optional<String> {
+            val str = attributeValue.s()
+            val substring = cls.simpleName.uppercase() + HASH
+            return if (str.startsWith(substring)) Optional.of(str.substring(substring.length)) else Optional.empty()
+        }
+    }
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/Identified.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/Identified.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+interface Identified {
+    val id: String
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/KsuidGenerator.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/main/kotlin/example/micronaut/KsuidGenerator.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.github.ksuid.Ksuid
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Requires(classes = [Ksuid::class]) // <1>
+@Singleton // <2>
+class KsuidGenerator : IdGenerator {
+    override fun generate(): String = Ksuid.newKsuid().toString()
+}

--- a/guides/micronaut-dynamodb/kotlin/src/main/resources/application.properties
+++ b/guides/micronaut-dynamodb/kotlin/src/main/resources/application.properties
@@ -1,0 +1,20 @@
+micronaut.application.name=bookcatalogue
+endpoints.health.enabled=true
+endpoints.health.sensitive=false
+#tag::otel[]
+otel.traces.exporter=otlp
+otel.traces.propagator=tracecontext, baggage, xray
+otel.traces.exclusions=/health
+#end::otel[]
+netty.default.allocator.max-order=3
+#tag::dynamodb[]
+dynamodb.table-name=bookcatalogue
+#end::dynamodb[]
+#tag::testresources[]
+# <1>
+test-resources.containers.dynamodb.image-name=amazon/dynamodb-local
+# <2>
+test-resources.containers.dynamodb.hostnames[0]=dynamodb-local.host
+# <3>
+test-resources.containers.dynamodb.exposed-ports[0].dynamodb-local.port=8000
+#end::testresources[]

--- a/guides/micronaut-dynamodb/kotlin/src/test/kotlin/example/micronaut/BooksControllerTest.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/test/kotlin/example/micronaut/BooksControllerTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@Disabled
+@MicronautTest // <1>
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // <2>
+class BooksControllerTest { // <3>
+
+    @Inject
+    @field:Client("/")
+    lateinit var httpClient: HttpClient // <4>
+
+    @Test
+    fun testRetrieveBooks() {
+        val client = httpClient.toBlocking()
+
+        val releaseItIsbn = "1680502395"
+        val releaseItName = "Release It!"
+        var saveResponse: HttpResponse<Any> = client.exchange<Map<String, String>, Any>(
+            saveRequest(releaseItIsbn, releaseItName)
+        )
+        assertEquals(HttpStatus.CREATED, saveResponse.status())
+        var location = saveResponse.headers[HttpHeaders.LOCATION]
+        assertNotNull(location)
+        assertTrue(location!!.startsWith("/books/"))
+        val releaseItId = location.substring("/books/".length)
+
+        val continuousDeliveryIsbn = "0321601912"
+        val continuousDeliveryName = "Continuous Delivery"
+        saveResponse = client.exchange<Map<String, String>, Any>(
+            saveRequest(continuousDeliveryIsbn, continuousDeliveryName)
+        )
+        assertEquals(HttpStatus.CREATED, saveResponse.status())
+        location = saveResponse.headers[HttpHeaders.LOCATION]
+        assertNotNull(location)
+        assertTrue(location!!.startsWith("/books/"))
+        val continuousDeliveryId = location.substring("/books/".length)
+
+        val buildingMicroservicesIsbn = "1491950358"
+        val buildingMicroservicesName = "Building Microservices"
+        saveResponse = client.exchange<Map<String, String>, Any>(
+            saveRequest(buildingMicroservicesIsbn, buildingMicroservicesName)
+        )
+        assertEquals(HttpStatus.CREATED, saveResponse.status())
+        location = saveResponse.headers[HttpHeaders.LOCATION]
+        assertNotNull(location)
+        assertTrue(location!!.startsWith("/books/"))
+        val buildingMicroservicesId = location.substring("/books/".length)
+
+        val result = client.retrieve(
+            HttpRequest.GET<Any>(
+                UriBuilder.of("/books")
+                    .path(continuousDeliveryId)
+                    .build()
+            ),
+            Book::class.java
+        )
+        assertEquals(continuousDeliveryName, result.name)
+
+        val books = client.retrieve(HttpRequest.GET<Any>("/books"), Argument.listOf(Book::class.java))
+        assertEquals(3, books.size)
+
+        assertTrue(books.any { it.isbn == continuousDeliveryIsbn && it.name == continuousDeliveryName })
+        assertTrue(books.any { it.isbn == releaseItIsbn && it.name == releaseItName })
+        assertTrue(books.any { it.isbn == buildingMicroservicesIsbn && it.name == buildingMicroservicesName })
+
+        var deleteResponse = client.exchange<Any, Any>(
+            HttpRequest.DELETE<Any>(
+                UriBuilder.of("/books")
+                    .path(continuousDeliveryId)
+                    .build()
+                    .toString()
+            )
+        )
+        assertEquals(HttpStatus.NO_CONTENT, deleteResponse.status())
+        deleteResponse = client.exchange<Any, Any>(
+            HttpRequest.DELETE<Any>(
+                UriBuilder.of("/books")
+                    .path(releaseItId)
+                    .build()
+                    .toString()
+            )
+        )
+        assertEquals(HttpStatus.NO_CONTENT, deleteResponse.status())
+        deleteResponse = client.exchange<Any, Any>(
+            HttpRequest.DELETE<Any>(
+                UriBuilder.of("/books")
+                    .path(buildingMicroservicesId)
+                    .build()
+                    .toString()
+            )
+        )
+        assertEquals(HttpStatus.NO_CONTENT, deleteResponse.status())
+    }
+
+    companion object {
+        private fun saveRequest(isbn: String, name: String): HttpRequest<Map<String, String>> =
+            HttpRequest.POST(
+                "/books",
+                mapOf("isbn" to isbn, "name" to name)
+            )
+    }
+}

--- a/guides/micronaut-dynamodb/kotlin/src/test/kotlin/example/micronaut/TestBootstrap.kt
+++ b/guides/micronaut-dynamodb/kotlin/src/test/kotlin/example/micronaut/TestBootstrap.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.context.event.StartupEvent
+import jakarta.inject.Singleton
+
+@Requires(property = "dynamodb-local.host")
+@Requires(property = "dynamodb-local.port")
+@Requires(env = [Environment.TEST])
+@Singleton
+class TestBootstrap(
+    private val dynamoRepository: DynamoRepository<*>
+) : ApplicationEventListener<StartupEvent> {
+
+    override fun onApplicationEvent(event: StartupEvent) {
+        if (!dynamoRepository.existsTable()) {
+            dynamoRepository.createTable()
+        }
+    }
+}

--- a/guides/micronaut-dynamodb/kotlin/src/test/resources/application-test.properties
+++ b/guides/micronaut-dynamodb/kotlin/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+aws.region=us-east-1

--- a/guides/micronaut-dynamodb/metadata.json
+++ b/guides/micronaut-dynamodb/metadata.json
@@ -4,7 +4,7 @@
   "authors": ["Sergio del Amo"],
   "categories": ["Data Access"],
   "publicationDate": "2022-07-05",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "cloud": "AWS",
   "env": {"AWS_ACCESS_KEY_ID": "XXX", "AWS_SECRET_ACCESS_KEY": "YYY", "AWS_REGION": "us-east-1"},
   "apps": [


### PR DESCRIPTION
## Summary
- Add Kotlin source, resources, and JUnit tests for the Micronaut DynamoDB guide.
- Enable Kotlin in `guides/micronaut-dynamodb/metadata.json`.
- Keep the existing Asciidoc macros so the guide resolves per language.

Fixes #1216

## Validation
- `./gradlew micronautDynamodbGenerateProjects micronautDynamodbGenerateDocs --stacktrace`
- `./gradlew -p build/code/micronaut-dynamodb/micronaut-dynamodb-gradle-kotlin compileKotlin testClasses --stacktrace`
- `./gradlew micronautDynamodbRunTestScript --stacktrace`

---
###### ✨ This message was AI-generated using gpt-5
