### PR TITLE
docs: add Postmark email guide

### DIFF
--- a/guides/micronaut-email-postmark/groovy/src/main/groovy/example/micronaut/MailController.groovy
+++ b/guides/micronaut-email-postmark/groovy/src/main/groovy/example/micronaut/MailController.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.postmarkapp.postmark.client.data.model.message.Message
+import com.postmarkapp.postmark.client.data.model.message.MessageResponse
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.micronaut.email.AsyncEmailSender
+import io.micronaut.email.Email
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+
+import static io.micronaut.email.BodyType.HTML
+
+@CompileStatic
+@Slf4j
+@Controller('/mail') // <1>
+class MailController {
+
+    private final AsyncEmailSender<Message, MessageResponse> emailSender
+
+    MailController(AsyncEmailSender<Message, MessageResponse> emailSender) { // <2>
+        this.emailSender = emailSender
+    }
+
+    @Post('/send') // <3>
+    Publisher<HttpResponse<?>> send(@Body('to') String to) { // <4>
+        Mono.from(emailSender.sendAsync(Email.builder()
+                .to(to)
+                .subject('Sending email with Postmark is Fun')
+                .body('and <em>easy</em> to do anywhere with <strong>Micronaut Email</strong>', HTML), // <5>
+                { Message message ->
+                    message.tag = 'welcome'
+                    message.addHeader('X-Customer-Type', 'trial')
+                }))
+                .doOnNext(rsp -> {
+                    log.info('message id: {}', rsp.messageId)
+                }).map(rsp -> HttpResponse.accepted()) // <6>
+                as Publisher
+    }
+}

--- a/guides/micronaut-email-postmark/groovy/src/test/groovy/example/micronaut/EmailSenderReplacement.groovy
+++ b/guides/micronaut-email-postmark/groovy/src/test/groovy/example/micronaut/EmailSenderReplacement.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.postmarkapp.postmark.client.data.model.message.Message
+import com.postmarkapp.postmark.client.data.model.message.MessageResponse
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.email.AsyncTransactionalEmailSender
+import io.micronaut.email.Email
+import io.micronaut.email.EmailException
+import io.micronaut.email.postmark.PostmarkEmailSender
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
+import java.util.function.Consumer
+
+@Requires(property = 'spec.name', value = 'MailControllerSpec') // <1>
+@Singleton
+@Replaces(PostmarkEmailSender)
+@Named(EmailSenderReplacement.NAME)
+class EmailSenderReplacement implements AsyncTransactionalEmailSender<Message, MessageResponse> {
+
+    public static final String NAME = 'postmark'
+
+    final List<Email> emails = []
+    final List<Message> messages = []
+
+    @Override
+    String getName() {
+        NAME
+    }
+
+    @Override
+    Publisher<MessageResponse> sendAsync(@NotNull @Valid Email email,
+                                  @NotNull Consumer<Message> emailRequest) throws EmailException {
+        emails << email
+        Message message = new Message()
+        emailRequest.accept(message)
+        messages << message
+        MessageResponse response = new MessageResponse()
+        response.messageId = '00000000-0000-0000-0000-000000000000'
+        Mono.just(response)
+    }
+}

--- a/guides/micronaut-email-postmark/groovy/src/test/groovy/example/micronaut/MailControllerSpec.groovy
+++ b/guides/micronaut-email-postmark/groovy/src/test/groovy/example/micronaut/MailControllerSpec.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.email.AsyncTransactionalEmailSender
+import io.micronaut.email.Email
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+import static io.micronaut.email.BodyType.HTML
+import static io.micronaut.http.HttpStatus.ACCEPTED
+
+@Property(name = 'spec.name', value = 'MailControllerSpec') // <1>
+@MicronautTest // <2>
+class MailControllerSpec extends Specification {
+
+    @Inject
+    @Client('/')
+    HttpClient httpClient // <3>
+
+    @Inject
+    BeanContext beanContext
+
+    void getMailSendEndpointSendsAnEmail() {
+
+        when:
+        HttpResponse<?> response = httpClient.toBlocking().exchange(
+                HttpRequest.POST('/mail/send', [to: 'johnsnow@micronaut.example']))
+
+        then:
+        ACCEPTED == response.status()
+
+        when:
+        AsyncTransactionalEmailSender<?, ?> sender = beanContext.getBean(AsyncTransactionalEmailSender)
+
+        then:
+        sender instanceof EmailSenderReplacement
+
+        when:
+        EmailSenderReplacement postmarkSender = (EmailSenderReplacement) sender
+
+        then:
+        1 == postmarkSender.emails.size()
+
+        when:
+        Email email = postmarkSender.emails[0]
+
+        then:
+        email.from.email == 'john@micronaut.example'
+        email.to
+        email.to.first()
+        email.to.first().email == 'johnsnow@micronaut.example'
+        email.subject == 'Sending email with Postmark is Fun'
+        email.body
+        email.body.get(HTML).present
+        email.body.get(HTML).get() == 'and <em>easy</em> to do anywhere with <strong>Micronaut Email</strong>'
+        1 == postmarkSender.messages.size()
+        postmarkSender.messages[0].tag == 'welcome'
+        postmarkSender.messages[0].headers[0].name == 'X-Customer-Type'
+        postmarkSender.messages[0].headers[0].value == 'trial'
+    }
+}

