### PR TITLE
Add Groovy variant for OpenAPI generator client guide

### DIFF
--- a/guides/micronaut-openapi-generator-client/groovy/src/main/resources/application.properties
+++ b/guides/micronaut-openapi-generator-client/groovy/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+micronaut.application.name=openapi-micronaut
+micronaut.server.port=8080
+#tag::openapiconfig[]
+openapi-micronaut-client.base-path=https://api.open-meteo.com
+#end::openapiconfig[]

--- a/guides/micronaut-openapi-generator-client/groovy/src/openapi/openmeteo.yml
+++ b/guides/micronaut-openapi-generator-client/groovy/src/openapi/openmeteo.yml
@@ -1,0 +1,461 @@
+openapi: 3.0.0
+info:
+  title: Open-Meteo APIs
+  description: 'Open-Meteo offers free weather forecast APIs for open-source developers and non-commercial use. No API key is required.'
+  version: '1.0'
+  contact:
+    name: Open-Meteo
+    url: https://open-meteo.com
+    email: info@open-meteo.com
+  license:
+    name: Attribution 4.0 International (CC BY 4.0)
+    url: https://creativecommons.org/licenses/by/4.0/
+  termsOfService: https://open-meteo.com/en/features#terms
+paths:
+  /v1/forecast:
+    servers:
+      - url: https://api.open-meteo.com
+    get:
+      tags:
+      - Weather Forecast APIs
+      summary: 7 day weather forecast for coordinates
+      description: 7 day weather variables in hourly and daily resolution for given WGS84 latitude and longitude coordinates. Available worldwide.
+      parameters:
+      - name: hourly
+        in: query
+        explode: false
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - temperature_2m
+            - relativehumidity_2m
+            - dewpoint_2m
+            - apparent_temperature
+            - pressure_msl
+            - cloudcover
+            - cloudcover_low
+            - cloudcover_mid
+            - cloudcover_high
+            - windspeed_10m
+            - windspeed_80m
+            - windspeed_120m
+            - windspeed_180m
+            - winddirection_10m
+            - winddirection_80m
+            - winddirection_120m
+            - winddirection_180m
+            - windgusts_10m
+            - shortwave_radiation
+            - direct_radiation
+            - direct_normal_irradiance
+            - diffuse_radiation
+            - vapor_pressure_deficit
+            - evapotranspiration
+            - precipitation
+            - weathercode
+            - snow_height
+            - freezinglevel_height
+            - soil_temperature_0cm
+            - soil_temperature_6cm
+            - soil_temperature_18cm
+            - soil_temperature_54cm
+            - soil_moisture_0_1cm
+            - soil_moisture_1_3cm
+            - soil_moisture_3_9cm
+            - soil_moisture_9_27cm
+            - soil_moisture_27_81cm
+      - name: daily
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - temperature_2m_max
+            - temperature_2m_min
+            - apparent_temperature_max
+            - apparent_temperature_min
+            - precipitation_sum
+            - precipitation_hours
+            - weathercode
+            - sunrise
+            - sunset
+            - windspeed_10m_max
+            - windgusts_10m_max
+            - winddirection_10m_dominant
+            - shortwave_radiation_sum
+            - uv_index_max
+            - uv_index_clear_sky_max
+            - et0_fao_evapotranspiration
+      - name: latitude
+        in: query
+        required: true
+        description: "WGS84 coordinate"
+        schema:
+          type: number
+          format: float
+      - name: longitude
+        in: query
+        required: true
+        description: "WGS84 coordinate"
+        schema:
+          type: number
+          format: float
+      - name: current_weather
+        in: query
+        schema:
+          type: boolean
+      - name: temperature_unit
+        in: query
+        schema:
+          type: string
+          default: celsius
+          enum:
+          - celsius
+          - fahrenheit
+      - name: windspeed_unit
+        in: query
+        schema:
+          type: string
+          default: kmh
+          enum:
+          - kmh
+          - ms
+          - mph
+          - kn
+      - name: timeformat
+        in: query
+        description: If format `unixtime` is selected, all time values are returned in UNIX epoch time in seconds. Please not that all time is then in GMT+0! For daily values with unix timestamp, please apply `utc_offset_seconds` again to get the correct date.
+        schema:
+          type: string
+          default: iso8601
+          enum:
+          - iso8601
+          - unixtime
+      - name: timezone
+        in: query
+        description: If `timezone` is set, all timestamps are returned as local-time and data is returned starting at 0:00 local-time. Any time zone name from the [time zone database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) is supported.
+        schema:
+          type: string
+      - name: past_days
+        in: query
+        description: If `past_days` is set, yesterdays or the day before yesterdays data are also returned.
+        schema:
+          type: integer
+          enum:
+          - 1
+          - 2
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  latitude:
+                    type: number
+                    example: 52.52
+                    description: WGS84 of the center of the weather grid-cell which was used to generate this forecast. This coordinate might be up to 5 km away.
+                  longitude:
+                    type: number
+                    example: 13.419.52
+                    description: WGS84 of the center of the weather grid-cell which was used to generate this forecast. This coordinate might be up to 5 km away.
+                  elevation:
+                    type: number
+                    example: 44.812
+                    description: The elevation in meters of the selected weather grid-cell. In mountain terrain it might differ from the location you would expect.
+                  generationtime_ms:
+                    type: number
+                    example: 2.2119
+                    description: Generation time of the weather forecast in milli seconds. This is mainly used for performance monitoring and improvements.
+                  utc_offset_seconds:
+                    type: integer
+                    example: 3600
+                    description: Applied timezone offset from the &timezone= parameter.
+                  hourly:
+                    type: HourlyResponse
+                    description: For each selected weather variable, data will be returned as a floating point array. Additionally a `time` array will be returned with ISO8601 timestamps.
+                  hourly_units:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: For each selected weather variable, the unit will be listed here.
+                  daily:
+                    type: DailyResponse
+                    description: For each selected daily weather variable, data will be returned as a floating point array. Additionally a `time` array will be returned with ISO8601 timestamps.
+                  daily_units:
+                    type: object
+                    additionalProperties:
+                      type: string
+                    description: For each selected daily weather variable, the unit will be listed here.
+                  current_weather:
+                    type: CurrentWeather
+                    description: "Current weather conditions with the attributes: time, temperature, windspeed, winddirection and weathercode"
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: boolean
+                    description: Always set true for errors
+                  reason:
+                    type: string
+                    description: Description of the error
+                    example: "Latitude must be in range of -90 to 90°. Given: 300"
+components:
+  schemas:
+    HourlyResponse:
+      type: object
+      required:
+        - time
+      properties:
+        time:
+          type: array
+          items:
+            type: string
+        temperature_2m:
+          type: array
+          items:
+            type: float
+        relativehumidity_2m:
+          type: array
+          items:
+            type: float
+        dewpoint_2m:
+          type: array
+          items:
+            type: float
+        apparent_temperature:
+          type: array
+          items:
+            type: float
+        pressure_msl:
+          type: array
+          items:
+            type: float
+        cloudcover:
+          type: array
+          items:
+            type: float
+        cloudcover_low:
+          type: array
+          items:
+            type: float
+        cloudcover_mid:
+          type: array
+          items:
+            type: float
+        cloudcover_high:
+          type: array
+          items:
+            type: float
+        windspeed_10m:
+          type: array
+          items:
+            type: float
+        windspeed_80m:
+          type: array
+          items:
+            type: float
+        windspeed_120m:
+          type: array
+          items:
+            type: float
+        windspeed_180m:
+          type: array
+          items:
+            type: float
+        winddirection_10m:
+          type: array
+          items:
+            type: float
+        winddirection_80m:
+          type: array
+          items:
+            type: float
+        winddirection_120m:
+          type: array
+          items:
+            type: float
+        winddirection_180m:
+          type: array
+          items:
+            type: float
+        windgusts_10m:
+          type: array
+          items:
+            type: float
+        shortwave_radiation:
+          type: array
+          items:
+            type: float
+        direct_radiation:
+          type: array
+          items:
+            type: float
+        direct_normal_irradiance:
+          type: array
+          items:
+            type: float
+        diffuse_radiation:
+          type: array
+          items:
+            type: float
+        vapor_pressure_deficit:
+          type: array
+          items:
+            type: float
+        evapotranspiration:
+          type: array
+          items:
+            type: float
+        precipitation:
+          type: array
+          items:
+            type: float
+        weathercode:
+          type: array
+          items:
+            type: float
+        snow_height:
+          type: array
+          items:
+            type: float
+        freezinglevel_height:
+          type: array
+          items:
+            type: float
+        soil_temperature_0cm:
+          type: array
+          items:
+            type: float
+        soil_temperature_6cm:
+          type: array
+          items:
+            type: float
+        soil_temperature_18cm:
+          type: array
+          items:
+            type: float
+        soil_temperature_54cm:
+          type: array
+          items:
+            type: float
+        soil_moisture_0_1cm:
+          type: array
+          items:
+            type: float
+        soil_moisture_1_3cm:
+          type: array
+          items:
+            type: float
+        soil_moisture_3_9cm:
+          type: array
+          items:
+            type: float
+        soil_moisture_9_27cm:
+          type: array
+          items:
+            type: float
+        soil_moisture_27_81cm:
+          type: array
+          items:
+            type: float
+    DailyResponse:
+      type: object
+      properties:
+        time:
+          type: array
+          items:
+            type: string
+        temperature_2m_max:
+          type: array
+          items:
+            type: float
+        temperature_2m_min:
+          type: array
+          items:
+            type: float
+        apparent_temperature_max:
+          type: array
+          items:
+            type: float
+        apparent_temperature_min:
+          type: array
+          items:
+            type: float
+        precipitation_sum:
+          type: array
+          items:
+            type: float
+        precipitation_hours:
+          type: array
+          items:
+            type: float
+        weathercode:
+          type: array
+          items:
+            type: float
+        sunrise:
+          type: array
+          items:
+            type: float
+        sunset:
+          type: array
+          items:
+            type: float
+        windspeed_10m_max:
+          type: array
+          items:
+            type: float
+        windgusts_10m_max:
+          type: array
+          items:
+            type: float
+        winddirection_10m_dominant:
+          type: array
+          items:
+            type: float
+        shortwave_radiation_sum:
+          type: array
+          items:
+            type: float
+        uv_index_max:
+          type: array
+          items:
+            type: float
+        uv_index_clear_sky_max:
+          type: array
+          items:
+            type: float
+        et0_fao_evapotranspiration:
+          type: array
+          items:
+            type: float
+      required:
+        - time
+    CurrentWeather:
+      type: object
+      properties:
+        time:
+          type: string
+        temperature:
+          type: float
+        windspeed:
+          type: float
+        winddirection:
+          type: float
+        weathercode:
+          type: int
+      required:
+        - time
+        - temperature
+        - windspeed
+        - winddirection
+        - weathercode

