### PR TITLE
Add Groovy variant for many-to-many MySQL guide

### DIFF
--- a/guides/micronaut-data-many-to-many-base/groovy/src/main/groovy/example/micronaut/Role.groovy
+++ b/guides/micronaut-data-many-to-many-base/groovy/src/main/groovy/example/micronaut/Role.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import jakarta.validation.constraints.NotBlank
+
+@CompileStatic
+@MappedEntity // <1>
+class Role {
+
+    @Nullable
+    @Id // <2>
+    @GeneratedValue // <3>
+    Long id
+
+    @NotBlank // <4>
+    final String authority
+
+    Role(String authority) {
+        this.authority = authority
+    }
+}

--- a/guides/micronaut-data-many-to-many-base/groovy/src/main/groovy/example/micronaut/User.groovy
+++ b/guides/micronaut-data-many-to-many-base/groovy/src/main/groovy/example/micronaut/User.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+import jakarta.validation.constraints.NotBlank
+
+@CompileStatic
+@Introspected // <1>
+class User {
+
+    @NonNull
+    @NotBlank
+    final Long id
+
+    @NonNull
+    @NotBlank
+    final String username
+
+    @Nullable
+    final List<String> authorities
+
+    User(@NonNull Long id,
+         @NonNull String username,
+         @Nullable List<String> authorities) {
+        this.id = id
+        this.username = username
+        this.authorities = authorities
+    }
+}

--- a/guides/micronaut-data-many-to-many-base/groovy/src/main/groovy/example/micronaut/UserEntity.groovy
+++ b/guides/micronaut-data-many-to-many-base/groovy/src/main/groovy/example/micronaut/UserEntity.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.data.annotation.GeneratedValue
+import io.micronaut.data.annotation.Id
+import io.micronaut.data.annotation.MappedEntity
+import jakarta.validation.constraints.NotBlank
+
+@CompileStatic
+@MappedEntity('users') // <1>
+class UserEntity {
+
+    @Nullable
+    @Id // <2>
+    @GeneratedValue // <3>
+    Long id
+
+    @NotBlank // <4>
+    final String username
+
+    UserEntity(String username) {
+        this.username = username
+    }
+}

--- a/guides/micronaut-data-many-to-many-base/groovy/src/main/groovy/example/micronaut/UserRole.groovy
+++ b/guides/micronaut-data-many-to-many-base/groovy/src/main/groovy/example/micronaut/UserRole.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.data.annotation.EmbeddedId
+import io.micronaut.data.annotation.MappedEntity
+
+@CompileStatic
+@MappedEntity // <1>
+class UserRole {
+
+    @EmbeddedId // <2>
+    final UserRoleId id
+
+    UserRole(UserRoleId id) {
+        this.id = id
+    }
+
+    UserRole(UserEntity user, Role role) {
+        this(new UserRoleId(user, role))
+    }
+}

--- a/guides/micronaut-data-many-to-many-base/groovy/src/main/groovy/example/micronaut/UserRoleId.groovy
+++ b/guides/micronaut-data-many-to-many-base/groovy/src/main/groovy/example/micronaut/UserRoleId.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import groovy.transform.CompileStatic
+import io.micronaut.core.annotation.Creator
+import io.micronaut.data.annotation.Embeddable
+import io.micronaut.data.annotation.Relation
+
+@CompileStatic
+@Embeddable // <1>
+class UserRoleId {
+
+    @Relation(value = Relation.Kind.MANY_TO_ONE) // <2>
+    final UserEntity user
+
+    @Relation(value = Relation.Kind.MANY_TO_ONE) // <2>
+    final Role role
+
+    @Creator
+    UserRoleId(UserEntity user, Role role) {
+        this.user = user
+        this.role = role
+    }
+
+    @Override
+    boolean equals(Object o) {
+        if (this.is(o)) {
+            return true
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false
+        }
+        UserRoleId that = (UserRoleId) o
+        role.id == that.role.id && user.id == that.user.id
+    }
+
+    @Override
+    int hashCode() {
+        Objects.hash(role.id, user.id)
+    }
+}

