### PR TITLE
Add Groovy variant for Docker Hub registry guide

### DIFF
--- a/guides/micronaut-push-to-registry-docker-hub/metadata.json
+++ b/guides/micronaut-push-to-registry-docker-hub/metadata.json
@@ -6,7 +6,7 @@
   "categories": ["Registry"],
   "publicationDate": "2025-03-16",
   "buildTools": ["GRADLE"],
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "apps": [
     {
       "name": "default"


### PR DESCRIPTION
## Summary

- Adds `GROOVY` to the Docker Hub registry guide metadata while preserving `JAVA`.
- Keeps the guide's existing generated-starter shape; no checked-in language source tree is required for this guide.

## Validation

- `git diff --check origin/master...HEAD`
- `./gradlew micronautPushToRegistryDockerHubRunTestScript --stacktrace`
- `./gradlew micronautPushToRegistryDockerHubGenerateDocs micronautPushToRegistryDockerHubGenerateZips micronautPushToRegistryDockerHubIndex --stacktrace`
- `./gradlew micronautPushToRegistryDockerHubBuild --stacktrace` fails only in the existing Java native-test path with the local GraalVM reachability metadata/toolchain mismatch previously recorded by QA. The generated Java and Groovy non-native tests and guide docs/zips/index path pass, and the native script does not exercise the new Groovy generated app.

## Release Metadata

- Target branch: `master`
- Release signal: `version.txt` on `master` reports `5.0.0`
- Selected Micronaut organization project: `5.0.1 Release`
- Ambiguity note: no open public `5.0.0` Micronaut organization project was found, so `5.0.1 Release` is the earliest matching open release board identified during QA and rechecked during code review.
- Type label: `type: docs`

## PR Assets

None. This is a metadata-only guide-generation change with no rendered image, PDF, or external artifact asset to attach.

Closes #1748

---
###### ✨ This message was AI-generated using gpt-5
