### PR TITLE
Add Groovy variant for Oracle Cloud registry guide

### DIFF
--- a/guides/micronaut-push-to-oracle-cloud-container-registry/metadata.json
+++ b/guides/micronaut-push-to-oracle-cloud-container-registry/metadata.json
@@ -7,7 +7,7 @@
   "categories": ["Registry"],
   "publicationDate": "2025-03-16",
   "buildTools": ["GRADLE"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "apps": [
     {
       "name": "default"


### PR DESCRIPTION
## Summary
- Enable the Groovy variant for `micronaut-push-to-oracle-cloud-container-registry` by adding `GROOVY` to guide metadata.
- Rely on the existing guide generator for the default sample app; this guide has no checked-in Java source overrides to translate.

## Verification
- `git diff --check`
- `./gradlew micronautPushToOracleCloudContainerRegistryRunTestScript --stacktrace`
- QA also verified generated Groovy app, rendered Groovy guide output, ZIP output, and index/tag links. The native-inclusive guide build has a recorded local GraalVM/reachability metadata caveat in the Paperclip QA artifact.

## Release / Project Target
- Target branch: `master`
- Release target: Micronaut 5.x guide content
- Selected Micronaut organization project: `5.0.1 Release`
- Ambiguity note: `master` advertises `5.0.0` in `version.txt`, but there is no open public `5.0.0 Release` project; `5.0.1 Release` is the earliest open public Micronaut Platform BOM release board in the same 5.x line.
- Project association note: this run confirmed project `5.0.1 Release` exists, but could not add the PR to it because the active GitHub token lacks the required `project` scope.

## PR Assets
- [Rendered Groovy guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/aaca50903eb7785f9787450e50ff2167e3a2ae93/assets/pr-1833/af6be720654a/micronaut-push-to-oracle-cloud-container-registry-gradle-groovy.html)

Closes #1746

---
###### ✨ This message was AI-generated using gpt-5