### PR TITLE
Add Kotlin variant for Jaeger OpenTelemetry guide

### DIFF
--- a/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/metadata.json
+++ b/guides/micronaut-microservices-distributed-tracing-jaeger-opentelemetry/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["jaeger", "validation", "distributed-tracing"],
   "categories": ["Distributed Tracing"],
   "publicationDate": "2022-08-04",
-  "languages": ["JAVA", "GROOVY"],
+  "languages": ["JAVA", "GROOVY", "KOTLIN"],
   "apps": [
     {
       "name": "bookcatalogue",


### PR DESCRIPTION
## Summary
- Enable the existing Kotlin sample variant for `micronaut-microservices-distributed-tracing-jaeger-opentelemetry`.
- Preserve the existing Java and Groovy variants.
- Add a trailing newline to the guide metadata file.

Closes #1721.

## Review Context
- Target branch: `master`.
- Release signal: `version.txt = 5.0.0`.
- Selected Micronaut organization project: `5.0.1 Release`.
- Ambiguity note: there is no open `5.0.0 Release` organization project and no stable repository GitHub release to compare against; `5.0.1 Release` is the earliest open Micronaut Platform BOM board that can reasonably consume this docs/sample update.

## Verification
- `git diff --check origin/master...HEAD`
- `./gradlew micronautMicroservicesDistributedTracingJaegerOpentelemetryRunTestScript --stacktrace`

The aggregate guide build's native segment was not completed locally because the available GraalVM/native-image installation does not support the reachability metadata schema used by the configured native-build-tools repository. QA reproduced the same failure against existing generated Java native tests, so this is recorded as an environment/toolchain validation caveat rather than a Kotlin source regression.

## PR Assets
No separate visual or binary PR asset is required for this source-only metadata enablement. The generated Kotlin sample projects and zip are produced by the guide build.

---
###### ✨ This message was AI-generated using gpt-5