### PR TITLE
Add Kotlin version for reactor streaming HTTP client guide

### DIFF
--- a/guides/micronaut-reactor-streaming-http-client/kotlin/src/main/kotlin/example/micronaut/HomeController.kt
+++ b/guides/micronaut-reactor-streaming-http-client/kotlin/src/main/kotlin/example/micronaut/HomeController.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.exceptions.ConfigurationException
+import io.micronaut.core.io.buffer.ByteBuffer
+import io.micronaut.core.io.buffer.ReferenceCounted
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.reactor.http.client.ReactorStreamingHttpClient
+import jakarta.annotation.PreDestroy
+import reactor.core.publisher.Flux
+import java.net.MalformedURLException
+import java.net.URI
+
+@Controller // <1>
+class HomeController : AutoCloseable {
+
+    private val reactorStreamingHttpClient: ReactorStreamingHttpClient
+
+    init {
+        val urlStr = "https://guides.micronaut.io/"
+        val url = try {
+            URI.create(urlStr).toURL()
+        } catch (e: MalformedURLException) {
+            throw ConfigurationException("malformed URL$urlStr")
+        }
+        reactorStreamingHttpClient = ReactorStreamingHttpClient.create(url) // <2>
+    }
+
+    @Get // <3>
+    fun download(): Flux<ByteBuffer<*>> {
+        val request: HttpRequest<*> = HttpRequest.GET<Any>(DEFAULT_URI)
+        return reactorStreamingHttpClient.dataStream(request).doOnNext { byteBuffer ->
+            if (byteBuffer is ReferenceCounted) {
+                byteBuffer.retain()
+            }
+        } // <4>
+    }
+
+    @PreDestroy // <5>
+    override fun close() {
+        reactorStreamingHttpClient.close()
+    }
+
+    companion object {
+        private val DEFAULT_URI: URI = URI.create("https://guides.micronaut.io/micronaut5K.png")
+    }
+}

--- a/guides/micronaut-reactor-streaming-http-client/kotlin/src/main/kotlin/example/micronaut/HomeController.kt
+++ b/guides/micronaut-reactor-streaming-http-client/kotlin/src/main/kotlin/example/micronaut/HomeController.kt
@@ -37,7 +37,7 @@ class HomeController : AutoCloseable {
         val url = try {
             URI.create(urlStr).toURL()
         } catch (e: MalformedURLException) {
-            throw ConfigurationException("malformed URL$urlStr")
+            throw ConfigurationException("malformed URL: $urlStr")
         }
         reactorStreamingHttpClient = ReactorStreamingHttpClient.create(url) // <2>
     }

--- a/guides/micronaut-reactor-streaming-http-client/kotlin/src/test/kotlin/example/micronaut/HomeControllerTest.kt
+++ b/guides/micronaut-reactor-streaming-http-client/kotlin/src/test/kotlin/example/micronaut/HomeControllerTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledInNativeImage
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.HexFormat
+
+@MicronautTest // <1>
+class HomeControllerTest {
+
+    private val hexFormat: HexFormat = HexFormat.of()
+
+    @DisabledInNativeImage
+    @Test
+    fun downloadFile(
+        @Client("/") httpClient: HttpClient, // <2>
+        resourceLoader: ResourceLoader
+    ) {
+        val resource = resourceLoader.getResource("micronaut5K.png")
+        assertTrue(resource.isPresent)
+        val expectedByteArray = Files.readAllBytes(Path.of(resource.get().toURI()))
+
+        val digest = MessageDigest.getInstance("SHA-256")
+        val expectedEncodedHash = digest.digest(expectedByteArray)
+        val expected = hexFormat.formatHex(expectedEncodedHash)
+
+        val client: BlockingHttpClient = httpClient.toBlocking()
+        val resp = assertDoesNotThrow<HttpResponse<ByteArray>> {
+            client.exchange(HttpRequest.GET<Any>("/"), ByteArray::class.java)
+        }
+        val responseBytes = resp.body()
+
+        val responseEncodedHash = digest.digest(responseBytes)
+        val response = hexFormat.formatHex(responseEncodedHash)
+        assertEquals(expected, response)
+    }
+}

--- a/guides/micronaut-reactor-streaming-http-client/kotlin/src/test/kotlin/example/micronaut/HomeControllerTest.kt
+++ b/guides/micronaut-reactor-streaming-http-client/kotlin/src/test/kotlin/example/micronaut/HomeControllerTest.kt
@@ -55,7 +55,7 @@ class HomeControllerTest {
         val resp = assertDoesNotThrow<HttpResponse<ByteArray>> {
             client.exchange(HttpRequest.GET<Any>("/"), ByteArray::class.java)
         }
-        val responseBytes = resp.body()
+        val responseBytes = resp.body() ?: throw AssertionError("Expected response body")
 
         val responseEncodedHash = digest.digest(responseBytes)
         val response = hexFormat.formatHex(responseEncodedHash)

--- a/guides/micronaut-reactor-streaming-http-client/metadata.json
+++ b/guides/micronaut-reactor-streaming-http-client/metadata.json
@@ -5,7 +5,7 @@
   "tags": [],
   "categories": ["HTTP Client"],
   "publicationDate": "2023-12-14",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "buildTools": ["GRADLE"],
   "apps": [
     {


### PR DESCRIPTION
## Summary
- Add the Kotlin variant for `guides/micronaut-reactor-streaming-http-client`.
- Enable `KOTLIN` in the guide metadata while preserving the Java variant.
- Mirror the existing Java controller/test behavior for streaming `micronaut5K.png` and verifying the SHA-256 hash.

## Verification
- `git diff --check -- guides/micronaut-reactor-streaming-http-client`
- `./gradlew micronautReactorStreamingHttpClientBuild -x micronautReactorStreamingHttpClientRunNativeTestScript --stacktrace`
- `./gradlew micronautReactorStreamingHttpClientRunTestScript --stacktrace`
- GitHub checks: `Generate Guide Test Matrix`, `Running micronautReactorStreamingHttpClientBuild with Java 25`, and `license/cla` passed.

## Release Target
- Target branch: `master`.
- Release target: 5.0.x default-branch docs/sample-code work.
- Micronaut organization project: `5.0.1 Release` (#146). Ambiguity preserved from QA intake: `version.txt` on `master` reports `5.0.0`, but no open `5.0.0 Release` organization project was found; `5.0.1 Release` is the closest open 5.0-line board.

## Routing Notes
- The `5.0.1 Release` organization project exists, but this token could not add the PR to the project because GitHub returned `INSUFFICIENT_SCOPES`; `addProjectV2ItemById` requires the `project` scope and the token only has `read:project` for project access.
- The linked issue creator is `sdelamo`; requesting `sdelamo` as reviewer failed because GitHub returned `Review cannot be requested from pull request author` (HTTP 422).

## PR Assets
No separate binary or screenshot asset is required for this source-only guide variant. The rendered Kotlin guide output was generated locally and includes `HomeController.kt` and `HomeControllerTest.kt` snippets.

Closes #1751.

---
###### ✨ This message was AI-generated using gpt-5