--- a/guides/micronaut-email-postmark/java/src/main/java/example/micronaut/MailController.java
+++ b/guides/micronaut-email-postmark/java/src/main/java/example/micronaut/MailController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import com.postmarkapp.postmark.client.data.model.message.Message;
+import com.postmarkapp.postmark.client.data.model.message.MessageResponse;
+import io.micronaut.email.AsyncEmailSender;
+import io.micronaut.email.Email;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import static io.micronaut.email.BodyType.HTML;
+
+@Controller("/mail") // <1>
+public class MailController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MailController.class);
+
+    private final AsyncEmailSender<Message, MessageResponse> emailSender;
+
+    public MailController(AsyncEmailSender<Message, MessageResponse> emailSender) { // <2>
+        this.emailSender = emailSender;
+    }
+
+    @Post("/send") // <3>
+    public Publisher<HttpResponse<?>> send(@Body("to") String to) { // <4>
+        return Mono.from(emailSender.sendAsync(Email.builder()
+                        .to(to)
+                        .subject("Sending email with Postmark is Fun")
+                        .body("and <em>easy</em> to do anywhere with <strong>Micronaut Email</strong>", HTML),
+                        message -> { // <5>
+                            message.setTag("welcome");
+                            message.addHeader("X-Customer-Type", "trial");
+                        }))
+                .doOnNext(rsp -> {
+                    LOG.info("message id: {}", rsp.getMessageId());
+                }).map(rsp -> HttpResponse.accepted()); // <6>
+    }
+}

--- a/guides/micronaut-email-postmark/java/src/test/java/example/micronaut/EmailSenderReplacement.java
+++ b/guides/micronaut-email-postmark/java/src/test/java/example/micronaut/EmailSenderReplacement.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import com.postmarkapp.postmark.client.data.model.message.Message;
+import com.postmarkapp.postmark.client.data.model.message.MessageResponse;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.email.AsyncTransactionalEmailSender;
+import io.micronaut.email.Email;
+import io.micronaut.email.EmailException;
+import io.micronaut.email.postmark.PostmarkEmailSender;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+@Requires(property = "spec.name", value = "MailControllerTest") // <1>
+@Singleton
+@Replaces(PostmarkEmailSender.class)
+@Named(EmailSenderReplacement.NAME)
+class EmailSenderReplacement implements AsyncTransactionalEmailSender<Message, MessageResponse> {
+
+    public static final String NAME = "postmark";
+
+    final List<Email> emails = new ArrayList<>();
+    final List<Message> messages = new ArrayList<>();
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Publisher<MessageResponse> sendAsync(@NotNull @Valid Email email,
+                                         @NotNull Consumer<Message> emailRequest) throws EmailException {
+        emails.add(email);
+        Message message = new Message();
+        emailRequest.accept(message);
+        messages.add(message);
+        MessageResponse response = new MessageResponse();
+        response.setMessageId("00000000-0000-0000-0000-000000000000");
+        return Mono.just(response);
+    }
+
+    public List<Email> getEmails() {
+        return emails;
+    }
+
+    public List<Message> getMessages() {
+        return messages;
+    }
+}