--- a/guides/micronaut-openapi-generator-client/groovy/src/test/groovy/example/micronaut/WeatherClientSpec.groovy
+++ b/guides/micronaut-openapi-generator-client/groovy/src/test/groovy/example/micronaut/WeatherClientSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import example.openmeteo.api.WeatherForecastApisApi
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+// tag::test[]
+@MicronautTest
+class WeatherClientSpec extends Specification {
+
+    @Inject
+    WeatherForecastApisApi api // <1>
+
+    void "fetches weather for Montaigu-Vendee"() {
+        when:
+        def forecast = api.v1ForecastGet(46.97386f, -1.3111076f, // <2>
+                null,
+                null,
+                true,
+                null,
+                null,
+                null,
+                null,
+                null)
+        def weather = forecast.block().currentWeather // <3>
+
+        then:
+        weather.temperature < 50
+    }
+}
+// end::test[]

--- a/guides/micronaut-openapi-generator-client/groovy/src/test/resources/application-test.properties
+++ b/guides/micronaut-openapi-generator-client/groovy/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+micronaut.server.port=-1

--- a/guides/micronaut-openapi-generator-client/metadata.json
+++ b/guides/micronaut-openapi-generator-client/metadata.json
@@ -6,7 +6,7 @@
   "authors": ["Andriy Dmytruk", "Cédric Champeau"],
   "tags": ["openapi", "client"],
   "categories": ["OpenAPI"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "publicationDate": "2022-05-31",
   "apps": [
     {


### PR DESCRIPTION
## Summary
- Add the Groovy sample variant for `guides/micronaut-openapi-generator-client`.
- Keep the existing Java variant and update guide metadata to publish `JAVA` and `GROOVY`.
- Copy the Open-Meteo OpenAPI input and resource configuration to the Groovy sample, matching the Java variant.

Closes #1734.

## Verification
- `git diff --check origin/master..HEAD -- guides/micronaut-openapi-generator-client`
- `./gradlew micronautOpenapiGeneratorClientRunTestScript --stacktrace`
- `./gradlew micronautOpenapiGeneratorClientBuild -x micronautOpenapiGeneratorClientRunNativeTestScript --stacktrace`

The exact full build command `./gradlew micronautOpenapiGeneratorClientBuild --stacktrace` was attempted during implementation and QA. It fails in the pre-existing generated Java native test path because the local GraalVM reachability metadata schema is missing/mismatched; QA reproduced that same failure on the parent commit, so it is not treated as a Groovy regression.

## Release And Routing
- Target branch: `master`
- Type label: `type: docs`
- Selected Micronaut organization project: `5.0.1 Release`
- Ambiguity note: repository `version.txt` is `5.0.0`, but no open `5.0.0 Release` board exists; the selected board is the open Micronaut Platform BOM release board `5.0.1 Release`.

## PR Assets
Not applicable; this changes guide source/sample code and does not require a separate rendered artifact attachment.

---
###### ✨ This message was AI-generated using gpt-5
