### PR TITLE
Add Groovy diskspace MCP STDIO guide

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/HttpValidationCompileOnlySupport.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/HttpValidationCompileOnlySupport.java
@@ -1,0 +1,20 @@
+package io.micronaut.guides.feature;
+
+import io.micronaut.starter.application.generator.GeneratorContext;
+import jakarta.inject.Singleton;
+
+import static io.micronaut.starter.build.dependencies.Scope.COMPILE_ONLY;
+
+@Singleton
+public class HttpValidationCompileOnlySupport extends AbstractFeature {
+
+    public HttpValidationCompileOnlySupport() {
+        super("http-validation-compile-only-support", "micronaut-router", COMPILE_ONLY);
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        super.apply(generatorContext);
+        addDependency(generatorContext, "micronaut-http-server", COMPILE_ONLY);
+    }
+}

--- a/buildSrc/src/main/resources/pom.xml
+++ b/buildSrc/src/main/resources/pom.xml
@@ -203,5 +203,15 @@
             <artifactId>swagger-annotations</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-router</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-http-server</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/guides/micronaut-mcp-diskspace-http/java/src/test/java/example/micronaut/MyToolsTest.java
+++ b/guides/micronaut-mcp-diskspace-http/java/src/test/java/example/micronaut/MyToolsTest.java
@@ -48,6 +48,6 @@ class MyToolsTest {
         McpSchema.Tool tool = listToolsResult.tools().get(0);
         assertEquals("freeDiskSpace", tool.name());
         assertEquals("Free Disk Space", tool.title());
-        assertEquals("Return the free disk space in the users computer", tool.description());
+        assertEquals("Return the free disk space on the user's computer", tool.description());
     }
 }

--- a/guides/micronaut-mcp-diskspace-stdio/metadata.json
+++ b/guides/micronaut-mcp-diskspace-stdio/metadata.json
@@ -3,7 +3,7 @@
   "title": "Disk Space MCP Server with STDIO transport",
   "intro": "Build an MCP Server with STDIO transport to expose your machine disk space.",
   "authors": ["Sergio del Amo"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "tags": [],
   "categories": ["MCP"],
   "publicationDate": "2026-01-11",
@@ -11,6 +11,7 @@
     {
       "excludeTest": ["DefaultTest"],
       "name": "default",
+      "invisibleFeatures": ["http-validation-compile-only-support"],
       "features": ["mcp-stdio"]
     }
   ]

--- a/guides/micronaut-mcp-diskspace/groovy/src/main/groovy/example/micronaut/DiskUtils.groovy
+++ b/guides/micronaut-mcp-diskspace/groovy/src/main/groovy/example/micronaut/DiskUtils.groovy
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package example.micronaut;
+package example.micronaut
 
-import io.micronaut.mcp.annotations.Tool;
-import jakarta.inject.Singleton;
-import java.io.File;
+final class DiskUtils {
 
-@Singleton // <1>
-class MyTools {
-    @Tool(title = "Free Disk Space",
-          description = "Return the free disk space on the user's computer")  // <2>
-    String freeDiskSpace() {
-        return DiskUtils.freeDiskSpace();
+    private DiskUtils() {
+    }
+
+    static String freeDiskSpace() {
+        File root = new File('/')
+        long freeBytes = root.freeSpace
+        double freeGB = freeBytes / (1024.0 * 1024 * 1024)
+        String.format('Free disk space: %.2f GB', freeGB)
     }
 }

--- a/guides/micronaut-mcp-diskspace/groovy/src/main/groovy/example/micronaut/MyTools.groovy
+++ b/guides/micronaut-mcp-diskspace/groovy/src/main/groovy/example/micronaut/MyTools.groovy
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package example.micronaut;
+package example.micronaut
 
-import io.micronaut.mcp.annotations.Tool;
-import jakarta.inject.Singleton;
-import java.io.File;
+import io.micronaut.mcp.annotations.Tool
+import jakarta.inject.Singleton
 
 @Singleton // <1>
 class MyTools {
-    @Tool(title = "Free Disk Space",
-          description = "Return the free disk space on the user's computer")  // <2>
+
+    @Tool(title = 'Free Disk Space',
+            description = "Return the free disk space on the user's computer") // <2>
     String freeDiskSpace() {
-        return DiskUtils.freeDiskSpace();
+        DiskUtils.freeDiskSpace()
     }
 }


### PR DESCRIPTION
## Summary

- Add the Groovy shared diskspace MCP sample implementation.
- Enable Groovy for `micronaut-mcp-diskspace-stdio` while preserving the Java variant.
- Add a hidden compile-only support feature for Micronaut HTTP validation classes needed during generated Groovy compilation.
- Polish the shared MCP tool description and keep the HTTP guide test expectation aligned.

## Verification

- `git diff --check origin/master...HEAD`
- `./gradlew micronautMcpDiskspaceStdioBuild --stacktrace`
- `./gradlew micronautMcpDiskspaceStdioRunTestScript --stacktrace`
- `./gradlew micronautMcpDiskspaceHttpRunTestScript micronautMcpDiskspaceStdioBuild micronautMcpDiskspaceStdioRunTestScript --stacktrace`

## Release And Routing

- Target branch: `master`
- Release target: default-branch `5.0.0` docs/site target from `version.txt`
- Micronaut organization project selected by QA: `5.0.1 Release`
- Project linkage status: not linked by this run because GitHub rejected `addProjectV2ItemById`; exact reason: token lacks the `project` scope and has `read:project` only.
- Ambiguity note: `version.txt` reports `5.0.0`, but no open public `5.0.0` Micronaut organization project was found; `5.0.1 Release` is the earliest open release board found for this docs/sample-code change.
- Type label: `type: docs`
- Closing keyword: Closes #1715

## Review Handoff

- Linked GitHub issue creator: `sdelamo`
- Requested reviewer status: GitHub rejected requesting `sdelamo`; exact reason: `Review cannot be requested from pull request author. (HTTP 422)`.
- Copilot review thread status: addressed and resolved.

## PR Assets

No PR-visible asset upload is required for this source/metadata-only guide variant; rendered guide output was verified by the focused guide build.

---
###### ✨ This message was AI-generated using gpt-5-codex