--- a/guides/micronaut-email-postmark/java/src/test/java/example/micronaut/MailControllerTest.java
+++ b/guides/micronaut-email-postmark/java/src/test/java/example/micronaut/MailControllerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.email.AsyncTransactionalEmailSender;
+import io.micronaut.email.Email;
+import com.postmarkapp.postmark.client.data.model.message.Message;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static io.micronaut.email.BodyType.HTML;
+import static io.micronaut.http.HttpStatus.ACCEPTED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Property(name = "spec.name", value = "MailControllerTest") // <1>
+@MicronautTest // <2>
+public class MailControllerTest {
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient; // <3>
+
+    @Inject
+    BeanContext beanContext;
+
+    @Test
+    void getMailSendEndpointSendsAnEmail() {
+
+        HttpResponse<?> response = httpClient.toBlocking().exchange(
+                HttpRequest.POST("/mail/send",
+                Collections.singletonMap("to", "johnsnow@micronaut.example")));
+        assertEquals(ACCEPTED, response.status());
+
+        AsyncTransactionalEmailSender<?, ?> sender = beanContext.getBean(AsyncTransactionalEmailSender.class);
+        assertTrue(sender instanceof EmailSenderReplacement);
+
+        EmailSenderReplacement postmarkSender = (EmailSenderReplacement) sender;
+        assertTrue(CollectionUtils.isNotEmpty(postmarkSender.emails));
+        assertEquals(1, postmarkSender.emails.size());
+
+        Email email = postmarkSender.emails.get(0);
+        assertEquals(email.getFrom().getEmail(), "john@micronaut.example");
+        assertNotNull(email.getTo());
+        assertTrue(email.getTo().stream().findFirst().isPresent());
+        assertEquals(email.getTo().stream().findFirst().get().getEmail(), "johnsnow@micronaut.example");
+        assertEquals(email.getSubject(), "Sending email with Postmark is Fun");
+        assertNotNull(email.getBody());
+        assertTrue(email.getBody().get(HTML).isPresent());
+        assertEquals(email.getBody().get(HTML).get(), "and <em>easy</em> to do anywhere with <strong>Micronaut Email</strong>");
+
+        assertEquals(1, postmarkSender.getMessages().size());
+        Message message = postmarkSender.getMessages().get(0);
+        assertEquals("welcome", message.getTag());
+        assertEquals("X-Customer-Type", message.getHeaders().get(0).getName());
+        assertEquals("trial", message.getHeaders().get(0).getValue());
+    }
+}

--- a/guides/micronaut-email-postmark/kotlin/src/main/kotlin/example/micronaut/MailController.kt
+++ b/guides/micronaut-email-postmark/kotlin/src/main/kotlin/example/micronaut/MailController.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.postmarkapp.postmark.client.data.model.message.Message
+import com.postmarkapp.postmark.client.data.model.message.MessageResponse
+import io.micronaut.email.AsyncEmailSender
+import io.micronaut.email.BodyType.HTML
+import io.micronaut.email.Email
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import org.reactivestreams.Publisher
+import org.slf4j.LoggerFactory
+import reactor.core.publisher.Mono
+
+@Controller("/mail") // <1>
+class MailController(private val emailSender: AsyncEmailSender<Message, MessageResponse>) { // <2>
+
+    @Post("/send") // <3>
+    fun send(@Body("to") to: String): Publisher<HttpResponse<*>> { // <4>
+        return Mono.from(emailSender.sendAsync(Email.builder()
+                .to(to)
+                .subject("Sending email with Postmark is Fun")
+                .body("and <em>easy</em> to do anywhere with <strong>Micronaut Email</strong>", HTML)
+        ) { message: Message -> // <5>
+            message.tag = "welcome"
+            message.addHeader("X-Customer-Type", "trial")
+        })
+                .doOnNext { rsp: MessageResponse ->
+                    LOG.info("message id: {}", rsp.messageId)
+                }.map { rsp: MessageResponse -> HttpResponse.accepted<Any>() } // <6>
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(MailController::class.java)
+    }
+}

