### PR TITLE
Add Micronaut Control Panel guide

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/ControlPanelUi.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/ControlPanelUi.java
@@ -12,9 +12,7 @@ public class ControlPanelUi extends AbstractFeature {
     }
 
     @Override
-    protected void addDependency(GeneratorContext generatorContext,
-                                 String artifactId,
-                                 Scope scope) {
+    public void apply(GeneratorContext generatorContext) {
         addDependencyWithoutLookup(generatorContext, "io.micronaut.controlpanel");
     }
 }

--- a/buildSrc/src/main/java/io/micronaut/guides/feature/ControlPanelUi.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/ControlPanelUi.java
@@ -1,0 +1,20 @@
+package io.micronaut.guides.feature;
+
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.Scope;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ControlPanelUi extends AbstractFeature {
+
+    public ControlPanelUi() {
+        super("control-panel-ui", "micronaut-control-panel-ui", Scope.COMPILE);
+    }
+
+    @Override
+    protected void addDependency(GeneratorContext generatorContext,
+                                 String artifactId,
+                                 Scope scope) {
+        addDependencyWithoutLookup(generatorContext, "io.micronaut.controlpanel");
+    }
+}

--- a/guides/micronaut-control-panel/java/src/test/java/example/micronaut/ControlPanelTest.java
+++ b/guides/micronaut-control-panel/java/src/test/java/example/micronaut/ControlPanelTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package example.micronaut;
 
 import io.micronaut.http.HttpRequest;

--- a/guides/micronaut-control-panel/java/src/test/java/example/micronaut/ControlPanelTest.java
+++ b/guides/micronaut-control-panel/java/src/test/java/example/micronaut/ControlPanelTest.java
@@ -1,0 +1,29 @@
+package example.micronaut;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest // <1>
+class ControlPanelTest {
+
+    @Inject
+    @Client("/") // <2>
+    HttpClient client;
+
+    @Test
+    void rendersTheControlPanel() {
+        var blockingClient = client.toBlocking();
+        var index = blockingClient.exchange(HttpRequest.GET("/control-panel"), String.class);
+
+        assertEquals(HttpStatus.OK, index.status());
+        assertTrue(index.body().contains("Routes"));
+    }
+}

--- a/guides/micronaut-control-panel/metadata.json
+++ b/guides/micronaut-control-panel/metadata.json
@@ -1,0 +1,15 @@
+{
+  "title": "Micronaut Control Panel",
+  "intro": "Learn how to add Micronaut Control Panel to a development application.",
+  "authors": ["Micronaut Team"],
+  "tags": ["control-panel", "development", "views"],
+  "categories": ["Development"],
+  "publicationDate": "2026-05-27",
+  "languages": ["JAVA"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["control-panel-ui", "views-handlebars", "management"]
+    }
+  ]
+}

--- a/guides/micronaut-control-panel/micronaut-control-panel.adoc
+++ b/guides/micronaut-control-panel/micronaut-control-panel.adoc
@@ -1,0 +1,63 @@
+common:header-top.adoc[]
+
+== Getting Started
+
+In this guide, you will add Micronaut Control Panel to a Micronaut application and verify that the built-in routes panel is available.
+
+Micronaut Control Panel is intended for development-time application inspection. Keep it enabled only in development or test environments.
+
+common:requirements.adoc[]
+
+common:completesolution.adoc[]
+
+common:create-app.adoc[]
+
+=== Add Micronaut Control Panel
+
+Add the Micronaut Control Panel UI dependency:
+
+dependency:micronaut-control-panel-ui[groupId=io.micronaut.controlpanel]
+
+Micronaut Control Panel uses Micronaut Views with Handlebars templates to render panel pages:
+
+dependency:micronaut-views-handlebars[groupId=io.micronaut.views]
+
+Add Micronaut Management so the Control Panel controller can inspect management endpoints:
+
+dependency:micronaut-management[]
+
+By default, Control Panel is enabled in the `dev` and `test` environments and is available at `/control-panel`.
+
+=== Configure the Path
+
+You can keep the default path or configure a different one. This guide uses the default path explicitly:
+
+resource:application.properties[tag=control-panel]
+
+=== Test the Control Panel
+
+The UI module includes a routes panel. The following test starts the application, opens the Control Panel, and verifies that the routes panel is rendered:
+
+test:ControlPanelTest[]
+
+callout:micronaut-test[]
+callout:http-client[]
+
+common:testApp.adoc[]
+
+common:runapp.adoc[]
+
+Start the application in the `dev` environment:
+
+[source,bash]
+----
+MICRONAUT_ENVIRONMENTS=dev ./gradlew run
+----
+
+Open `http://localhost:8080/control-panel` in a browser. The built-in routes panel appears on the Control Panel dashboard.
+
+== Next Steps
+
+Read the https://micronaut-projects.github.io/micronaut-control-panel/latest/guide/[Micronaut Control Panel documentation] to learn about the built-in management, cache, datasource, Kafka, and object storage panels.
+
+common:helpWithMicronaut.adoc[]

--- a/guides/micronaut-control-panel/src/main/resources/application.properties
+++ b/guides/micronaut-control-panel/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+#tag::control-panel[]
+micronaut.control-panel.path=/control-panel
+#end::control-panel[]


### PR DESCRIPTION
## Summary

- Adds a Java-only Micronaut Guide for adding Micronaut Control Panel to a development application.
- Adds a small guides build feature for `io.micronaut.controlpanel:micronaut-control-panel-ui` so generated guide apps can include the Control Panel UI dependency.
- Includes a generated app test that starts the app, requests `/control-panel`, and verifies the built-in routes panel renders.

## Validation

- `./gradlew micronautControlPanelGenerateDocs micronautControlPanelGenerateZips micronautControlPanelIndex micronautControlPanelRunTestScript --rerun-tasks` - passed for generated Gradle and Maven Java apps.
- `./gradlew micronautControlPanelGenerateDocs micronautControlPanelRunTestScript` - passed after the final import cleanup.
- Rendered HTML inspected: `build/dist/micronaut-control-panel.html`.
- PDF exported with Playwright: `micronaut-control-panel-guide.pdf`.

## PDF Artifact

The exact PDF export was generated locally as `micronaut-control-panel-guide.pdf` and intentionally not committed. I attempted to publish it with `gh gist create --public micronaut-control-panel-guide.pdf`, but GitHub CLI rejected the binary file with `binary file not supported`. A maintainer-visible PR attachment still needs a browser upload or another approved binary artifact host.

## Notes

`./gradlew micronautControlPanelBuild` was not used as the final validation command because this repository runs native tests from that task when the local JDK is GraalVM. The generated Control Panel app passed JVM validation, but native-image test compilation fails on the existing Control Panel `ControlPanelEnabledCondition` image-heap initialization issue, which is outside this beginner development-UI guide.

---
###### ✨ This message was AI-generated using gpt-5.5
