### PR TITLE
Add Kotlin diskspace MCP HTTP guide variant

### DIFF
--- a/guides/micronaut-mcp-diskspace-http/java/src/test/java/example/micronaut/MyToolsTest.java
+++ b/guides/micronaut-mcp-diskspace-http/java/src/test/java/example/micronaut/MyToolsTest.java
@@ -48,6 +48,6 @@ class MyToolsTest {
         McpSchema.Tool tool = listToolsResult.tools().get(0);
         assertEquals("freeDiskSpace", tool.name());
         assertEquals("Free Disk Space", tool.title());
-        assertEquals("Return the free disk space in the users computer", tool.description());
+        assertEquals("Return the free disk space in the user's computer", tool.description());
     }
 }

--- a/guides/micronaut-mcp-diskspace-http/kotlin/src/test/kotlin/example/micronaut/MyToolsTest.kt
+++ b/guides/micronaut-mcp-diskspace-http/kotlin/src/test/kotlin/example/micronaut/MyToolsTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.modelcontextprotocol.client.McpSyncClient
+import io.modelcontextprotocol.spec.McpSchema
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@MicronautTest
+class MyToolsTest {
+
+    @Test
+    fun mcpCallTool(mcpClient: McpSyncClient) {
+        val callToolResult = assertDoesNotThrow<McpSchema.CallToolResult> {
+            mcpClient.callTool(McpSchema.CallToolRequest("freeDiskSpace", emptyMap()))
+        }
+        assertEquals(1, callToolResult.content().size)
+        assertInstanceOf(McpSchema.TextContent::class.java, callToolResult.content()[0])
+        val textContent = callToolResult.content()[0] as McpSchema.TextContent
+        val response = textContent.text()
+        assertTrue(response.contains("Free disk space"))
+    }
+
+    @Test
+    fun mcpListTools(mcpClient: McpSyncClient) {
+        val listToolsResult = assertDoesNotThrow<McpSchema.ListToolsResult> {
+            mcpClient.listTools()
+        }
+
+        assertEquals(1, listToolsResult.tools().size)
+        val tool = listToolsResult.tools()[0]
+        assertEquals("freeDiskSpace", tool.name())
+        assertEquals("Free Disk Space", tool.title())
+        assertEquals("Return the free disk space in the user's computer", tool.description())
+    }
+}

--- a/guides/micronaut-mcp-diskspace-http/metadata.json
+++ b/guides/micronaut-mcp-diskspace-http/metadata.json
@@ -3,7 +3,7 @@
   "title": "Disk Space MCP Server with Streamable HTTP transport",
   "intro": "Build an MCP Server with Streamable HTTP transport to expose your machine disk space.",
   "authors": ["Sergio del Amo"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "tags": [],
   "categories": ["MCP"],
   "publicationDate": "2026-01-11",

--- a/guides/micronaut-mcp-diskspace/kotlin/src/main/kotlin/example/micronaut/DiskUtils.kt
+++ b/guides/micronaut-mcp-diskspace/kotlin/src/main/kotlin/example/micronaut/DiskUtils.kt
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package example.micronaut;
+package example.micronaut
 
-import io.micronaut.mcp.annotations.Tool;
-import jakarta.inject.Singleton;
-import java.io.File;
+import java.io.File
 
-@Singleton // <1>
-class MyTools {
-    @Tool(title = "Free Disk Space",
-          description = "Return the free disk space in the user's computer")  // <2>
-    String freeDiskSpace() {
-        return DiskUtils.freeDiskSpace();
+object DiskUtils {
+
+    fun freeDiskSpace(): String {
+        val root = File("/")
+        val freeBytes = root.freeSpace
+        val freeGB = freeBytes / (1024.0 * 1024 * 1024)
+        return "Free disk space: %.2f GB".format(freeGB)
     }
 }

--- a/guides/micronaut-mcp-diskspace/kotlin/src/main/kotlin/example/micronaut/MyTools.kt
+++ b/guides/micronaut-mcp-diskspace/kotlin/src/main/kotlin/example/micronaut/MyTools.kt
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package example.micronaut;
+package example.micronaut
 
-import io.micronaut.mcp.annotations.Tool;
-import jakarta.inject.Singleton;
-import java.io.File;
+import io.micronaut.mcp.annotations.Tool
+import jakarta.inject.Singleton
 
 @Singleton // <1>
 class MyTools {
-    @Tool(title = "Free Disk Space",
-          description = "Return the free disk space in the user's computer")  // <2>
-    String freeDiskSpace() {
-        return DiskUtils.freeDiskSpace();
+
+    @Tool(
+        title = "Free Disk Space",
+        description = "Return the free disk space in the user's computer"
+    ) // <2>
+    fun freeDiskSpace(): String {
+        return DiskUtils.freeDiskSpace()
     }
 }


### PR DESCRIPTION
## Summary
- Add Kotlin source for the shared diskspace MCP guide base.
- Add Kotlin MCP HTTP client coverage for `freeDiskSpace` and `listTools`.
- Include `KOTLIN` in `micronaut-mcp-diskspace-http` metadata.
- Normalize the tool description wording across Java and Kotlin.

## Verification
- `git diff --check origin/master...HEAD`
- `./gradlew micronautMcpDiskspaceHttpRunTestScript --stacktrace`
- `./gradlew micronautMcpDiskspaceHttpBuild --stacktrace -x micronautMcpDiskspaceHttpRunNativeTestScript --rerun-tasks`

## PR Assets
- [Rendered Kotlin guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/e0c36804281375238aee45b12994e9edbd71605a/assets/pr-1816/6c956f700ef1/micronaut-mcp-diskspace-http-gradle-kotlin.html)

## Release And Project Notes
- Target branch: `master`, default 5.0.x guide stream.
- Micronaut organization project selected upstream: `5.0.1 Release`.
- Ambiguity preserved from QA: the default branch version signal is `5.0.0`, but `5.0.0 Release` is closed; `5.0.1 Release` is the open 5.0.x Platform BOM release board selected for this PR.

Closes #1714

---
###### ✨ This message was AI-generated using gpt-5.3-codex