### PR TITLE
Add Kotlin diskspace MCP STDIO guide

### DIFF
--- a/guides/micronaut-mcp-diskspace-http/java/src/test/java/example/micronaut/MyToolsTest.java
+++ b/guides/micronaut-mcp-diskspace-http/java/src/test/java/example/micronaut/MyToolsTest.java
@@ -48,6 +48,6 @@ class MyToolsTest {
         McpSchema.Tool tool = listToolsResult.tools().get(0);
         assertEquals("freeDiskSpace", tool.name());
         assertEquals("Free Disk Space", tool.title());
-        assertEquals("Return the free disk space in the users computer", tool.description());
+        assertEquals("Returns the free disk space in the user's computer", tool.description());
     }
 }

--- a/guides/micronaut-mcp-diskspace-stdio/metadata.json
+++ b/guides/micronaut-mcp-diskspace-stdio/metadata.json
@@ -3,7 +3,7 @@
   "title": "Disk Space MCP Server with STDIO transport",
   "intro": "Build an MCP Server with STDIO transport to expose your machine disk space.",
   "authors": ["Sergio del Amo"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "tags": [],
   "categories": ["MCP"],
   "publicationDate": "2026-01-11",

--- a/guides/micronaut-mcp-diskspace/java/src/main/java/example/micronaut/MyTools.java
+++ b/guides/micronaut-mcp-diskspace/java/src/main/java/example/micronaut/MyTools.java
@@ -22,7 +22,7 @@ import java.io.File;
 @Singleton // <1>
 class MyTools {
     @Tool(title = "Free Disk Space",
-          description = "Return the free disk space in the users computer")  // <2>
+          description = "Returns the free disk space in the user's computer")  // <2>
     String freeDiskSpace() {
         return DiskUtils.freeDiskSpace();
     }

--- a/guides/micronaut-mcp-diskspace/kotlin/src/main/kotlin/example/micronaut/DiskUtils.kt
+++ b/guides/micronaut-mcp-diskspace/kotlin/src/main/kotlin/example/micronaut/DiskUtils.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import java.io.File
+
+object DiskUtils {
+
+    fun freeDiskSpace(): String {
+        val root = File("/")
+        val freeBytes = root.freeSpace
+        val freeGB = freeBytes / (1024.0 * 1024 * 1024)
+        return "Free disk space: %.2f GB".format(freeGB)
+    }
+}

--- a/guides/micronaut-mcp-diskspace/kotlin/src/main/kotlin/example/micronaut/MyTools.kt
+++ b/guides/micronaut-mcp-diskspace/kotlin/src/main/kotlin/example/micronaut/MyTools.kt
@@ -23,7 +23,7 @@ class MyTools {
 
     @Tool(
         title = "Free Disk Space",
-        description = "Return the free disk space in the users computer"
+        description = "Returns the free disk space in the user's computer"
     ) // <2>
     fun freeDiskSpace(): String {
         return DiskUtils.freeDiskSpace()

--- a/guides/micronaut-mcp-diskspace/kotlin/src/main/kotlin/example/micronaut/MyTools.kt
+++ b/guides/micronaut-mcp-diskspace/kotlin/src/main/kotlin/example/micronaut/MyTools.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.mcp.annotations.Tool
+import jakarta.inject.Singleton
+
+@Singleton // <1>
+class MyTools {
+
+    @Tool(
+        title = "Free Disk Space",
+        description = "Return the free disk space in the users computer"
+    ) // <2>
+    fun freeDiskSpace(): String {
+        return DiskUtils.freeDiskSpace()
+    }
+}


### PR DESCRIPTION
## Summary
- add the Kotlin sample implementation for the shared `micronaut-mcp-diskspace` guide base
- enable Kotlin for `guides/micronaut-mcp-diskspace-stdio`
- verify the generated STDIO Kotlin guide renders with Kotlin source and ZIP links

Closes #1716

## Release Targeting
- Target branch: `master`
- Type label: `type: docs`
- QA-selected Micronaut organization project: `5.0.1 Release` (project #146)
- QA ambiguity note: `5.1.0 Release` is also open because this repository has no normal stable release-tag signal; preserve this context if project placement is revisited
- Live project association: not applied by this run because the active `GITHUB_TOKEN` lacks `read:org`; `gh project item-add 146 --owner micronaut-projects --url ...` returned `unknown owner type`

## Verification
- `git diff --check origin/master...HEAD`
- `./gradlew micronautMcpDiskspaceStdioBuild --stacktrace`
- `./gradlew micronautMcpDiskspaceStdioRunTestScript --stacktrace`

## PR-visible Assets
No binary or screenshot asset is required for this sample-code/docs variant. Rendered guide output and generated Kotlin sample output were verified locally under `build/dist`, `build/docs/asciidoc`, and `build/code`.

## Handoff Notes
- Linked issue creator: `sdelamo`
- Reviewer request: GitHub rejected requesting `sdelamo` because they are the PR author: `Review cannot be requested from pull request author.`
- Copilot comment: non-blocking wording suggestion on text copied from the existing Java sample; no code-review changes requested for that cosmetic consistency point.

---
###### ✨ This message was AI-generated using gpt-5