--- a/guides/micronaut-data-many-to-many-base/groovy/src/main/resources/db/liquibase-changelog.xml
+++ b/guides/micronaut-data-many-to-many-base/groovy/src/main/resources/db/liquibase-changelog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <include file="changelog/01-schema.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/guides/micronaut-data-many-to-many-base/groovy/src/test/groovy/example/micronaut/ManyToManySpec.groovy
+++ b/guides/micronaut-data-many-to-many-base/groovy/src/test/groovy/example/micronaut/ManyToManySpec.groovy
@@ -1,0 +1,68 @@
+package example.micronaut
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false) // <1>
+class ManyToManySpec extends Specification {
+
+    private static final String ROLE_USER = 'ROLE_USER'
+    private static final String ROLE_ADMIN = 'ROLE_ADMIN'
+    private static final String U_SERGIO = 'sergio'
+    private static final String U_TIM = 'tim'
+
+    @Inject
+    RoleJdbcRepository roleRepo
+
+    @Inject
+    UserJdbcRepository userRepo
+
+    @Inject
+    UserRoleJdbcRepository userRoleRepo
+
+    void "test many-to-many persistence"() {
+        when:
+        Role roleUser = roleRepo.save(ROLE_USER)
+        Role roleAdmin = roleRepo.save(ROLE_ADMIN)
+
+        then:
+        !userRepo.findByUsername(U_SERGIO).present
+
+        when:
+        UserEntity sergio = userRepo.save(U_SERGIO)
+
+        then:
+        assertUser(userRepo.findByUsername(U_SERGIO).orElse(null), U_SERGIO, null)
+
+        when:
+        userRoleRepo.save(new UserRole(sergio, roleUser))
+        userRoleRepo.save(new UserRole(sergio, roleAdmin))
+
+        then:
+        assertUser(userRepo.findByUsername(U_SERGIO).orElse(null), U_SERGIO, [ROLE_ADMIN, ROLE_USER])
+
+        when:
+        UserEntity tim = userRepo.save(U_TIM)
+        userRoleRepo.save(new UserRole(tim, roleUser))
+
+        then:
+        assertUser(userRepo.findByUsername(U_TIM).orElse(null), U_TIM, [ROLE_USER])
+
+        cleanup:
+        userRoleRepo.delete(new UserRole(tim, roleUser))
+        userRoleRepo.delete(new UserRole(sergio, roleUser))
+        userRoleRepo.delete(new UserRole(sergio, roleAdmin))
+        userRepo.delete(sergio)
+        userRepo.delete(tim)
+        roleRepo.deleteByAuthority(ROLE_ADMIN)
+        roleRepo.deleteByAuthority(ROLE_USER)
+    }
+
+    private static void assertUser(User user, String expectedUsername, List<String> expectedAuthorities) {
+        assert user
+        assert user.id
+        assert user.username == expectedUsername
+        assert user.authorities == expectedAuthorities
+    }
+}

--- a/guides/micronaut-data-many-to-many-mysql/groovy/src/main/groovy/example/micronaut/RoleJdbcRepository.groovy
+++ b/guides/micronaut-data-many-to-many-mysql/groovy/src/main/groovy/example/micronaut/RoleJdbcRepository.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+
+@JdbcRepository(dialect = Dialect.MYSQL) // <1>
+interface RoleJdbcRepository extends CrudRepository<Role, Long> { // <2>
+    Role save(String authority)
+
+    Optional<Role> findByAuthority(String authority)
+
+    void deleteByAuthority(String authority)
+}

--- a/guides/micronaut-data-many-to-many-mysql/groovy/src/main/groovy/example/micronaut/UserJdbcRepository.groovy
+++ b/guides/micronaut-data-many-to-many-mysql/groovy/src/main/groovy/example/micronaut/UserJdbcRepository.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.annotation.Query
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+
+@JdbcRepository(dialect = Dialect.MYSQL) // <1>
+interface UserJdbcRepository extends CrudRepository<UserEntity, Long> { // <2>
+    UserEntity save(String username)
+
+    // <3>
+    @Query(value = '''
+            SELECT
+                u.id,
+                u.username,
+                GROUP_CONCAT(DISTINCT r.authority ORDER BY r.authority SEPARATOR ',') AS authorities
+            FROM users AS u
+            LEFT JOIN user_role AS ur ON ur.user_id = u.id
+            LEFT JOIN role AS r ON r.id = ur.role_id
+            WHERE u.username = :username
+            GROUP BY u.id, u.username;
+            ''')
+    Optional<User> findByUsername(String username)
+}

--- a/guides/micronaut-data-many-to-many-mysql/groovy/src/main/groovy/example/micronaut/UserRoleJdbcRepository.groovy
+++ b/guides/micronaut-data-many-to-many-mysql/groovy/src/main/groovy/example/micronaut/UserRoleJdbcRepository.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.repository.CrudRepository
+
+@JdbcRepository(dialect = Dialect.MYSQL) // <1>
+interface UserRoleJdbcRepository extends CrudRepository<UserRole, UserRoleId> { // <2>
+}

