### PR TITLE
Add Kotlin version for micronaut-json-schema

### DIFF
--- a/guides/micronaut-json-schema/kotlin/src/main/kotlin/example/micronaut/Product.kt
+++ b/guides/micronaut-json-schema/kotlin/src/main/kotlin/example/micronaut/Product.kt
@@ -25,7 +25,7 @@ import jakarta.validation.constraints.Size
 @JsonSchema(description = "A product from Acme's catalog") // <2>
 data class Product(
     @field:NotNull // <3>
-    @field:JsonPropertyDescription("The unique identifier for a product // <1>") // <1>
+    @field:JsonPropertyDescription("The unique identifier for a product") // <1>
     val productId: Long,
 
     @field:NotBlank

--- a/guides/micronaut-json-schema/kotlin/src/main/kotlin/example/micronaut/Product.kt
+++ b/guides/micronaut-json-schema/kotlin/src/main/kotlin/example/micronaut/Product.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import io.micronaut.jsonschema.JsonSchema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+
+@JsonSchema(description = "A product from Acme's catalog") // <2>
+data class Product(
+    @field:NotNull // <3>
+    @field:JsonPropertyDescription("The unique identifier for a product // <1>") // <1>
+    val productId: Long,
+
+    @field:NotBlank
+    @field:JsonPropertyDescription("Name of the product")
+    val productName: String,
+
+    @field:NotNull // <3>
+    @field:Positive // <4>
+    @field:JsonPropertyDescription("The price of the product")
+    val price: Double,
+
+    @field:Size(min = 1) // <4>
+    val tags: Set<String>?
+)

--- a/guides/micronaut-json-schema/kotlin/src/test/kotlin/example/micronaut/JsonSchemaExposedTest.kt
+++ b/guides/micronaut-json-schema/kotlin/src/test/kotlin/example/micronaut/JsonSchemaExposedTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+@MicronautTest // <1>
+class JsonSchemaExposedTest {
+
+    @Test
+    fun productJsonSchemaExposed(@Client("/") httpClient: HttpClient) { // <2>
+        val client = httpClient.toBlocking()
+        assertDoesNotThrow { client.exchange<Any>("/schemas/product.schema.json") }
+    }
+}

--- a/guides/micronaut-json-schema/kotlin/src/test/kotlin/example/micronaut/JsonSchemaGeneratedTest.kt
+++ b/guides/micronaut-json-schema/kotlin/src/test/kotlin/example/micronaut/JsonSchemaGeneratedTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@MicronautTest(startApplication = false) // <1>
+class JsonSchemaGeneratedTest {
+
+    @Test
+    fun buildGeneratesJsonSchema(resourceLoader: ResourceLoader) {
+        assertTrue(resourceLoader.getResource("META-INF/schemas/product.schema.json").isPresent)
+    }
+}

--- a/guides/micronaut-json-schema/kotlin/src/test/kotlin/example/micronaut/ProductSchemaTest.kt
+++ b/guides/micronaut-json-schema/kotlin/src/test/kotlin/example/micronaut/ProductSchemaTest.kt
@@ -45,7 +45,7 @@ class ProductSchemaTest {
   "type": "object",
   "properties": {
     "productId": {
-      "description": "The unique identifier for a product // <1>",
+      "description": "The unique identifier for a product",
       "type": "integer"
     },
     "productName": {

--- a/guides/micronaut-json-schema/kotlin/src/test/kotlin/example/micronaut/ProductSchemaTest.kt
+++ b/guides/micronaut-json-schema/kotlin/src/test/kotlin/example/micronaut/ProductSchemaTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.json.JSONException
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+
+@MicronautTest // <1>
+class ProductSchemaTest {
+
+    @Test
+    @Throws(JSONException::class)
+    fun testProductSchema(@Client("/") httpClient: HttpClient) { // <2>
+        val client = httpClient.toBlocking()
+        val request: HttpRequest<*> = HttpRequest.GET<Any>("/schemas/product.schema.json")
+        val json = assertDoesNotThrow<String> { client.retrieve(request) }
+        assertNotNull(json)
+        val expected = """
+{
+  "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
+  "${'$'}id": "http://localhost:8080/schemas/product.schema.json",
+  "title": "Product",
+  "description": "A product from Acme's catalog",
+  "type": "object",
+  "properties": {
+    "productId": {
+      "description": "The unique identifier for a product // <1>",
+      "type": "integer"
+    },
+    "productName": {
+      "description": "Name of the product",
+      "type": "string"
+    },
+    "price": {
+      "description": "The price of the product",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "required": [ "productId", "productName", "price" ]
+}"""
+        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT)
+    }
+}

--- a/guides/micronaut-json-schema/metadata.json
+++ b/guides/micronaut-json-schema/metadata.json
@@ -1,10 +1,10 @@
 {
   "title": "Micronaut JSON Schema",
-  "intro": "Generate a JSON Schema specification of your Java objects at compilation thanks to Micronaut JSON Schema.",
+  "intro": "Generate a JSON Schema specification of your objects at compilation thanks to Micronaut JSON Schema.",
   "authors": ["Sergio del Amo"],
   "categories": ["JSON Schema"],
   "publicationDate": "2024-10-07",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "name": "default",

--- a/guides/micronaut-json-schema/micronaut-json-schema.adoc
+++ b/guides/micronaut-json-schema/micronaut-json-schema.adoc
@@ -2,7 +2,7 @@ common:header-top.adoc[]
 
 == Getting Started
 
-This tutorial shows how to generate a JSON Schema of a Java class at compile-time using Micronaut JSON Schema.
+This tutorial shows how to generate a JSON Schema of a class at compile-time using Micronaut JSON Schema.
 The example shows a JSON Schema, such as the one found in the https://json-schema.org/learn/getting-started-step-by-step[Getting Started Tutorial on the JSON Schema website].
 
 common:requirements.adoc[]


### PR DESCRIPTION
## Summary
- Adds the Kotlin sample implementation for `guides/micronaut-json-schema`.
- Updates guide metadata to publish Java and Kotlin variants.
- Generalizes the guide intro text so it no longer describes the sample as Java-only.
- Fixes the Kotlin JSON schema property description so guide callout markup does not leak into generated schema output.

## Verification
- `git diff --check -- guides/micronaut-json-schema/metadata.json guides/micronaut-json-schema/micronaut-json-schema.adoc guides/micronaut-json-schema/kotlin`
- `./gradlew micronautJsonSchemaRunTestScript --stacktrace`
- `./gradlew micronautJsonSchemaBuild --stacktrace` reached generated projects, docs, zips, and generated Java/Kotlin regular tests, then failed only in the local native-image step because the local GraalVM/reachability metadata environment is incompatible.

CI is rerunning for commit `62dabed005`.

## Release And Routing
- Target branch: `master`
- Upstream selected Micronaut organization project: `5.0.1 Release`
- Ambiguity note: `micronaut-guides` has no SemVer GitHub releases and other Micronaut release boards remain open, so the upstream board choice is preserved.
- Project link attempt: GitHub rejected the project mutation because the available token lacks the required project scope.
- GitHub issue reporter: `sdelamo`
- Reviewer request: GitHub rejected requesting `sdelamo` because the PR was created by `sdelamo`: `Review cannot be requested from pull request author.`

## PR-Visible Assets
- Removed the stale generated schema asset link from the previous commit.
- The current generated Kotlin schema was verified locally from `build/code/micronaut-json-schema/micronaut-json-schema-gradle-kotlin/build/resources/main/META-INF/schemas/product.schema.json`; `productId.description` is `The unique identifier for a product`.

Closes #1712

---
###### ✨ This message was AI-generated using gpt-5