### PR TITLE
Add Groovy OCI OIDC guide variant

### DIFF
--- a/guides/micronaut-oauth2-oidc-oci/groovy/src/main/groovy/example/micronaut/HomeController.groovy
+++ b/guides/micronaut-oauth2-oidc-oci/groovy/src/main/groovy/example/micronaut/HomeController.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.views.View
+
+@Controller // <1>
+class HomeController {
+
+    @Secured(SecurityRule.IS_ANONYMOUS) // <2>
+    @View("home") // <3>
+    @Get // <4>
+    Map<String, Object> index() {
+        [:]
+    }
+}

--- a/guides/micronaut-oauth2-oidc-oci/groovy/src/main/groovy/example/micronaut/IdentityDomainRolesFinder.groovy
+++ b/guides/micronaut-oauth2-oidc-oci/groovy/src/main/groovy/example/micronaut/IdentityDomainRolesFinder.groovy
@@ -1,0 +1,49 @@
+package example.micronaut
+
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.core.util.StringUtils
+import io.micronaut.json.JsonMapper
+import io.micronaut.security.token.RolesFinder
+import io.micronaut.security.token.config.TokenConfiguration
+import jakarta.inject.Singleton
+
+@Singleton // <1>
+@Replaces(RolesFinder)
+class IdentityDomainRolesFinder implements RolesFinder {
+
+    private static final String KEY_NAME = 'name'
+
+    private final TokenConfiguration tokenConfiguration
+
+    IdentityDomainRolesFinder(TokenConfiguration tokenConfiguration,
+                              JsonMapper jsonMapper) {
+        this.tokenConfiguration = tokenConfiguration
+    }
+
+    @Override
+    @NonNull
+    List<String> resolveRoles(@Nullable Map<String, Object> attributes) {
+        if (!attributes?.containsKey(tokenConfiguration.rolesName)) {
+            return Collections.emptyList()
+        }
+        Object obj = attributes[tokenConfiguration.rolesName]
+        if (obj == null) {
+            return Collections.emptyList()
+        }
+        if (obj instanceof Iterable) {
+            return obj.findResults { Object o ->
+                if (o instanceof Map) {
+                    Object name = o[KEY_NAME]
+                    String nameValue = name?.toString()
+                    if (StringUtils.isNotEmpty(nameValue)) {
+                        return nameValue
+                    }
+                }
+                null
+            }
+        }
+        Collections.emptyList()
+    }
+}

--- a/guides/micronaut-oauth2-oidc-oci/groovy/src/test/groovy/example/micronaut/IdentityDomainRolesFinderSpec.groovy
+++ b/guides/micronaut-oauth2-oidc-oci/groovy/src/test/groovy/example/micronaut/IdentityDomainRolesFinderSpec.groovy
@@ -1,0 +1,38 @@
+package example.micronaut
+
+import io.micronaut.security.token.RolesFinder
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class IdentityDomainRolesFinderSpec extends Specification {
+
+    @Inject
+    RolesFinder rolesFinder
+
+    void 'test find roles'() {
+        expect:
+        rolesFinder instanceof IdentityDomainRolesFinder
+
+        when:
+        List<String> roles = rolesFinder.resolveRoles([
+                groups: [[name: 'ROLE_ADMIN', id: 'cab3a10ad56935ca1726464bcaa12a34']]
+        ])
+
+        then:
+        roles == ['ROLE_ADMIN']
+
+        when:
+        roles = rolesFinder.resolveRoles(Collections.emptyMap())
+
+        then:
+        roles == Collections.emptyList()
+
+        when:
+        roles = rolesFinder.resolveRoles([groups: 'foo'])
+
+        then:
+        roles == Collections.emptyList()
+    }
+}

--- a/guides/micronaut-oauth2-oidc-oci/groovy/src/test/groovy/example/micronaut/Oauth2ClientConfigurationSpec.groovy
+++ b/guides/micronaut-oauth2-oidc-oci/groovy/src/test/groovy/example/micronaut/Oauth2ClientConfigurationSpec.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.BeanContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.security.oauth2.configuration.OauthClientConfiguration
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class Oauth2ClientConfigurationSpec extends Specification {
+
+    @Inject
+    BeanContext beanContext
+
+    void 'bean of type OauthClientConfiguration with name qualifier oci exists'() {
+        expect:
+        beanContext.containsBean(OauthClientConfiguration, Qualifiers.byName('oci'))
+    }
+}

--- a/guides/micronaut-oauth2-oidc-oci/metadata.json
+++ b/guides/micronaut-oauth2-oidc-oci/metadata.json
@@ -6,7 +6,7 @@
   "cloud": "OCI",
   "categories": ["Authorization Code"],
   "publicationDate": "2024-11-25",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary

- Add the Groovy sample implementation for the OCI OIDC guide.
- Update `micronaut-oauth2-oidc-oci` metadata to publish Java and Groovy variants.
- Keep the existing Java/native guide behavior intact while rendering Groovy source snippets and generated Gradle/Maven Groovy projects.

## Release And Project Target

- Target branch: `master`.
- Release line: guides `5.0.x` line from `version.txt`.
- Micronaut organization project: `5.0.1 Release`. Ambiguity preserved from QA intake: this is a Micronaut Platform BOM release board recommendation because this repository has no stable release tag/release baseline and no open `5.0.0 Release` board was available.

## Verification

- `git diff --check origin/master...HEAD`
- `./gradlew micronautOauth2OidcOciRunTestScript --stacktrace`
- `./gradlew micronautOauth2OidcOciBuild -x micronautOauth2OidcOciRunNativeTestScript --stacktrace`

## PR Assets

- Not applicable; this change adds guide source/sample files and rendered generated output was verified locally without any separate image, PDF, or binary artifact required for review.

Closes #1724

---
###### ✨ This message was AI-generated using gpt-5-codex