### PR TITLE
Add Micronaut Views HTMX guide

### DIFF
--- a/guides/micronaut-views-htmx/java/src/main/java/example/micronaut/FruitController.java
+++ b/guides/micronaut-views-htmx/java/src/main/java/example/micronaut/FruitController.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.views.ModelAndView;
+import io.micronaut.views.htmx.http.HtmxRequestHeaders;
+import io.micronaut.views.htmx.http.HtmxResponse;
+import io.micronaut.views.htmx.http.HtmxResponseHeaders;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+
+@Controller("/fruits") // <1>
+class FruitController {
+
+    @Produces(MediaType.TEXT_HTML) // <2>
+    @Get // <3>
+    ModelAndView<Map<String, Object>> index(@Nullable HtmxRequestHeaders htmxRequestHeaders) { // <4>
+        Map<String, Object> model = fruit("Apple", "Red");
+        return htmxRequestHeaders == null
+                ? new ModelAndView<>("fruits.html", model)
+                : new ModelAndView<>("fruit.html", model);
+    }
+
+    @Produces(MediaType.TEXT_HTML)
+    @Post // <5>
+    HtmxResponse<?> select(@NonNull HtmxRequestHeaders htmxRequestHeaders) { // <6>
+        return HtmxResponse.builder()
+                .modelAndView(new ModelAndView<>("fruit.html", fruit("Banana", "Yellow")))
+                .modelAndView(new ModelAndView<>("message.html", Map.of("message", "Selected Banana")))
+                .build();
+    }
+
+    @Produces(MediaType.TEXT_HTML)
+    @Get("/refresh")
+    HttpResponse<?> refresh(@NonNull HtmxRequestHeaders htmxRequestHeaders) { // <7>
+        return HttpResponse.ok().header(HtmxResponseHeaders.HX_REFRESH, StringUtils.TRUE);
+    }
+
+    private static Map<String, Object> fruit(String name, String color) {
+        return Map.of("fruitName", name, "fruitColor", color);
+    }
+}

--- a/guides/micronaut-views-htmx/java/src/main/java/example/micronaut/FruitController.java
+++ b/guides/micronaut-views-htmx/java/src/main/java/example/micronaut/FruitController.java
@@ -26,9 +26,9 @@ import io.micronaut.views.ModelAndView;
 import io.micronaut.views.htmx.http.HtmxRequestHeaders;
 import io.micronaut.views.htmx.http.HtmxResponse;
 import io.micronaut.views.htmx.http.HtmxResponseHeaders;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import java.net.URI;
 import java.util.Map;
 
 @Controller("/fruits") // <1>
