### PR TITLE
Add Kotlin version for OCI OIDC guide

### DIFF
--- a/guides/micronaut-oauth2-oidc-oci/kotlin/src/main/kotlin/example/micronaut/HomeController.kt
+++ b/guides/micronaut-oauth2-oidc-oci/kotlin/src/main/kotlin/example/micronaut/HomeController.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.views.View
+
+@Controller // <1>
+class HomeController {
+
+    @Secured(SecurityRule.IS_ANONYMOUS) // <2>
+    @View("home") // <3>
+    @Get // <4>
+    fun index(): Map<String, Any> = HashMap()
+}

--- a/guides/micronaut-oauth2-oidc-oci/kotlin/src/main/kotlin/example/micronaut/IdentityDomainRolesFinder.kt
+++ b/guides/micronaut-oauth2-oidc-oci/kotlin/src/main/kotlin/example/micronaut/IdentityDomainRolesFinder.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.security.token.RolesFinder
+import io.micronaut.security.token.config.TokenConfiguration
+import jakarta.inject.Singleton
+
+@Singleton // <1>
+@Replaces(RolesFinder::class)
+class IdentityDomainRolesFinder(
+    private val tokenConfiguration: TokenConfiguration
+) : RolesFinder {
+
+    override fun resolveRoles(attributes: Map<String, Any>?): List<String> {
+        if (attributes == null || !attributes.containsKey(tokenConfiguration.rolesName)) {
+            return emptyList()
+        }
+        val obj = attributes[tokenConfiguration.rolesName] ?: return emptyList()
+        if (obj is Iterable<*>) {
+            return obj.mapNotNull { element ->
+                if (element is Map<*, *>) {
+                    element[KEY_NAME]?.toString()?.takeIf { it.isNotEmpty() }
+                } else {
+                    null
+                }
+            }
+        }
+        return emptyList()
+    }
+
+    companion object {
+        private const val KEY_NAME = "name"
+    }
+}

--- a/guides/micronaut-oauth2-oidc-oci/kotlin/src/test/kotlin/example/micronaut/IdentityDomainRolesFinderTest.kt
+++ b/guides/micronaut-oauth2-oidc-oci/kotlin/src/test/kotlin/example/micronaut/IdentityDomainRolesFinderTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.security.token.RolesFinder
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+@MicronautTest(startApplication = false)
+class IdentityDomainRolesFinderTest {
+
+    @Test
+    fun testFindRoles(rolesFinder: RolesFinder) {
+        assertInstanceOf(IdentityDomainRolesFinder::class.java, rolesFinder)
+        var roles = rolesFinder.resolveRoles(
+            mapOf("groups" to listOf(mapOf("name" to "ROLE_ADMIN", "id" to "cab3a10ad56935ca1726464bcaa12a34")))
+        )
+        var expectedRoles = listOf("ROLE_ADMIN")
+        assertEquals(expectedRoles, roles)
+
+        roles = rolesFinder.resolveRoles(emptyMap())
+        expectedRoles = emptyList()
+        assertEquals(expectedRoles, roles)
+
+        roles = rolesFinder.resolveRoles(mapOf("groups" to "foo"))
+        assertEquals(expectedRoles, roles)
+    }
+}

--- a/guides/micronaut-oauth2-oidc-oci/kotlin/src/test/kotlin/example/micronaut/Oauth2ClientConfigurationTest.kt
+++ b/guides/micronaut-oauth2-oidc-oci/kotlin/src/test/kotlin/example/micronaut/Oauth2ClientConfigurationTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.BeanContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.security.oauth2.configuration.OauthClientConfiguration
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@MicronautTest(startApplication = false)
+class Oauth2ClientConfigurationTest {
+
+    @Inject
+    lateinit var beanContext: BeanContext
+
+    @Test
+    fun beanOfTypeOauthClientConfigurationWithNameQualifierOciExists() {
+        assertTrue(beanContext.containsBean(OauthClientConfiguration::class.java, Qualifiers.byName("oci")))
+    }
+}

--- a/guides/micronaut-oauth2-oidc-oci/metadata.json
+++ b/guides/micronaut-oauth2-oidc-oci/metadata.json
@@ -6,7 +6,7 @@
   "cloud": "OCI",
   "categories": ["Authorization Code"],
   "publicationDate": "2024-11-25",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary

- Adds the Kotlin sample implementation for `guides/micronaut-oauth2-oidc-oci`.
- Updates guide metadata so the guide renders for Java and Kotlin.
- Keeps the shared OAuth2/OIDC configuration, Thymeleaf view, package name, and Java guide variant unchanged.

## Verification

- `git diff --check -- guides/micronaut-oauth2-oidc-oci`
- `./gradlew micronautOauth2OidcOciRunTestScript --stacktrace`
- `./gradlew micronautOauth2OidcOciBuild --stacktrace` reached generated docs/zips and regular Java/Kotlin tests, then failed only in native-image compilation for both generated Java and Kotlin projects because the local GraalVM installation lacks the reachability-metadata schema expected by the configured native-build-tools metadata repository.

## Release And Project

Target branch: `master`.

Release target: Micronaut Platform `5.0.0` line from `version.txt`.

Recommended Micronaut organization project: `5.0.1 Release` (#146). Ambiguity: `version.txt` says `5.0.0`, but there is no open public `5.0.0 Release` organization project and this repository has no stable GitHub release/tag history to compare against, so `5.0.1 Release` is the earliest open Micronaut Platform BOM board that can reasonably consume this docs/sample update.

Project linkage note: the `5.0.1 Release` project exists, but this run could not apply the live ProjectV2 item because GitHub rejected `addProjectV2ItemById` with `INSUFFICIENT_SCOPES`; the token has `read:project` but not the required `project` scope.

Reviewer routing note: GitHub issue #1725 was created by `sdelamo`, who is also the PR author. GitHub rejected the reviewer request with HTTP 422: `Review cannot be requested from pull request author.`

## PR Assets

No external PR asset is required for this source-only guide sample variant.

Closes #1725.

---
###### ✨ This message was AI-generated using gpt-5
