### PR TITLE
Add Groovy Keycloak OAuth2 guide variant

### DIFF
--- a/guides/micronaut-oauth2-keycloak/groovy/src/main/groovy/example/micronaut/EndSessionEndpointResolverReplacement.groovy
+++ b/guides/micronaut-oauth2-keycloak/groovy/src/main/groovy/example/micronaut/EndSessionEndpointResolverReplacement.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.security.config.SecurityConfiguration
+import io.micronaut.security.oauth2.client.OpenIdProviderMetadata
+import io.micronaut.security.oauth2.configuration.OauthClientConfiguration
+import io.micronaut.security.oauth2.endpoint.endsession.request.EndSessionEndpoint
+import io.micronaut.security.oauth2.endpoint.endsession.request.EndSessionEndpointResolver
+import io.micronaut.security.oauth2.endpoint.endsession.request.OktaEndSessionEndpoint
+import io.micronaut.security.oauth2.endpoint.endsession.response.EndSessionCallbackUrlBuilder
+import io.micronaut.security.token.reader.TokenResolver
+import jakarta.inject.Singleton
+
+import java.util.function.Supplier
+
+@CompileStatic
+@Singleton
+@Replaces(EndSessionEndpointResolver)
+class EndSessionEndpointResolverReplacement extends EndSessionEndpointResolver {
+    private final TokenResolver tokenResolver
+    private final SecurityConfiguration securityConfiguration
+
+    EndSessionEndpointResolverReplacement(BeanContext beanContext,
+                                          SecurityConfiguration securityConfiguration,
+                                          TokenResolver tokenResolver) {
+        super(beanContext)
+        this.tokenResolver = tokenResolver
+        this.securityConfiguration = securityConfiguration
+    }
+
+    @Override
+    Optional<EndSessionEndpoint> resolve(OauthClientConfiguration oauthClientConfiguration,
+                                         Supplier<OpenIdProviderMetadata> openIdProviderMetadata,
+                                         EndSessionCallbackUrlBuilder endSessionCallbackUrlBuilder) {
+        EndSessionEndpoint endSessionEndpoint = new OktaEndSessionEndpoint(endSessionCallbackUrlBuilder,
+                oauthClientConfiguration,
+                openIdProviderMetadata,
+                securityConfiguration,
+                tokenResolver)
+        Optional.of(endSessionEndpoint)
+    }
+}

--- a/guides/micronaut-oauth2-keycloak/groovy/src/main/groovy/example/micronaut/HomeController.groovy
+++ b/guides/micronaut-oauth2-keycloak/groovy/src/main/groovy/example/micronaut/HomeController.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.views.View
+
+@CompileStatic
+@Controller // <1>
+class HomeController {
+
+    @Secured(SecurityRule.IS_ANONYMOUS) // <2>
+    @View('home') // <3>
+    @Get // <4>
+    Map<String, Object> index() {
+        [:]
+    }
+}

--- a/guides/micronaut-oauth2-keycloak/groovy/src/main/resources/application-dev.properties
+++ b/guides/micronaut-oauth2-keycloak/groovy/src/main/resources/application-dev.properties
@@ -1,0 +1,16 @@
+#tag::port[]
+micronaut.server.port=8081
+#end::port[]
+#tag::oauth2[]
+# <1>
+micronaut.security.authentication=idtoken
+# <2>
+micronaut.security.oauth2.clients.keycloak.client-secret=${OAUTH_CLIENT_SECRET:secret}
+# <3>
+micronaut.security.oauth2.clients.keycloak.client-id=${OAUTH_CLIENT_ID:myclient}
+# <4>
+micronaut.security.oauth2.clients.keycloak.openid.issuer=${OIDC_ISSUER_DOMAIN:`http://localhost:8080`}/realms/${KEYCLOAK_REALM:myrealm}
+# <5>
+# <6>
+micronaut.security.endpoints.logout.get-allowed=true
+#end::oauth2[]

--- a/guides/micronaut-oauth2-keycloak/groovy/src/main/resources/views/home.html
+++ b/guides/micronaut-oauth2-keycloak/groovy/src/main/resources/views/home.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Home</title>
+</head>
+<body>
+<h1>Micronaut - Keycloak example</h1>
+
+<h2 th:if="${security}">username: <span th:text="${security.attributes.get('preferred_username')}"></span></h2>
+<h2 th:unless="${security}">username: Anonymous</h2>
+
+<nav>
+    <ul>
+        <li th:unless="${security}"><a href="/oauth/login/keycloak">Enter</a></li>
+        <li th:if="${security}"><a href="/oauth/logout">Logout</a></li>
+    </ul>
+</nav>
+</body>
+</html>

--- a/guides/micronaut-oauth2-keycloak/metadata.json
+++ b/guides/micronaut-oauth2-keycloak/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["oauth2", "keycloak", "oidc", "security"],
   "categories": ["Authorization Code"],
   "publicationDate": "2023-04-12",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary
- Adds the Groovy implementation for the `micronaut-oauth2-keycloak` guide.
- Includes the Groovy language in guide metadata while preserving the existing Java variant.
- Mirrors the existing Java Keycloak logout resolver, dev OAuth2 configuration, controller, and Thymeleaf view.

## Verification
- `./gradlew --rerun-tasks micronautOauth2KeycloakRunTestScript --stacktrace`
- `./gradlew --rerun-tasks micronautOauth2KeycloakBuild --stacktrace -x micronautOauth2KeycloakRunNativeTestScript`
- `git diff --check origin/master...HEAD`

The exact full build path remains subject to the previously documented local GraalVM reachability-metadata schema mismatch in the existing Java native-image path; QA accepted the non-native render/build validation for this guide change.

## Release Metadata
- Target branch: `master`
- Release target: default-branch docs/site line; `master:version.txt` was recorded as `5.0.0`
- Selected Micronaut organization project: `5.0.1 Release`
- Project ambiguity: no open public `5.0.0` Micronaut organization project was found, so QA selected the earliest open `5.0.1 Release` board for this docs/sample-code fix.
- Live project association: attempted, but the available GitHub token lacks the `project` scope required by `addProjectV2ItemById`.
- Type label: `type: docs`

## PR Assets
- [Rendered Gradle Groovy guide](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/5b71faeab75a9275c141a1d0287c7270d155603a/assets/pr-1820/7e6a9575c151/micronaut-oauth2-keycloak-gradle-groovy.html)

Closes #1722

---
###### ✨ This message was AI-generated using gpt-5