--- a/guides/micronaut-data-many-to-many-mysql/groovy/src/main/resources/application.properties
+++ b/guides/micronaut-data-many-to-many-mysql/groovy/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+micronaut.application.name=micronautguide
+#tag::liquibase[]
+liquibase.datasources.default.change-log=classpath\:db/liquibase-changelog.xml
+#end::liquibase[]
+#tag::datasource[]
+datasources.default.schema-generate=NONE
+# <1>
+datasources.default.driver-class-name=com.mysql.cj.jdbc.Driver
+# <2>
+datasources.default.db-type=mysql
+# <3>
+datasources.default.dialect=MYSQL
+#end::datasource[]

--- a/guides/micronaut-data-many-to-many-mysql/groovy/src/main/resources/db/changelog/01-schema.xml
+++ b/guides/micronaut-data-many-to-many-mysql/groovy/src/main/resources/db/changelog/01-schema.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="01" author="username">
+      <createTable tableName="users">
+          <column name="id" type="BIGINT" autoIncrement="true">
+              <constraints primaryKey="true" primaryKeyName="pk_user" nullable="false"/>
+          </column>
+          <column name="username" type="VARCHAR(255)">
+              <constraints nullable="false" unique="true" uniqueConstraintName="uk_user_username"/>
+          </column>
+      </createTable>
+
+      <createTable tableName="role">
+          <column name="id" type="BIGINT" autoIncrement="true">
+              <constraints primaryKey="true" primaryKeyName="pk_role" nullable="false"/>
+          </column>
+          <column name="authority" type="VARCHAR(255)">
+              <constraints nullable="false" unique="true" uniqueConstraintName="uk_role_authority"/>
+          </column>
+      </createTable>
+
+      <createTable tableName="user_role">
+          <column name="user_id" type="BIGINT">
+              <constraints nullable="false"/>
+          </column>
+          <column name="role_id" type="BIGINT">
+              <constraints nullable="false"/>
+          </column>
+      </createTable>
+
+      <addPrimaryKey tableName="user_role" constraintName="pk_user_role" columnNames="user_id, role_id"/>
+
+      <addForeignKeyConstraint
+              baseTableName="user_role"
+              baseColumnNames="user_id"
+              constraintName="fk_user_role_user"
+              referencedTableName="users"
+              referencedColumnNames="id"
+              onDelete="CASCADE"/>
+
+      <addForeignKeyConstraint
+              baseTableName="user_role"
+              baseColumnNames="role_id"
+              constraintName="fk_user_role_role"
+              referencedTableName="role"
+              referencedColumnNames="id"
+              onDelete="CASCADE"/>
+  </changeSet>
+</databaseChangeLog>

--- a/guides/micronaut-data-many-to-many-mysql/metadata.json
+++ b/guides/micronaut-data-many-to-many-mysql/metadata.json
@@ -5,7 +5,7 @@
   "authors": ["Sergio del Amo"],
   "tags": [],
   "categories": ["Database Modeling"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "publicationDate": "2025-11-12",
   "apps": [
     {


### PR DESCRIPTION
## Summary

- Add Groovy source and resources for the shared many-to-many base guide and the MySQL guide variant.
- Add `GROOVY` to `guides/micronaut-data-many-to-many-mysql/metadata.json`.
- Use a Spock `ManyToManySpec` with Micronaut field injection for the repositories.

## Verification

- `git diff --check origin/master...HEAD`
- `docker info`
- `./gradlew micronautDataManyToManyMysqlBuild --stacktrace -x micronautDataManyToManyMysqlRunNativeTestScript`

The native-image path was left out of the reviewer rerun because the local GraalVM setup fails in the pre-existing generated Java native-test path with reachability-metadata schema compatibility. The non-native guide build and generated sample test script pass with Docker/Testcontainers.

## Release Target

Target branch: `master`.

Micronaut organization project selected by QA intake: `5.0.1 Release` (#146). The recorded ambiguity still applies: `micronaut-guides` has no stable GitHub release and default branch metadata still says `5.0.0`, so `5.0.1 Release` is the earliest open Micronaut Platform BOM release board selected for this docs/sample-code change.

## Routing Notes

- Linked issue creator/reporter: `sdelamo`. The reviewer request was attempted after PR creation, but GitHub rejected it with: `Review cannot be requested from pull request author.`
- Live project association was attempted for `5.0.1 Release` (#146), but GitHub rejected the mutation because `addProjectV2ItemById` requires the `project` scope and the available token only has `read:project` for projects.

## PR Assets

None. This PR changes sample code/resources and guide metadata only; no rendered screenshot, PDF, or generated artifact upload is needed for review.

Closes #1689

---
###### ✨ This message was AI-generated using GPT-5