@@ -45,7 +45,10 @@ class FruitController {
 
     @Produces(MediaType.TEXT_HTML)
     @Post // <5>
-    HtmxResponse<?> select(@NonNull HtmxRequestHeaders htmxRequestHeaders) { // <6>
+    Object select(@Nullable HtmxRequestHeaders htmxRequestHeaders) { // <6>
+        if (htmxRequestHeaders == null) {
+            return new ModelAndView<>("fruits.html", fruit("Banana", "Yellow"));
+        }
         return HtmxResponse.builder()
                 .modelAndView(new ModelAndView<>("fruit.html", fruit("Banana", "Yellow")))
                 .modelAndView(new ModelAndView<>("message.html", Map.of("message", "Selected Banana")))
@@ -54,7 +57,10 @@ class FruitController {
 
     @Produces(MediaType.TEXT_HTML)
     @Get("/refresh")
-    HttpResponse<?> refresh(@NonNull HtmxRequestHeaders htmxRequestHeaders) { // <7>
+    HttpResponse<?> refresh(@Nullable HtmxRequestHeaders htmxRequestHeaders) { // <7>
+        if (htmxRequestHeaders == null) {
+            return HttpResponse.seeOther(URI.create("/fruits"));
+        }
         return HttpResponse.ok().header(HtmxResponseHeaders.HX_REFRESH, StringUtils.TRUE);
     }
 

--- a/guides/micronaut-views-htmx/java/src/test/java/example/micronaut/FruitControllerTest.java
+++ b/guides/micronaut-views-htmx/java/src/test/java/example/micronaut/FruitControllerTest.java
@@ -60,6 +60,17 @@ class FruitControllerTest {
     }
 
     @Test
+    void normalPostRendersFullPage(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+
+        String html = client.retrieve(HttpRequest.POST("/fruits", Collections.emptyMap()));
+
+        assertTrue(html.contains("<!DOCTYPE html>"));
+        assertTrue(html.contains("<h2>Banana</h2>"));
+        assertTrue(html.contains("hx-post=\"/fruits\""));
+    }
+
+    @Test
     void htmxPostCanRenderOutOfBandSwap(@Client("/") HttpClient httpClient) {
         BlockingHttpClient client = httpClient.toBlocking();
         HttpRequest<?> request = HttpRequest.POST("/fruits", Collections.emptyMap())
@@ -68,7 +79,9 @@ class FruitControllerTest {
         String html = client.retrieve(request);
 
         assertTrue(html.contains("<h2>Banana</h2>"));
-        assertTrue(html.contains("<div id=\"message\" hx-swap-oob=\"true\">Selected Banana</div>"));
+        assertTrue(html.contains("id=\"message\""));
+        assertTrue(html.contains("hx-swap-oob=\"true\""));
+        assertTrue(html.contains("Selected Banana"));
     }
 
     @Test

--- a/guides/micronaut-views-htmx/java/src/test/java/example/micronaut/FruitControllerTest.java
+++ b/guides/micronaut-views-htmx/java/src/test/java/example/micronaut/FruitControllerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import io.micronaut.views.htmx.http.HtmxRequestHeaders;
+import io.micronaut.views.htmx.http.HtmxResponseHeaders;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest // <1>
+class FruitControllerTest {
+
+    @Test
+    void normalRequestRendersFullPage(@Client("/") HttpClient httpClient) { // <2>
+        BlockingHttpClient client = httpClient.toBlocking();
+
+        String html = client.retrieve("/fruits");
+
+        assertTrue(html.contains("<!DOCTYPE html>"));
+        assertTrue(html.contains("hx-post=\"/fruits\""));
+        assertTrue(html.contains("<h2>Apple</h2>"));
+    }
+
+    @Test
+    void htmxRequestRendersPartial(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpRequest<?> request = HttpRequest.GET("/fruits")
+                .header(HtmxRequestHeaders.HX_REQUEST, StringUtils.TRUE);
+
+        String html = client.retrieve(request);
+
+        assertFalse(html.contains("<!DOCTYPE html>"));
+        assertTrue(html.contains("<section id=\"fruit\">"));
+        assertTrue(html.contains("<h2>Apple</h2>"));
+    }
+
+    @Test
+    void htmxPostCanRenderOutOfBandSwap(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpRequest<?> request = HttpRequest.POST("/fruits", Collections.emptyMap())
+                .header(HtmxRequestHeaders.HX_REQUEST, StringUtils.TRUE);
+
+        String html = client.retrieve(request);
+
+        assertTrue(html.contains("<h2>Banana</h2>"));
+        assertTrue(html.contains("<div id=\"message\" hx-swap-oob=\"true\">Selected Banana</div>"));
+    }
+
+    @Test
+    void htmxResponseHeadersCanBeSet(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpRequest<?> request = HttpRequest.GET("/fruits/refresh")
+                .header(HtmxRequestHeaders.HX_REQUEST, StringUtils.TRUE);
+
+        HttpResponse<?> response = client.exchange(request);
+
+        assertEquals(StringUtils.TRUE, response.getHeaders().get(HtmxResponseHeaders.HX_REFRESH));
+    }
+}

--- a/guides/micronaut-views-htmx/metadata.json
+++ b/guides/micronaut-views-htmx/metadata.json
@@ -1,0 +1,15 @@
+{
+  "title": "HTMX with Micronaut Views",
+  "intro": "Learn how to use HTMX request and response helpers with Micronaut Views.",
+  "authors": ["Sergio del Amo"],
+  "tags": ["htmx", "views", "thymeleaf"],
+  "categories": ["Views"],
+  "publicationDate": "2026-05-28",
+  "languages": ["JAVA"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["views-thymeleaf", "htmx"]
+    }
+  ]
+}

--- a/guides/micronaut-views-htmx/micronaut-views-htmx.adoc
+++ b/guides/micronaut-views-htmx/micronaut-views-htmx.adoc
@@ -28,8 +28,8 @@ source:FruitController[]
 <3> A normal `GET /fruits` request renders the full page.
 <4> `HtmxRequestHeaders` is bound only when the request contains HTMX headers. The route uses it to choose the full-page view or the partial view.
 <5> A form submission can return several templates in one HTMX response.
-<6> `HtmxResponse` renders each `ModelAndView` in order. The second template uses an out-of-band swap.
-<7> HTMX response header constants avoid hard-coding response header names.
+<6> The POST route also accepts normal browser submissions. When HTMX headers are present, `HtmxResponse` renders each `ModelAndView` in order. The second template uses an out-of-band swap.
+<7> The refresh route falls back to a redirect for normal browser requests. For HTMX requests, response header constants avoid hard-coding response header names.
 
 == Full Page
 

--- a/guides/micronaut-views-htmx/micronaut-views-htmx.adoc
+++ b/guides/micronaut-views-htmx/micronaut-views-htmx.adoc
@@ -1,0 +1,77 @@
+common:header.adoc[]
+
+common:requirements.adoc[]
+
+common:completesolution.adoc[]
+
+common:create-app-features.adoc[]
+
+common:micronaut-views-thymeleaf.adoc[]
+
+== HTMX
+
+https://htmx.org[HTMX] lets you add dynamic behavior to server-rendered HTML with HTML attributes.
+Micronaut Views provides helpers for HTMX request headers, response headers, and multi-template responses.
+
+The `htmx` feature adds the Micronaut Views HTMX integration to the application.
+
+dependency:micronaut-views-htmx[groupId=io.micronaut.views]
+
+== Controller
+
+Create a controller that renders a full page for normal browser requests and a partial template for HTMX requests.
+
+source:FruitController[]
+
+<1> The controller is available under `/fruits`.
+<2> The routes render HTML.
+<3> A normal `GET /fruits` request renders the full page.
+<4> `HtmxRequestHeaders` is bound only when the request contains HTMX headers. The route uses it to choose the full-page view or the partial view.
+<5> A form submission can return several templates in one HTMX response.
+<6> `HtmxResponse` renders each `ModelAndView` in order. The second template uses an out-of-band swap.
+<7> HTMX response header constants avoid hard-coding response header names.
+
+== Full Page
+
+Create a Thymeleaf template in `src/main/resources/views/fruits.html`.
+It renders a regular page and adds HTMX attributes to the form.
+
+resource:views/fruits.html[]
+
+== Partial View
+
+Create a Thymeleaf partial in `src/main/resources/views/fruit.html`.
+The controller returns this template when the request is an HTMX request.
+
+resource:views/fruit.html[]
+
+== Out-of-band Swap
+
+Create another partial in `src/main/resources/views/message.html`.
+The `hx-swap-oob` attribute updates an element outside the normal target.
+
+resource:views/message.html[]
+
+== Test
+
+Write a test that verifies normal HTML rendering, HTMX partial rendering, out-of-band swaps, and HTMX response headers.
+
+test:FruitControllerTest[]
+
+callout:micronaut-test[]
+callout:http-client[]
+
+common:testApp.adoc[]
+
+common:runapp.adoc[]
+
+Visit http://localhost:8080/fruits and click the button. HTMX replaces the fruit section without reloading the whole page.
+
+common:next.adoc[]
+
+Read more about:
+
+- https://micronaut-projects.github.io/micronaut-views/latest/guide/#htmx[Micronaut Views HTMX].
+- https://htmx.org/docs/[HTMX].
+
+common:helpWithMicronaut.adoc[]

--- a/guides/micronaut-views-htmx/src/main/resources/views/fruit.html
+++ b/guides/micronaut-views-htmx/src/main/resources/views/fruit.html
@@ -1,0 +1,4 @@
+<section id="fruit">
+    <h2 th:text="${fruitName}"></h2>
+    <p th:text="${fruitColor}"></p>
+</section>

--- a/guides/micronaut-views-htmx/src/main/resources/views/fruits.html
+++ b/guides/micronaut-views-htmx/src/main/resources/views/fruits.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Fruits</title>
+</head>
+<body>
+<main>
+    <h1>Fruits</h1>
+    <section id="fruit">
+        <h2 th:text="${fruitName}"></h2>
+        <p th:text="${fruitColor}"></p>
+    </section>
+    <div id="message">Choose another fruit</div>
+    <form method="post" action="/fruits" hx-post="/fruits" hx-target="#fruit" hx-swap="outerHTML">
+        <button type="submit">Choose Banana</button>
+    </form>
+</main>
+</body>
+</html>

--- a/guides/micronaut-views-htmx/src/main/resources/views/message.html
+++ b/guides/micronaut-views-htmx/src/main/resources/views/message.html
@@ -1,0 +1,1 @@
+<div id="message" hx-swap-oob="true" th:text="${message}"></div>


### PR DESCRIPTION
## Summary

- Added the `micronaut-views-htmx` standalone guide for using HTMX with Micronaut Views.
- Covers full-page Thymeleaf rendering, HTMX partial rendering, out-of-band swaps, and HTMX response headers.
- Java-only guide, matching the existing Java-only Views guide pattern.
- Addressed review feedback by adding normal browser fallbacks for the POST and refresh routes, plus a less brittle out-of-band swap assertion.

## Validation

- `./gradlew micronautViewsHtmxRunTestScript` passed for generated Gradle and Maven Java apps after the review-fix commit.
- `./gradlew asciidoctor copyHtmlToDist` passed and rendered `build/dist/micronaut-views-htmx-gradle-java.html` after the review-fix commit.
- Inspected rendered HTML for the guide title, controller snippets, HTMX attributes, normal POST fallback test, out-of-band swap content, and tests.
- Earlier local `./gradlew micronautViewsHtmxBuild` generated the guide, zips, and docs, then failed in `micronautViewsHtmxRunNativeTestScript` because the local GraalVM installation does not provide the reachability metadata schema expected by the local Gradle native-build-tools cache. The JVM generated-app tests passed separately.

## Review PDF

- Public PDF artifact exported from the rendered Gradle Java guide page after the review-fix commit: [micronaut-views-htmx-guide-preview.pdf](https://filebin.net/mng-484-micronaut-views-htmx/micronaut-views-htmx-guide-preview.pdf)
- Download verification: SHA-256 `c364d427bf610072841675dba9c23ffc00c4bbab808b7e8e16a8019ff1f5b135`, matching the locally exported PDF and the updated Paperclip attachment.
- The PDF was not committed to the repository.

## Notes

- Duplicate checks found no open `micronaut-guides` issue or PR for HTMX under `htmx` / `HTMX` searches.
- Existing nearby coverage includes `micronaut-views-thymeleaf`, `micronaut-webjars-stimulus`, `micronaut-static-resources`, `hotwire-turbo-micronaut-chat`, and `micronaut-turbo-native`.
- Qute was considered but not implemented here because `views-qute` is not currently a Micronaut Launch feature; the related Micronaut Views enhancement is still open.

---
###### ✨ This message was AI-generated using gpt-5.5