--- a/guides/micronaut-email-postmark/kotlin/src/test/kotlin/example/micronaut/EmailSenderReplacement.kt
+++ b/guides/micronaut-email-postmark/kotlin/src/test/kotlin/example/micronaut/EmailSenderReplacement.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import com.postmarkapp.postmark.client.data.model.message.Message
+import com.postmarkapp.postmark.client.data.model.message.MessageResponse
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.email.AsyncTransactionalEmailSender
+import io.micronaut.email.Email
+import io.micronaut.email.EmailException
+import io.micronaut.email.postmark.PostmarkEmailSender
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+import java.util.function.Consumer
+import jakarta.validation.Valid
+
+@Requires(property = "spec.name", value = "MailControllerTest") // <1>
+@Singleton
+@Replaces(PostmarkEmailSender::class)
+@Named(EmailSenderReplacement.NAME)
+open class EmailSenderReplacement : AsyncTransactionalEmailSender<Message, MessageResponse> {
+
+    val emails = mutableListOf<Email>()
+    val messages = mutableListOf<Message>()
+
+    override fun getName(): String = NAME
+
+    @Throws(EmailException::class)
+    override fun sendAsync(@Valid email: Email,
+                           emailRequest: Consumer<Message>): Publisher<MessageResponse> {
+        emails.add(email)
+        val message = Message()
+        emailRequest.accept(message)
+        messages.add(message)
+        val response = MessageResponse()
+        response.messageId = "00000000-0000-0000-0000-000000000000"
+        return Mono.just(response)
+    }
+
+    companion object {
+        const val NAME = "postmark"
+    }
+}

--- a/guides/micronaut-email-postmark/kotlin/src/test/kotlin/example/micronaut/MailControllerTest.kt
+++ b/guides/micronaut-email-postmark/kotlin/src/test/kotlin/example/micronaut/MailControllerTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.util.CollectionUtils
+import io.micronaut.email.AsyncTransactionalEmailSender
+import io.micronaut.email.BodyType.HTML
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus.ACCEPTED
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@Property(name = "spec.name", value = "MailControllerTest") // <1>
+@MicronautTest // <2>
+class MailControllerTest(@Client("/") val httpClient: HttpClient) { // <3>
+
+    @Inject
+    lateinit var beanContext: BeanContext
+
+    @Test
+    fun mailSendEndpointSendsAnEmail() {
+
+        val response: HttpResponse<*> = httpClient.toBlocking().exchange<Map<String, String>, Any>(
+                HttpRequest.POST("/mail/send", mapOf("to" to "johnsnow@micronaut.example")))
+        assertEquals(ACCEPTED, response.status())
+
+        val sender = beanContext.getBean(AsyncTransactionalEmailSender::class.java)
+        assertTrue(sender is EmailSenderReplacement)
+
+        val postmarkSender = sender as EmailSenderReplacement
+        assertTrue(CollectionUtils.isNotEmpty(postmarkSender.emails as Collection<*>?))
+        assertEquals(1, postmarkSender.emails.size)
+
+        val email = postmarkSender.emails[0]
+        assertEquals(email.from.email, "john@micronaut.example")
+        assertNotNull(email.to)
+        assertTrue(email.to!!.stream().findFirst().isPresent)
+        assertEquals(email.to!!.stream().findFirst().get().email, "johnsnow@micronaut.example")
+        assertEquals(email.subject, "Sending email with Postmark is Fun")
+        assertNotNull(email.body)
+        assertTrue(email.body!![HTML].isPresent)
+        assertEquals(email.body!![HTML].get(), "and <em>easy</em> to do anywhere with <strong>Micronaut Email</strong>")
+
+        assertEquals(1, postmarkSender.messages.size)
+        val message = postmarkSender.messages[0]
+        assertEquals("welcome", message.tag)
+        assertEquals("X-Customer-Type", message.headers[0].name)
+        assertEquals("trial", message.headers[0].value)
+    }
+}

--- a/guides/micronaut-email-postmark/metadata.json
+++ b/guides/micronaut-email-postmark/metadata.json
@@ -1,0 +1,16 @@
+{
+  "title": "Send Emails with Postmark from the Micronaut Framework",
+  "intro": "Learn how to send emails with Postmark from a Micronaut application.",
+  "authors": ["Sergio del Amo"],
+  "tags": ["postmark"],
+  "categories": ["Email"],
+  "base": "micronaut-email",
+  "publicationDate": "2026-05-28",
+  "env": { "POSTMARK_API_TOKEN": "XXX" },
+  "apps": [
+    {
+      "name": "default",
+      "features": ["email-postmark","validation"]
+    }
+  ]
+}

