### PR TITLE
Add Groovy variant for MCP diskspace HTTP guide

### DIFF
--- a/guides/micronaut-mcp-diskspace-http/groovy/src/test/groovy/example/micronaut/MyToolsSpec.groovy
+++ b/guides/micronaut-mcp-diskspace-http/groovy/src/test/groovy/example/micronaut/MyToolsSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.modelcontextprotocol.client.McpSyncClient
+import io.modelcontextprotocol.spec.McpSchema
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class MyToolsSpec extends Specification {
+
+    @Inject
+    McpSyncClient mcpClient
+
+    void mcpCallTool() {
+        when:
+        McpSchema.CallToolResult callToolResult =
+                mcpClient.callTool(new McpSchema.CallToolRequest('freeDiskSpace', Collections.emptyMap()))
+
+        then:
+        callToolResult.content().size() == 1
+        callToolResult.content().first() instanceof McpSchema.TextContent
+
+        when:
+        String response = ((McpSchema.TextContent) callToolResult.content().first()).text()
+
+        then:
+        response.contains('Free disk space')
+    }
+
+    void mcpListTools() {
+        when:
+        McpSchema.ListToolsResult listToolsResult = mcpClient.listTools()
+
+        then:
+        listToolsResult.tools().size() == 1
+
+        when:
+        McpSchema.Tool tool = listToolsResult.tools().first()
+
+        then:
+        tool.name() == 'freeDiskSpace'
+        tool.title() == 'Free Disk Space'
+        tool.description() == 'Return the free disk space in the users computer'
+    }
+}

--- a/guides/micronaut-mcp-diskspace-http/groovy/src/test/groovy/example/micronaut/MyToolsSpec.groovy
+++ b/guides/micronaut-mcp-diskspace-http/groovy/src/test/groovy/example/micronaut/MyToolsSpec.groovy
@@ -56,6 +56,6 @@ class MyToolsSpec extends Specification {
         then:
         tool.name() == 'freeDiskSpace'
         tool.title() == 'Free Disk Space'
-        tool.description() == 'Return the free disk space in the users computer'
+        tool.description() == 'Return the free disk space in the user\'s computer'
     }
 }

--- a/guides/micronaut-mcp-diskspace-http/java/src/test/java/example/micronaut/MyToolsTest.java
+++ b/guides/micronaut-mcp-diskspace-http/java/src/test/java/example/micronaut/MyToolsTest.java
@@ -48,6 +48,6 @@ class MyToolsTest {
         McpSchema.Tool tool = listToolsResult.tools().get(0);
         assertEquals("freeDiskSpace", tool.name());
         assertEquals("Free Disk Space", tool.title());
-        assertEquals("Return the free disk space in the users computer", tool.description());
+        assertEquals("Return the free disk space in the user's computer", tool.description());
     }
 }

