### PR TITLE
Add Groovy reactor streaming HTTP client guide

### DIFF
--- a/guides/micronaut-reactor-streaming-http-client/groovy/src/main/groovy/example/micronaut/HomeController.groovy
+++ b/guides/micronaut-reactor-streaming-http-client/groovy/src/main/groovy/example/micronaut/HomeController.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.exceptions.ConfigurationException
+import io.micronaut.core.io.buffer.ByteBuffer
+import io.micronaut.core.io.buffer.ReferenceCounted
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.reactor.http.client.ReactorStreamingHttpClient
+import jakarta.annotation.PreDestroy
+import reactor.core.publisher.Flux
+
+@Controller // <1>
+class HomeController implements AutoCloseable {
+    private static final URI DEFAULT_URI = URI.create('https://guides.micronaut.io/micronaut5K.png')
+
+    private final ReactorStreamingHttpClient reactorStreamingHttpClient
+
+    HomeController() {
+        String urlStr = 'https://guides.micronaut.io/'
+        URL url
+        try {
+            url = new URL(urlStr)
+        } catch (MalformedURLException e) {
+            throw new ConfigurationException('malformed URL' + urlStr)
+        }
+        reactorStreamingHttpClient = ReactorStreamingHttpClient.create(url) // <2>
+    }
+
+    @Get // <3>
+    Flux<ByteBuffer<?>> download() {
+        HttpRequest<?> request = HttpRequest.GET(DEFAULT_URI)
+        reactorStreamingHttpClient.dataStream(request).doOnNext { ByteBuffer<?> bb ->
+            if (bb instanceof ReferenceCounted) {
+                ((ReferenceCounted) bb).retain()
+            }
+        } // <4>
+    }
+
+    @PreDestroy // <5>
+    @Override
+    void close() {
+        if (reactorStreamingHttpClient != null) {
+            reactorStreamingHttpClient.close()
+        }
+    }
+}

--- a/guides/micronaut-reactor-streaming-http-client/groovy/src/test/groovy/example/micronaut/HomeControllerSpec.groovy
+++ b/guides/micronaut-reactor-streaming-http-client/groovy/src/test/groovy/example/micronaut/HomeControllerSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.HexFormat
+
+@MicronautTest // <1>
+class HomeControllerSpec extends Specification {
+
+    private final HexFormat hexFormat = HexFormat.of()
+
+    @Inject
+    @Client("/") // <2>
+    HttpClient httpClient
+
+    @Inject
+    ResourceLoader resourceLoader
+
+    void "download file"() {
+        when:
+        Optional<URL> resource = resourceLoader.getResource('micronaut5K.png')
+
+        then:
+        resource.present
+
+        when:
+        byte[] expectedByteArray = Files.readAllBytes(Path.of(resource.get().toURI()))
+        MessageDigest digest = MessageDigest.getInstance('SHA-256')
+        String expected = hexFormat.formatHex(digest.digest(expectedByteArray))
+
+        HttpResponse<byte[]> resp = httpClient.toBlocking()
+                .exchange(HttpRequest.GET('/'), byte[])
+        byte[] responseBytes = resp.body()
+
+        String response = hexFormat.formatHex(digest.digest(responseBytes))
+
+        then:
+        expected == response
+    }
+}

--- a/guides/micronaut-reactor-streaming-http-client/metadata.json
+++ b/guides/micronaut-reactor-streaming-http-client/metadata.json
@@ -5,7 +5,7 @@
   "tags": [],
   "categories": ["HTTP Client"],
   "publicationDate": "2023-12-14",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "buildTools": ["GRADLE"],
   "apps": [
     {


### PR DESCRIPTION
## Summary

- Adds the Groovy implementation for `micronaut-reactor-streaming-http-client`.
- Adds a Spock test that verifies the streamed download hash against the shared `micronaut5K.png` test resource.
- Updates guide metadata so the guide renders for Java and Groovy.

Closes #1750.

## Verification

- `git diff --check origin/master..HEAD`
- `./gradlew micronautReactorStreamingHttpClientRunTestScript --stacktrace`
- `./gradlew micronautReactorStreamingHttpClientBuild --stacktrace -x micronautReactorStreamingHttpClientRunNativeTestScript`
- `./gradlew micronautReactorStreamingHttpClientBuild --stacktrace` was attempted and failed only in the existing generated Java native-test step because the local GraalVM installation does not support the configured reachability-metadata schema.

## PR Assets

- [Generated Groovy guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/4e42f9d4615552866cc44d3f76b2fdcf2600d7aa/assets/pr-1836/600ba6c06ee2/micronaut-reactor-streaming-http-client-gradle-groovy.html)

## Release Targeting

- Target branch: `master`.
- Release target: default-branch Micronaut 5.0.0-era guide/sample content.
- Micronaut organization project recommended by QA: `5.0.1 Release`.
- Ambiguity note: `version.txt` names 5.0.0, but QA found no open public `5.0.0` board; `5.0.1 Release` was the earliest open public Micronaut Platform BOM board for this guide update.
- Project tooling gap: active `GITHUB_TOKEN` lacks `read:org`, so `gh` could not read or apply Micronaut organization projects in this run.

---
###### ✨ This message was AI-generated using gpt-5
