### PR TITLE
Add Kotlin variant for REST API test-first guide

### DIFF
--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/building-a-rest-api-spring-boot-vs-micronaut-test-first.adoc
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/building-a-rest-api-spring-boot-vs-micronaut-test-first.adoc
@@ -10,9 +10,9 @@ This guide compares how to test serialization in Micronaut Framework and Spring 
 
 This guide is the first tutorial of https://guides.micronaut.io/latest/tag-building_a_rest_api.html[Building a REST API] - a series of tutorials comparing how to develop a REST API with Micronaut Framework and Spring Boot.
 
-== Record
+== Model
 
-The application you will build is a REST API for Software as a Service (SaaS) subscriptions. The application serializes and deserializes the following Java record from and to JSON.
+The application you will build is a REST API for Software as a Service (SaaS) subscriptions. The application serializes and deserializes the following type from and to JSON.
 
 source:SaasSubscription[app=springboot]
 
@@ -27,7 +27,7 @@ callout:serdeable[]
 
 == Expected JSON
 
-We want deserialization from a JSON object into the Java record:
+We want deserialization from a JSON object into the application type:
 
 testResource:expected.json[app=micronautframeworkjacksondatabind]
 

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/building-a-rest-api-spring-boot-vs-micronaut-test-first.adoc
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/building-a-rest-api-spring-boot-vs-micronaut-test-first.adoc
@@ -17,7 +17,7 @@ The application you will build is a REST API for Software as a Service (SaaS) su
 source:SaasSubscription[app=springboot]
 
 Micronaut supports serialization with Jackson Databind or with https://micronaut-projects.github.io/micronaut-serialization/latest/guide/[Micronaut Serialization].