--- a/guides/micronaut-mcp-diskspace-http/metadata.json
+++ b/guides/micronaut-mcp-diskspace-http/metadata.json
@@ -3,7 +3,7 @@
   "title": "Disk Space MCP Server with Streamable HTTP transport",
   "intro": "Build an MCP Server with Streamable HTTP transport to expose your machine disk space.",
   "authors": ["Sergio del Amo"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "tags": [],
   "categories": ["MCP"],
   "publicationDate": "2026-01-11",

--- a/guides/micronaut-mcp-diskspace/groovy/src/main/groovy/example/micronaut/DiskUtils.groovy
+++ b/guides/micronaut-mcp-diskspace/groovy/src/main/groovy/example/micronaut/DiskUtils.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+final class DiskUtils {
+
+    private DiskUtils() {
+    }
+
+    static String freeDiskSpace() {
+        File root = new File('/')
+        long freeBytes = root.freeSpace
+        double freeGB = freeBytes / (1024.0 * 1024 * 1024)
+        String.format('Free disk space: %.2f GB', freeGB)
+    }
+}

--- a/guides/micronaut-mcp-diskspace/groovy/src/main/groovy/example/micronaut/MyTools.groovy
+++ b/guides/micronaut-mcp-diskspace/groovy/src/main/groovy/example/micronaut/MyTools.groovy
@@ -22,7 +22,7 @@ import jakarta.inject.Singleton
 class MyTools {
 
     @Tool(title = 'Free Disk Space',
-            description = 'Return the free disk space in the users computer') // <2>
+            description = 'Return the free disk space in the user\'s computer') // <2>
     String freeDiskSpace() {
         DiskUtils.freeDiskSpace()
     }

--- a/guides/micronaut-mcp-diskspace/groovy/src/main/groovy/example/micronaut/MyTools.groovy
+++ b/guides/micronaut-mcp-diskspace/groovy/src/main/groovy/example/micronaut/MyTools.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.mcp.annotations.Tool
+import jakarta.inject.Singleton
+
+@Singleton // <1>
+class MyTools {
+
+    @Tool(title = 'Free Disk Space',
+            description = 'Return the free disk space in the users computer') // <2>
+    String freeDiskSpace() {
+        DiskUtils.freeDiskSpace()
+    }
+}

--- a/guides/micronaut-mcp-diskspace/java/src/main/java/example/micronaut/MyTools.java
+++ b/guides/micronaut-mcp-diskspace/java/src/main/java/example/micronaut/MyTools.java
@@ -22,7 +22,7 @@ import java.io.File;
 @Singleton // <1>
 class MyTools {
     @Tool(title = "Free Disk Space",
-          description = "Return the free disk space in the users computer")  // <2>
+          description = "Return the free disk space in the user's computer")  // <2>
     String freeDiskSpace() {
         return DiskUtils.freeDiskSpace();
     }


### PR DESCRIPTION
## Summary

- Add the Groovy `DiskUtils` and `MyTools` sample implementation for the shared MCP diskspace guide.
- Add a Spock HTTP MCP client test for the Groovy generated guide.
- Enable `GROOVY` for `guides/micronaut-mcp-diskspace-http` while preserving the existing Java guide.
- Correct the client-facing MCP tool description grammar in the existing Java sample and matching Groovy variant.

Closes #1713

## Release And Project

Target branch: `master`.
Release target signal: `version.txt` on `master` is `5.0.0`.
Selected Micronaut organization project: `5.0.1 Release`.

Ambiguity note: QA found no open public `5.0.0` Micronaut organization project. `5.0.1 Release` is the earliest open release board that appears able to consume this docs/sample-code fix from the current default branch.

Project-link status: attempted to add this PR to `5.0.1 Release`, but GitHub GraphQL returned that the available token lacks the required `project` scope for `addProjectV2ItemById`; the REST ProjectsV2 fallback returned `403 Must have admin rights to Repository`; the Paperclip plugin tool fallback was not callable by this agent token and returned `Board access required`.

Reviewer request status: attempted to request the linked issue creator `sdelamo`, but GitHub returned `422 Review cannot be requested from pull request author` because the PR is authored by `sdelamo`.

## Validation

- `git diff --check origin/master...HEAD`
- `./gradlew micronautMcpDiskspaceHttpRunTestScript --stacktrace --rerun-tasks`
- `./gradlew micronautMcpDiskspaceHttpBuild --stacktrace -x micronautMcpDiskspaceHttpRunNativeTestScript --rerun-tasks`
- `./mvnw -q test spotless:check` from `build/code/micronaut-mcp-diskspace-http/micronaut-mcp-diskspace-http-maven-groovy`

Native test note: the native test script was not rerun for this PR handoff because implementation and QA both recorded an existing local GraalVM reachability metadata schema/toolchain failure in the Java native-test path, outside the new Groovy variant.

## PR Assets

- Rendered HTML inspected at `build/dist/micronaut-mcp-diskspace-http.html`.
- Generated PDF: [Rendered guide PDF](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/6e7acaefd396057b88287eaa189c306200ff5a79/assets/pr-1815/b3bf1c0b63c7/micronaut-mcp-diskspace-http.pdf)

---
###### ✨ This message was AI-generated using gpt-5
