### PR TITLE
Add Groovy version for Spring Boot bean factory guide

### DIFF
--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/metadata.json
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["spring-boot"],
   "categories": ["Spring Boot"],
   "publicationDate": "2022-09-13",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "apps": [
     {
       "framework": "Spring Boot",

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/groovy/src/main/groovy/example/micronaut/Greeter.groovy
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/groovy/src/main/groovy/example/micronaut/Greeter.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+interface Greeter {
+    String greet()
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/groovy/src/main/groovy/example/micronaut/GreeterFactory.groovy
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/groovy/src/main/groovy/example/micronaut/GreeterFactory.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+
+@Factory // <1>
+class GreeterFactory {
+
+    @Bean
+    Greeter helloGreeter() {
+        new HelloGreeter()
+    }
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/groovy/src/main/groovy/example/micronaut/HelloGreeter.groovy
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/groovy/src/main/groovy/example/micronaut/HelloGreeter.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+class HelloGreeter implements Greeter {
+
+    @Override
+    String greet() {
+        "Hello"
+    }
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/groovy/src/test/groovy/example/micronaut/GreeterSpec.groovy
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/micronautframework/groovy/src/test/groovy/example/micronaut/GreeterSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest // <1>
+class GreeterSpec extends Specification {
+
+    @Inject // <2>
+    Greeter greeter
+
+    void "hello greeter is injected as bean of type Greeter"() {
+        expect:
+        greeter
+        greeter.greet() == "Hello"
+    }
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/spring-boot-to-micronaut-at-configuration-at-bean-at-factory.adoc
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/spring-boot-to-micronaut-at-configuration-at-bean-at-factory.adoc
@@ -34,7 +34,7 @@ callout:spring-at-configuration[]
 
 The following test verifies that it is possible to inject a bean of type `Greeter` in a Spring Boot application.
 
-test:GreeterTest[app=springboot]
+rawTest:GreeterTest[app=springboot]
 
 callout:spring-boot-test[]
 callout:autowired[arg0=Greeter]
@@ -64,4 +64,3 @@ This guide illustrates that the `@Configuration` and `@Factory` APIs of both fra
 Read more https://guides.micronaut.io/latest/tag-spring_boot_to_micronaut.html[Spring Boot to Micronaut] guides.
 
 common:helpWithMicronaut.adoc[]
-

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/groovy/src/main/groovy/example/micronaut/Greeter.groovy
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/groovy/src/main/groovy/example/micronaut/Greeter.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+interface Greeter {
+    String greet()
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/groovy/src/main/groovy/example/micronaut/GreeterFactory.groovy
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/groovy/src/main/groovy/example/micronaut/GreeterFactory.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration // <1>
+class GreeterFactory {
+
+    @Bean
+    Greeter helloGreeter() {
+        new HelloGreeter()
+    }
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/groovy/src/main/groovy/example/micronaut/HelloGreeter.groovy
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/groovy/src/main/groovy/example/micronaut/HelloGreeter.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+class HelloGreeter implements Greeter {
+
+    @Override
+    String greet() {
+        "Hello"
+    }
+}

--- a/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/groovy/src/test/groovy/example/micronaut/GreeterTest.groovy
+++ b/guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory/springboot/groovy/src/test/groovy/example/micronaut/GreeterTest.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest // <1>
+class GreeterTest {
+
+    @Autowired // <2>
+    Greeter greeter
+
+    @Test
+    void helloGreeterIsInjectedAsBeanOfTypeGreeter() {
+        assert greeter
+        assert greeter.greet() == "Hello"
+    }
+}


### PR DESCRIPTION
## Summary
- Add Groovy sample source and tests for the Spring Boot application in the `@Configuration` / `@Bean` guide.
- Add Groovy sample source and tests for the Micronaut application using `@Factory` / `@Bean`.
- Enable `GROOVY` in the guide metadata.
- Use a raw test include for the Spring Boot sample so the Groovy JUnit test remains named `GreeterTest` and is executed by Maven Surefire.

## Verification
- `git diff --check -- guides/spring-boot-to-micronaut-at-configuration-at-bean-at-factory`
- `./gradlew springBootToMicronautAtConfigurationAtBeanAtFactoryRunTestScript springBootToMicronautAtConfigurationAtBeanAtFactoryGenerateDocs --stacktrace`
- `./mvnw -q test spotless:check` in generated Maven Groovy `springboot`; verified Surefire runs `example.micronaut.GreeterTest`
- `./mvnw -q test spotless:check` in generated Maven Groovy `micronautframework`

I also reran `./gradlew springBootToMicronautAtConfigurationAtBeanAtFactoryBuild --stacktrace`. It generated docs/zips and then failed at `:springBootToMicronautAtConfigurationAtBeanAtFactoryRunNativeTestScript` in the generated Gradle Java Micronaut native test because the local GraalVM installation does not match the reachability metadata schema. QA and Security already recorded the same local native tooling caveat; it is not in the new Groovy source path.

## Release And Project
- Target branch: `master`.
- Release target: default-branch guide version signal is `5.0.0`.
- Micronaut organization project selected upstream: `5.0.1 Release`; ambiguity preserved because no open public `5.0.0 Release`, `5.0.0-M*`, or `5.0.0-RC*` board was returned.
- Project linking was attempted, but the available token can read projects and lacks the `project` write scope required by `addProjectV2ItemById`; live project association could not be applied in this run.
- Sibling Kotlin work for this same guide is tracked separately in #1774 / #1805; this PR intentionally contains only the Groovy variant.

## PR Assets
- Not applicable for this guide source/sample-code change.

Fixes #1773

---
###### ✨ This message was AI-generated using gpt-5