--- a/guides/micronaut-email-postmark/micronaut-email-postmark.adoc
+++ b/guides/micronaut-email-postmark/micronaut-email-postmark.adoc
@@ -1,0 +1,73 @@
+external:micronaut-email/header.adoc[]
+
+=== Controller
+
+Create a `MailController` class. This class uses a collaborator, `emailSender`, to send an email.
+
+You can send emails asynchronously using the https://micronaut-projects.github.io/micronaut-email/latest/api/index.html[AsyncEmailSender] API or synchronously using the https://micronaut-projects.github.io/micronaut-email/latest/api/index.html[EmailSender] API.
+
+source:MailController[]
+
+callout:controller[arg0=/mail/send]
+callout:constructor-di[arg0=AsyncEmailSender]
+callout:post[arg0=send,arg1=/mail/send]
+callout:body-qualifier[]
+<5> Pass a `Consumer<Message>` to customize the Postmark message before sending it.
+<6> Return 202 ACCEPTED as the result if the email delivery succeeds.
+
+external:micronaut-email/configuration.adoc[]
+
+=== Postmark
+
+https://postmark.com/[Postmark] is a transactional email service.
+
+Postmark supports transactional email delivery with features such as message streams, metadata, headers, and tags.
+
+==== Postmark API Key
+
+To use the Micronaut Postmark integration, you need a Postmark server API token.
+
+You need to https://micronaut-projects.github.io/micronaut-email/latest/guide/#io.micronaut.email.postmark.PostmarkConfigurationProperties[configure] the `postmark.api-key` property. However, don't put it in `application.properties`. It's a password. Expose it via the `POSTMARK_API_TOKEN` environment variable, use a secret manager, or create an environment-specific configuration file that will not be included in source version control.
+
+==== Dependency
+
+Because we added the `email-postmark` feature, the application contains the following dependency:
+
+dependency:micronaut-email-postmark[groupId=io.micronaut.email]
+
+=== Customize the Postmark message
+
+The controller passes a `Consumer<Message>` to the email sender. Use that callback to customize the underlying Postmark message, for example to set a tag or add custom headers before Micronaut Email sends the message.
+
+external:micronaut-email/test.adoc[]
+
+== Running the Application
+
+=== API Key
+
+Set the Postmark API key as an environment variable before you run the application:
+
+[source, bash]
+----
+export POSTMARK_API_TOKEN=xxx
+----
+
+=== From email address
+
+Change the property `micronaut.email.from.email` to a sender address or sender signature verified in Postmark.
+
+=== Run
+common:runapp-instructions.adoc[]
+
+=== Invoke
+
+[source, bash]
+----
+curl -d '{"to":"john@micronaut.example"}' \
+     -H "Content-Type: application/json" \
+     -X POST http://localhost:8080/mail/send
+----
+
+external:micronaut-email/next.adoc[]
+
+common:helpWithMicronaut.adoc[]


### PR DESCRIPTION
## Summary

- Adds the `micronaut-email-postmark` standalone guide.
- Reuses the shared Micronaut Email base guide and adds Java, Groovy, and Kotlin examples.
- Demonstrates configuring Postmark with `POSTMARK_API_TOKEN` and using the `Consumer<Message>` callback to set a Postmark tag and custom header.

Closes #841.

## Validation

- `./gradlew clean micronautEmailPostmarkRunTestScript`
- `./gradlew clean micronautEmailPostmarkBuild -x micronautEmailPostmarkRunNativeTestScript`
- Rendered HTML inspected: `build/dist/micronaut-email-postmark-gradle-java.html`

## Review PDF

- PDF: `micronaut-email-postmark-guide-preview.pdf`
- PR-visible PDF link: https://files.catbox.moe/71hr09.pdf

## Notes

- `./gradlew clean micronautEmailPostmarkBuild` was also attempted without exclusions, but this local machine failed during `nativeTestCompile` because its GraalVM installation does not support the reachability metadata schema in the configured repository. The guide’s generated Java/Groovy/Kotlin and Maven Java tests passed through `micronautEmailPostmarkRunTestScript`.
- No secrets or local credentials are included in source, rendered HTML, or the PDF.

---
###### ✨ This message was AI-generated using gpt-5.5
