### PR TITLE
Add Kotlin version for OCI registry guide

### DIFF
--- a/guides/micronaut-push-to-oracle-cloud-container-registry/metadata.json
+++ b/guides/micronaut-push-to-oracle-cloud-container-registry/metadata.json
@@ -7,7 +7,7 @@
   "categories": ["Registry"],
   "publicationDate": "2025-03-16",
   "buildTools": ["GRADLE"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "name": "default"


### PR DESCRIPTION
## Summary
- Enable the Kotlin variant for `micronaut-push-to-oracle-cloud-container-registry` by adding `KOTLIN` to guide metadata.
- This guide has no checked-in language source tree; the Kotlin sample is generated from Starter metadata, matching the existing generated-app guide pattern.

Closes #1747

## Validation
- `git diff --check origin/master..HEAD`
- `./gradlew micronautPushToOracleCloudContainerRegistryBuild --stacktrace -x micronautPushToOracleCloudContainerRegistryRunNativeTestScript`
- QA previously reran `./gradlew micronautPushToOracleCloudContainerRegistryRunTestScript --stacktrace`; the exact native build task remains blocked locally by the existing GraalVM reachability metadata schema mismatch affecting both Java and Kotlin generated native tests.

## Release / Project Metadata
- Target branch: `master`
- Release target: `5.0.0`
- Type label: `type: docs`
- QA-selected Micronaut organization project: `5.0.0 Release`
- Project ambiguity: live organization project lookup shows `5.0.0 Release` exists but is closed; no open `5.0.0` GA or prerelease board is available.
- Project link attempt: GitHub rejected `addProjectV2ItemById` because the available token lacks the `project` scope.

## Reviewer Routing
- Linked issue creator: `sdelamo`
- Reviewer request result: GitHub rejected the request because the issue creator is also the pull request author: `Review cannot be requested from pull request author. (HTTP 422)`

## PR Assets
- [Generated Kotlin guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/81c2da998f42c062c27f35ff338921fe458eafac/assets/pr-1834/0daa3ef87e11/micronaut-push-to-oracle-cloud-container-registry-gradle-kotlin.html)
- [Generated Kotlin sample ZIP](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/cb403b1d1c1bd0043692be361b8ce12d8b16fde4/assets/pr-1834/0daa3ef87e11/micronaut-push-to-oracle-cloud-container-registry-gradle-kotlin.zip)

---
###### ✨ This message was AI-generated using gpt-5