-If you use Micronaut Jackson Databind, the above record will be identical in Micronaut Framework and Spring Boot.
+If you use Micronaut Jackson Databind, the above model will be identical in Micronaut Framework and Spring Boot.
 
 === Micronaut Serialization
 If you use Micronaut Serialization, you must opt the class in to serialization, which you can do by annotating it with `@Serdeable`.

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/metadata.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["spring-boot"],
   "categories": ["Boot to Micronaut Building a REST API"],
   "publicationDate": "2024-04-24",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "buildTools": ["GRADLE"],
   "apps": [
     {

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
@@ -1,0 +1,3 @@
+package example.micronaut
+
+data class SaasSubscription(val id: Long, val name: String, val cents: Int)

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
@@ -1,0 +1,61 @@
+package example.micronaut
+
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+
+@MicronautTest(startApplication = false) // <1>
+class SaasSubscriptionJsonTest {
+
+    @Test
+    fun saasSubscriptionSerializationTest(json: JsonMapper, resourceLoader: ResourceLoader) { // <2>
+        val subscription = SaasSubscription(99L, "Professional", 4900)
+        val expected = getResourceAsString(resourceLoader, "expected.json")
+        val result = json.writeValueAsString(subscription)
+        assertThat(result).isEqualToIgnoringWhitespace(expected)
+
+        val documentContext = JsonPath.parse(result)
+        val id = documentContext.read<Number>("$.id")
+        assertThat(id)
+            .isNotNull()
+            .isEqualTo(99)
+
+        val name = documentContext.read<String>("$.name")
+        assertThat(name)
+            .isNotNull()
+            .isEqualTo("Professional")
+
+        val cents = documentContext.read<Number>("$.cents")
+        assertThat(cents)
+            .isNotNull()
+            .isEqualTo(4900)
+    }
+
+    @Test
+    fun saasSubscriptionDeserializationTest(json: JsonMapper) { // <2>
+        val expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+        """.trimIndent()
+        assertThat(json.readValue(expected, SaasSubscription::class.java))
+            .isEqualTo(SaasSubscription(100L, "Advanced", 2900))
+        val subscription = json.readValue(expected, SaasSubscription::class.java)!!
+        assertThat(subscription.id).isEqualTo(100)
+        assertThat(subscription.name).isEqualTo("Advanced")
+        assertThat(subscription.cents).isEqualTo(2900)
+    }
+
+    private fun getResourceAsString(resourceLoader: ResourceLoader, resourceName: String): String =
+        resourceLoader.getResourceAsStream(resourceName)
+            .map { inputStream ->
+                inputStream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+            }
+            .orElse("")
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/kotlin/src/test/resources/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkjacksondatabind/kotlin/src/test/resources/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
@@ -1,0 +1,6 @@
+package example.micronaut
+
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable // <1>
+data class SaasSubscription(val id: Long, val name: String, val cents: Int)

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
@@ -1,0 +1,61 @@
+package example.micronaut
+
+import com.jayway.jsonpath.JsonPath
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+
+@MicronautTest(startApplication = false) // <1>
+class SaasSubscriptionJsonTest {
+
+    @Test
+    fun saasSubscriptionSerializationTest(json: JsonMapper, resourceLoader: ResourceLoader) { // <2>
+        val subscription = SaasSubscription(99L, "Professional", 4900)
+        val expected = getResourceAsString(resourceLoader, "expected.json")
+        val result = json.writeValueAsString(subscription)
+        assertThat(result).isEqualToIgnoringWhitespace(expected)
+
+        val documentContext = JsonPath.parse(result)
+        val id = documentContext.read<Number>("$.id")
+        assertThat(id)
+            .isNotNull()
+            .isEqualTo(99)
+
+        val name = documentContext.read<String>("$.name")
+        assertThat(name)
+            .isNotNull()
+            .isEqualTo("Professional")
+
+        val cents = documentContext.read<Number>("$.cents")
+        assertThat(cents)
+            .isNotNull()
+            .isEqualTo(4900)
+    }
+
+    @Test
+    fun saasSubscriptionDeserializationTest(json: JsonMapper) { // <2>
+        val expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+        """.trimIndent()
+        assertThat(json.readValue(expected, SaasSubscription::class.java))
+            .isEqualTo(SaasSubscription(100L, "Advanced", 2900))
+        val subscription = json.readValue(expected, SaasSubscription::class.java)!!
+        assertThat(subscription.id).isEqualTo(100)
+        assertThat(subscription.name).isEqualTo("Advanced")
+        assertThat(subscription.cents).isEqualTo(2900)
+    }
+
+    private fun getResourceAsString(resourceLoader: ResourceLoader, resourceName: String): String =
+        resourceLoader.getResourceAsStream(resourceName)
+            .map { inputStream ->
+                inputStream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+            }
+            .orElse("")
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/kotlin/src/test/resources/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/micronautframeworkserde/kotlin/src/test/resources/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/kotlin/src/main/kotlin/example/micronaut/SaasSubscription.kt
@@ -1,0 +1,3 @@
+package example.micronaut
+
+data class SaasSubscription(val id: Long, val name: String, val cents: Int)

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/kotlin/src/test/kotlin/example/micronaut/SaasSubscriptionJsonTest.kt
@@ -1,0 +1,45 @@
+package example.micronaut
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.json.JsonTest
+import org.springframework.boot.test.json.JacksonTester
+
+@JsonTest // <1>
+class SaasSubscriptionJsonTest {
+
+    @Autowired // <2>
+    private lateinit var json: JacksonTester<SaasSubscription> // <3>
+
+    @Test
+    fun saasSubscriptionSerializationTest() {
+        val subscription = SaasSubscription(99L, "Professional", 4900)
+        assertThat(json.write(subscription)).isStrictlyEqualToJson("expected.json")
+        assertThat(json.write(subscription)).hasJsonPathNumberValue("@.id")
+        assertThat(json.write(subscription)).extractingJsonPathNumberValue("@.id")
+            .isEqualTo(99)
+        assertThat(json.write(subscription)).hasJsonPathStringValue("@.name")
+        assertThat(json.write(subscription)).extractingJsonPathStringValue("@.name")
+            .isEqualTo("Professional")
+        assertThat(json.write(subscription)).hasJsonPathNumberValue("@.cents")
+        assertThat(json.write(subscription)).extractingJsonPathNumberValue("@.cents")
+            .isEqualTo(4900)
+    }
+
+    @Test
+    fun saasSubscriptionDeserializationTest() {
+        val expected = """
+           {
+               "id":100,
+               "name": "Advanced",
+               "cents":2900
+           }
+        """.trimIndent()
+        assertThat(json.parse(expected))
+            .isEqualTo(SaasSubscription(100L, "Advanced", 2900))
+        assertThat(json.parseObject(expected).id).isEqualTo(100)
+        assertThat(json.parseObject(expected).name).isEqualTo("Advanced")
+        assertThat(json.parseObject(expected).cents).isEqualTo(2900)
+    }
+}

--- a/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/kotlin/src/test/resources/example/micronaut/expected.json
+++ b/guides/building-a-rest-api-spring-boot-vs-micronaut-test-first/springboot/kotlin/src/test/resources/example/micronaut/expected.json
@@ -1,0 +1,5 @@
+{
+  "id": 99,
+  "name": "Professional",
+  "cents": 4900
+}


### PR DESCRIPTION
## Summary

- Adds Kotlin sample models, serialization tests, and expected JSON resources for the Spring Boot, Micronaut Jackson Databind, and Micronaut Serialization app variants.
- Enables Kotlin rendering for `building-a-rest-api-spring-boot-vs-micronaut-test-first`.
- Updates shared guide wording from Java-record-specific language to language-neutral model/type wording.

## Verification

- `git diff --check origin/master...HEAD`
- `./gradlew buildingARestApiSpringBootVsMicronautTestFirstRunTestScript --stacktrace --rerun-tasks`
- `./gradlew buildingARestApiSpringBootVsMicronautTestFirstBuild --stacktrace -x buildingARestApiSpringBootVsMicronautTestFirstRunNativeTestScript`

Full local build caveat: prior implementation/QA runs reached the native-test phase and failed on the local GraalVM reachability metadata schema environment issue; the focused generated-app test script passes for all Java and Kotlin generated app variants.

## Release / Project

- Target branch: `master`
- Release target: default-branch `5.0.x` docs/sample-code work
- Selected Micronaut organization project: `5.0.1 Release`
- Ambiguity preserved from QA: the guides repository has no stable release tags, `version.txt` is `5.0.0`, and open Micronaut Platform BOM boards include `5.0.1 Release`, `5.1.0 Release`, `6.0.0 Release`, and `4.10.14 Release`; QA selected the earliest open 5.0.x board.
- Live project association was attempted but not applied because GitHub rejected the mutation with missing `project` token scope for `addProjectV2ItemById`.

## Reviewer Routing

- Requested reviewer `sdelamo` was attempted because `sdelamo` created the linked issue, but GitHub rejected it: `Review cannot be requested from pull request author.`

## PR Assets

- [Rendered java guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/aec37b5313b17d2598ac0fd203607a89b3e6718c/assets/pr-1838/d450c302228b/building-a-rest-api-spring-boot-vs-micronaut-test-first-gradle-java.html)
- [Rendered kotlin guide HTML](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/90014925882ff023da958dffd71bf87cbfec8af8/assets/pr-1838/d450c302228b/building-a-rest-api-spring-boot-vs-micronaut-test-first-gradle-kotlin.html)

Closes #1676

---
###### ✨ This message was AI-generated using gpt-5