### PR TITLE
Add Kotlin version for micronaut-static-resources

### DIFF
--- a/guides/micronaut-static-resources/kotlin/src/main/kotlin/example/micronaut/MainController.kt
+++ b/guides/micronaut-static-resources/kotlin/src/main/kotlin/example/micronaut/MainController.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.views.View
+import jakarta.validation.constraints.NotBlank
+
+@Controller // <1>
+open class MainController(
+    private val messageService: MessageService // <2>
+) {
+
+    @View("index.html") // <3>
+    @Get(value = "/hello/{name}", produces = [MediaType.TEXT_HTML]) // <4>
+    open fun index(@NotBlank name: String): Map<String, String> { // <5>
+        return mapOf("message" to messageService.sayHello(name))
+    }
+}

--- a/guides/micronaut-static-resources/kotlin/src/main/kotlin/example/micronaut/MessageService.kt
+++ b/guides/micronaut-static-resources/kotlin/src/main/kotlin/example/micronaut/MessageService.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import jakarta.validation.constraints.NotBlank
+
+interface MessageService {
+
+    fun sayHello(@NotBlank name: String?): String
+}

--- a/guides/micronaut-static-resources/kotlin/src/main/kotlin/example/micronaut/MyMessageService.kt
+++ b/guides/micronaut-static-resources/kotlin/src/main/kotlin/example/micronaut/MyMessageService.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+
+@Singleton // <1>
+open class MyMessageService : MessageService {
+
+    override fun sayHello(@NotBlank name: String?): String {
+        return "Hello $name!"
+    }
+}

--- a/guides/micronaut-static-resources/kotlin/src/test/kotlin/example/micronaut/MainControllerTest.kt
+++ b/guides/micronaut-static-resources/kotlin/src/test/kotlin/example/micronaut/MainControllerTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@MicronautTest // <1>
+class MainControllerTest {
+
+    @Inject
+    @field:Client("/hello") // <2>
+    lateinit var client: HttpClient
+
+    @Test
+    fun testItWorks() {
+        val html = client.toBlocking().retrieve("/Tim", String::class.java)
+        assertTrue(html.contains("<h1>Hello Tim!</h1>"))
+    }
+}

--- a/guides/micronaut-static-resources/kotlin/src/test/kotlin/example/micronaut/MessageServiceTest.kt
+++ b/guides/micronaut-static-resources/kotlin/src/test/kotlin/example/micronaut/MessageServiceTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.validation.ConstraintViolationException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+@MicronautTest(startApplication = false) // <1>
+class MessageServiceTest {
+
+    @Inject
+    lateinit var service: MessageService // <2>
+
+    @Test
+    fun testItWorks() {
+        assertEquals("Hello Tim!", service.sayHello("Tim"))
+    }
+
+    @Test
+    fun testValidationWithNull() {
+        val exception = assertThrows(ConstraintViolationException::class.java) { service.sayHello(null) }
+        assertEquals(1, exception.constraintViolations.size)
+        assertEquals("sayHello.name: must not be blank", exception.localizedMessage)
+    }
+
+    @Test
+    fun testValidationWithBlank() {
+        val exception = assertThrows(ConstraintViolationException::class.java) { service.sayHello("   ") }
+        assertEquals(1, exception.constraintViolations.size)
+        assertEquals("sayHello.name: must not be blank", exception.message)
+    }
+}

--- a/guides/micronaut-static-resources/kotlin/src/test/kotlin/example/micronaut/StaticResourceTest.kt
+++ b/guides/micronaut-static-resources/kotlin/src/test/kotlin/example/micronaut/StaticResourceTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@MicronautTest // <1>
+class StaticResourceTest {
+
+    @Inject
+    @field:Client("/css") // <2>
+    lateinit var cssClient: HttpClient
+
+    @Inject
+    @field:Client("/images") // <2>
+    lateinit var imageClient: HttpClient
+
+    @Test
+    fun stylesheetExists() {
+        val css = cssClient.toBlocking().retrieve("/style.css", String::class.java)
+        assertTrue(css.contains("html, body {"))
+    }
+
+    @Test
+    fun imageExists() {
+        val image = imageClient.toBlocking().retrieve("/micronaut_stacked_black.png", ByteArray::class.java)
+        val expectedLength = StaticResourceTest::class.java
+            .getResourceAsStream("/static/images/micronaut_stacked_black.png")!!
+            .use { it.readBytes().size }
+        assertEquals(expectedLength, image.size)
+    }
+}

--- a/guides/micronaut-static-resources/metadata.json
+++ b/guides/micronaut-static-resources/metadata.json
@@ -5,7 +5,7 @@
   "tags": ["static-resources", "views", "thymeleaf", "validation"],
   "categories": ["Static Resources"],
   "publicationDate": "2024-02-01",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "KOTLIN"],
   "apps": [
     {
       "name": "default",


### PR DESCRIPTION
## Summary

- Adds the Kotlin sample implementation for `guides/micronaut-static-resources`.
- Updates guide metadata to publish the Kotlin variant alongside Java.
- Keeps the change scoped to MNG-425; the sibling Groovy issue is not included.

Closes #1762

## Validation

- `git diff --cached --check`
- `./gradlew micronautStaticResourcesRunTestScript --stacktrace`
- `./gradlew micronautStaticResourcesBuild --stacktrace` fails only in native-image validation for both generated Java and Kotlin projects because the local GraalVM installation does not support the reachability-metadata schema from the configured repository.

## Release Project Note

QA selected the `5.0.1 Release` Micronaut organization project because the branch version signal is `5.0.0` and no open `5.0.0` project was available.

---
###### ✨ This message was AI-generated using gpt-5.5
