### PR TITLE
Add Kotlin variant for Keycloak OAuth2 guide

### DIFF
--- a/guides/micronaut-oauth2-keycloak/kotlin/src/main/kotlin/example/micronaut/EndSessionEndpointResolverReplacement.kt
+++ b/guides/micronaut-oauth2-keycloak/kotlin/src/main/kotlin/example/micronaut/EndSessionEndpointResolverReplacement.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.http.HttpRequest
+import io.micronaut.security.config.SecurityConfiguration
+import io.micronaut.security.oauth2.client.OpenIdProviderMetadata
+import io.micronaut.security.oauth2.configuration.OauthClientConfiguration
+import io.micronaut.security.oauth2.endpoint.endsession.request.EndSessionEndpoint
+import io.micronaut.security.oauth2.endpoint.endsession.request.EndSessionEndpointResolver
+import io.micronaut.security.oauth2.endpoint.endsession.request.OktaEndSessionEndpoint
+import io.micronaut.security.oauth2.endpoint.endsession.response.EndSessionCallbackUrlBuilder
+import io.micronaut.security.token.reader.TokenResolver
+import jakarta.inject.Singleton
+import java.util.Optional
+import java.util.function.Supplier
+
+@Singleton
+@Replaces(EndSessionEndpointResolver::class)
+class EndSessionEndpointResolverReplacement(
+    beanContext: BeanContext,
+    private val securityConfiguration: SecurityConfiguration,
+    private val tokenResolver: TokenResolver<HttpRequest<*>>
+) : EndSessionEndpointResolver(beanContext) {
+
+    override fun resolve(
+        oauthClientConfiguration: OauthClientConfiguration,
+        openIdProviderMetadata: Supplier<OpenIdProviderMetadata>,
+        endSessionCallbackUrlBuilder: EndSessionCallbackUrlBuilder<*>
+    ): Optional<EndSessionEndpoint> = Optional.of(
+        OktaEndSessionEndpoint(
+            endSessionCallbackUrlBuilder,
+            oauthClientConfiguration,
+            openIdProviderMetadata,
+            securityConfiguration,
+            tokenResolver
+        )
+    )
+}

--- a/guides/micronaut-oauth2-keycloak/kotlin/src/main/kotlin/example/micronaut/HomeController.kt
+++ b/guides/micronaut-oauth2-keycloak/kotlin/src/main/kotlin/example/micronaut/HomeController.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.views.View
+
+@Controller // <1>
+class HomeController {
+
+    @Secured(SecurityRule.IS_ANONYMOUS) // <2>
+    @View("home") // <3>
+    @Get // <4>
+    fun index(): Map<String, Any> = HashMap()
+}

--- a/guides/micronaut-oauth2-keycloak/kotlin/src/main/resources/application-dev.properties
+++ b/guides/micronaut-oauth2-keycloak/kotlin/src/main/resources/application-dev.properties
@@ -1,0 +1,16 @@
+#tag::port[]
+micronaut.server.port=8081
+#end::port[]
+#tag::oauth2[]
+# <1>
+micronaut.security.authentication=idtoken
+# <2>
+micronaut.security.oauth2.clients.keycloak.client-secret=${OAUTH_CLIENT_SECRET:secret}
+# <3>
+micronaut.security.oauth2.clients.keycloak.client-id=${OAUTH_CLIENT_ID:myclient}
+# <4>
+micronaut.security.oauth2.clients.keycloak.openid.issuer=${OIDC_ISSUER_DOMAIN:`http://localhost:8080`}/realms/${KEYCLOAK_REALM:myrealm}
+# <5>
+# <6>
+micronaut.security.endpoints.logout.get-allowed=true
+#end::oauth2[]

--- a/guides/micronaut-oauth2-keycloak/kotlin/src/main/resources/views/home.html
+++ b/guides/micronaut-oauth2-keycloak/kotlin/src/main/resources/views/home.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Home</title>
+</head>
+<body>
+<h1>Micronaut - Keycloak example</h1>
+
+<h2 th:if="${security}">username: <span th:text="${security.attributes.get('preferred_username')}"></span></h2>
+<h2 th:unless="${security}">username: Anonymous</h2>
+
+<nav>
+    <ul>
+        <li th:unless="${security}"><a href="/oauth/login/keycloak">Enter</a></li>
+        <li th:if="${security}"><a href="/oauth/logout">Logout</a></li>
+    </ul>
+</nav>
+</body>
+</html>

--- a/guides/micronaut-oauth2-keycloak/metadata.json
+++ b/guides/micronaut-oauth2-keycloak/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["oauth2", "keycloak", "oidc", "security"],
   "categories": ["Authorization Code"],
   "publicationDate": "2023-04-12",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary

- Adds the Kotlin sample implementation for `guides/micronaut-oauth2-keycloak`.
- Enables `KOTLIN` in guide metadata while preserving the existing Java variant.
- Copies the existing Keycloak dev configuration and Thymeleaf view behavior for the Kotlin generated app.

## Release And Project Context

- Target branch: `master`.
- Release target: Micronaut Platform `5.0.1 Release`.
- Ambiguity note: `version.txt` on the target branch indicates `5.0.0`, but no open `5.0.0 Release` organization project exists, and `5.0.1 Release` is the earliest open release board available for this docs/sample update.
- Project link attempt: `5.0.1 Release` (#146) exists, but GitHub rejected `addProjectV2ItemById` because the active token lacks the `project` scope.

## Verification

- `git diff --check -- guides/micronaut-oauth2-keycloak/metadata.json guides/micronaut-oauth2-keycloak/kotlin`
- `./gradlew micronautOauth2KeycloakRunTestScript --stacktrace --console=plain`
- `./gradlew micronautOauth2KeycloakGenerateDocs micronautOauth2KeycloakGenerateZips --stacktrace --console=plain`

QA also ran `./gradlew micronautOauth2KeycloakBuild --stacktrace`; the only remaining failure was the native-image step, caused by the local GraalVM reachability metadata schema mismatch and affecting both generated Java and generated Kotlin projects.

## PR Assets

- [Generated Kotlin sample ZIP](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/a6bd55474ff662a04ff8844145a90425e4651afe/assets/pr-1821/dd249ab792f8/micronaut-oauth2-keycloak-gradle-kotlin.zip)

## Reviewer Routing

- Linked GitHub issue creator: `sdelamo`.
- Reviewer request attempt: GitHub rejected the request lookup because the active token lacks `read:org` scope.

Closes #1723

---
###### ✨ This message was AI-generated using gpt-5
