### PR TITLE
Add Groovy version for singleton component guide

### DIFF
--- a/guides/spring-boot-to-micronaut-at-singleton-at-component/metadata.json
+++ b/guides/spring-boot-to-micronaut-at-singleton-at-component/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["spring-boot"],
   "categories": ["Spring Boot"],
   "publicationDate": "2022-09-13",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "apps": [
     {
       "framework": "Spring Boot",

--- a/guides/spring-boot-to-micronaut-at-singleton-at-component/micronautframework/groovy/src/main/groovy/example/micronaut/Greeter.groovy
+++ b/guides/spring-boot-to-micronaut-at-singleton-at-component/micronautframework/groovy/src/main/groovy/example/micronaut/Greeter.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+interface Greeter {
+    String greet()
+}

--- a/guides/spring-boot-to-micronaut-at-singleton-at-component/micronautframework/groovy/src/main/groovy/example/micronaut/HelloGreeter.groovy
+++ b/guides/spring-boot-to-micronaut-at-singleton-at-component/micronautframework/groovy/src/main/groovy/example/micronaut/HelloGreeter.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import jakarta.inject.Singleton
+
+@Singleton // <1>
+class HelloGreeter implements Greeter {
+
+    @Override
+    String greet() {
+        "Hello"
+    }
+}

--- a/guides/spring-boot-to-micronaut-at-singleton-at-component/micronautframework/groovy/src/test/groovy/example/micronaut/GreeterSpec.groovy
+++ b/guides/spring-boot-to-micronaut-at-singleton-at-component/micronautframework/groovy/src/test/groovy/example/micronaut/GreeterSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest // <1>
+class GreeterSpec extends Specification {
+
+    @Inject // <2>
+    Greeter greeter
+
+    void "hello greeter is injected as bean of type Greeter"() {
+        expect:
+        greeter
+        greeter.greet() == "Hello"
+    }
+}

--- a/guides/spring-boot-to-micronaut-at-singleton-at-component/springboot/groovy/src/main/groovy/example/micronaut/Greeter.groovy
+++ b/guides/spring-boot-to-micronaut-at-singleton-at-component/springboot/groovy/src/main/groovy/example/micronaut/Greeter.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+interface Greeter {
+    String greet()
+}

--- a/guides/spring-boot-to-micronaut-at-singleton-at-component/springboot/groovy/src/main/groovy/example/micronaut/HelloGreeter.groovy
+++ b/guides/spring-boot-to-micronaut-at-singleton-at-component/springboot/groovy/src/main/groovy/example/micronaut/HelloGreeter.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.springframework.stereotype.Component
+
+@Component // <1>
+class HelloGreeter implements Greeter {
+
+    @Override
+    String greet() {
+        "Hello"
+    }
+}

--- a/guides/spring-boot-to-micronaut-at-singleton-at-component/springboot/groovy/src/test/groovy/example/micronaut/GreeterSpec.groovy
+++ b/guides/spring-boot-to-micronaut-at-singleton-at-component/springboot/groovy/src/test/groovy/example/micronaut/GreeterSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest // <1>
+class GreeterSpec {
+
+    @Autowired // <2>
+    Greeter greeter
+
+    @Test
+    void helloGreeterIsInjectedAsBeanOfTypeGreeter() {
+        assert greeter
+        assert greeter.greet() == "Hello"
+    }
+}


### PR DESCRIPTION
## Summary
- Add the Groovy guide variant for `spring-boot-to-micronaut-at-singleton-at-component` under both `springboot` and `micronautframework`.
- Update guide metadata to publish `JAVA` and `GROOVY` for this guide.
- Keep this PR scoped to MNG-438; the sibling Kotlin variant is intentionally not included here.

## Validation
- `git diff --check -- guides/spring-boot-to-micronaut-at-singleton-at-component`
- `./gradlew springBootToMicronautAtSingletonAtComponentBuild --stacktrace` generated projects/docs/zips, then failed in `springBootToMicronautAtSingletonAtComponentRunNativeTestScript` because the local GraalVM installation lacks the reachability-metadata schema support expected by the configured repository. The failure occurs in the generated Java Micronaut native test path before Groovy-specific code is implicated.
- `./gradlew springBootToMicronautAtSingletonAtComponentRunTestScript --stacktrace`
- `./mvnw -q test spotless:check` in generated Maven Groovy `springboot`
- `./mvnw -q test spotless:check` in generated Maven Groovy `micronautframework`

## PR Assets
None. This is a source-only guide sample addition; generated `build/` output was validated locally and is not committed.

## Release Target
Target branch: `master`.

Micronaut organization project selected during QA intake: `5.0.1 Release` (#146). Ambiguity preserved: `version.txt` on `master` says `5.0.0`, but the open public Micronaut Platform BOM boards do not include an open `5.0.0 Release`; `5.0.1 Release` is the earliest open 5.0.x board visible for this docs/sample change.

## Reviewer Routing
Linked GitHub issue creator: `sdelamo`. Reviewer request was attempted after PR creation, but GitHub rejected it with: `Review cannot be requested from pull request author.`

## Project Link
The selected Micronaut organization project exists, but the active `GITHUB_TOKEN` cannot apply the PR project association because GitHub requires the `project` scope for `addProjectV2ItemById`. Live PR project items were checked and are currently empty.

Closes #1775

---
###### ✨ This message was AI-generated using gpt-5