### PR TITLE
Add Groovy variant for OpenAPI Asciidoc guide

### DIFF
--- a/guides/micronaut-openapi-adoc/groovy/src/main/groovy/example/micronaut/HomeController.groovy
+++ b/guides/micronaut-openapi-adoc/groovy/src/main/groovy/example/micronaut/HomeController.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.uri.UriBuilder
+import io.swagger.v3.oas.annotations.Hidden
+
+@Controller // <1>
+class HomeController {
+
+    private static final URI ADOC = UriBuilder.of('/swagger').path('micronaut-guides-1.0.adoc').build()
+
+    @Get // <2>
+    @Hidden // <3>
+    HttpResponse<?> home() {
+        HttpResponse.seeOther(ADOC)
+    }
+}

--- a/guides/micronaut-openapi-adoc/groovy/src/main/resources/META-INF/native-image/example.micronaut.micronautguide/resource-config.json
+++ b/guides/micronaut-openapi-adoc/groovy/src/main/resources/META-INF/native-image/example.micronaut.micronautguide/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources": {
+    "includes": [
+      {"pattern": "META-INF/swagger/micronaut-guides-1.0.adoc$"}
+    ]
+  }
+}

--- a/guides/micronaut-openapi-adoc/groovy/src/test/groovy/example/micronaut/HomeControllerHiddenAsciidocSpec.groovy
+++ b/guides/micronaut-openapi-adoc/groovy/src/test/groovy/example/micronaut/HomeControllerHiddenAsciidocSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+@MicronautTest(startApplication = false) // <1>
+class HomeControllerHiddenAsciidocSpec extends Specification {
+
+    @Inject
+    ResourceLoader resourceLoader
+
+    void 'home controller is hidden'() {
+        given:
+        Optional<InputStream> adocInputStream = resourceLoader.getResourceAsStream('META-INF/swagger/micronaut-guides-1.0.adoc')
+
+        expect:
+        adocInputStream.present
+
+        when:
+        String adoc = new String(adocInputStream.get().readAllBytes(), StandardCharsets.UTF_8)
+
+        then:
+        !adoc.contains('=== __GET__ `/`')
+    }
+}

--- a/guides/micronaut-openapi-adoc/groovy/src/test/groovy/example/micronaut/OpenApiAsciidocGeneratedSpec.groovy
+++ b/guides/micronaut-openapi-adoc/groovy/src/test/groovy/example/micronaut/OpenApiAsciidocGeneratedSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false) // <1>
+class OpenApiAsciidocGeneratedSpec extends Specification {
+
+    @Inject
+    ResourceLoader resourceLoader
+
+    void 'build generates open api'() {
+        expect:
+        resourceLoader.getResource('META-INF/swagger/micronaut-guides-1.0.adoc').present
+    }
+}

--- a/guides/micronaut-openapi-adoc/groovy/src/test/groovy/example/micronaut/OpenApiAsciidocSpec.groovy
+++ b/guides/micronaut-openapi-adoc/groovy/src/test/groovy/example/micronaut/OpenApiAsciidocSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest // <1>
+class OpenApiAsciidocSpec extends Specification {
+
+    @Inject
+    @Client('/') // <2>
+    HttpClient httpClient
+
+    void 'open api'() {
+        when:
+        httpClient.toBlocking().exchange('/swagger/micronaut-guides-1.0.adoc')
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/guides/micronaut-openapi-adoc/metadata.json
+++ b/guides/micronaut-openapi-adoc/metadata.json
@@ -6,7 +6,7 @@
   "tags": ["static-resources"],
   "categories": ["OpenAPI"],
   "publicationDate": "2023-12-04",
-  "languages": ["JAVA"],
+  "languages": ["JAVA", "GROOVY"],
   "buildTools": ["GRADLE"],
   "apps": [
     {

--- a/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/Application.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/Application.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.runtime.Micronaut
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.servers.Server
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = 'micronaut-guides',
+                version = '1.0'
+        ), servers = @Server(url = 'https://guides.micronaut.io')
+) // <1>
+class Application {
+
+    static void main(String[] args) {
+        Micronaut.run(Application, args)
+    }
+}

--- a/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/BuildTool.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/BuildTool.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+enum BuildTool {
+
+    GRADLE, MAVEN
+}

--- a/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/Guide.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/Guide.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.serde.annotation.Serdeable
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+import java.time.LocalDate
+
+@Serdeable // <1>
+class Guide {
+
+    @NotBlank
+    String title
+
+    @NotBlank
+    String intro
+
+    @NotNull
+    @Size(min = 1)
+    List<String> authors // <2>
+
+    @Nullable
+    List<String> tags
+
+    @NotNull
+    @Size(min = 1)
+    List<String> categories
+
+    @Schema(format = 'yyyy-MM-dd', example = '2018-05-23')
+    @NotNull
+    LocalDate publicationDate // <3>
+
+    @NotBlank
+    String slug
+
+    @NotBlank
+    String url
+
+    @NotNull
+    @Size(min = 1)
+    @Valid
+    List<Option> options
+
+    Guide(String title,
+          String intro,
+          List<String> authors,
+          @Nullable List<String> tags,
+          List<String> categories,
+          LocalDate publicationDate,
+          String slug,
+          String url,
+          List<Option> options) {
+        this.title = title
+        this.intro = intro
+        this.authors = authors
+        this.tags = tags
+        this.categories = categories
+        this.publicationDate = publicationDate
+        this.slug = slug
+        this.url = url
+        this.options = options
+    }
+}

--- a/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/Language.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/Language.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+enum Language {
+
+    GROOVY,
+    JAVA,
+    KOTLIN
+}

--- a/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/LatestGuidesController.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/LatestGuidesController.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+import java.time.LocalDate
+
+@Controller('/latest') // <1>
+class LatestGuidesController {
+
+    private static final List<Guide> GUIDES = [
+            new Guide(
+                    'Creating your first Micronaut application',
+                    'Learn how to create a Hello World Micronaut application with a controller and a functional test.',
+                    ['Iván López', 'Sergio dle Amo'],
+                    ['junit', 'getting_started', 'graalvm'],
+                    ['Getting Started'],
+                    LocalDate.of(2018, 5, 23),
+                    'creating-your-first-micronaut-app',
+                    'https://guides.micronaut.io/latest/creating-your-first-micronaut-app.html',
+                    [
+                            new Option(Language.JAVA, BuildTool.GRADLE, 'https://guides.micronaut.io/latest/creating-your-first-micronaut-app-gradle-java.html'),
+                            new Option(Language.GROOVY, BuildTool.GRADLE, 'https://guides.micronaut.io/latest/creating-your-first-micronaut-app-gradle-groovy.html'),
+                            new Option(Language.KOTLIN, BuildTool.GRADLE, 'https://guides.micronaut.io/latest/creating-your-first-micronaut-app-gradle-kotlin.html'),
+                            new Option(Language.JAVA, BuildTool.MAVEN, 'https://guides.micronaut.io/latest/creating-your-first-micronaut-app-maven-java.html'),
+                            new Option(Language.GROOVY, BuildTool.MAVEN, 'https://guides.micronaut.io/latest/creating-your-first-micronaut-app-maven-groovy.html'),
+                            new Option(Language.KOTLIN, BuildTool.MAVEN, 'https://guides.micronaut.io/latest/creating-your-first-micronaut-app-maven-kotlin.html')
+                    ]
+            )
+    ]
+
+    @Get('/guides.json') // <2>
+    List<Guide> latestGuides() {
+        GUIDES
+    }
+}

--- a/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/LatestGuidesController.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/LatestGuidesController.groovy
@@ -27,7 +27,7 @@ class LatestGuidesController {
             new Guide(
                     'Creating your first Micronaut application',
                     'Learn how to create a Hello World Micronaut application with a controller and a functional test.',
-                    ['Iván López', 'Sergio dle Amo'],
+                    ['Iván López', 'Sergio del Amo'],
                     ['junit', 'getting_started', 'graalvm'],
                     ['Getting Started'],
                     LocalDate.of(2018, 5, 23),

--- a/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/Option.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/main/groovy/example/micronaut/Option.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+@Serdeable // <1>
+class Option {
+
+    @NotNull
+    Language language // <2>
+
+    @NotNull
+    BuildTool buildTool // <2>
+
+    @NotBlank
+    String url // <2>
+
+    Option(Language language, BuildTool buildTool, String url) {
+        this.language = language
+        this.buildTool = buildTool
+        this.url = url
+    }
+}

--- a/guides/micronaut-openapi-base/groovy/src/test/groovy/example/micronaut/HomeControllerSpec.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/test/groovy/example/micronaut/HomeControllerSpec.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.util.StringUtils
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@Property(name = 'micronaut.http.client.follow-redirects', value = StringUtils.FALSE) // <1>
+@MicronautTest // <2>
+class HomeControllerSpec extends Specification {
+
+    @Inject
+    @Client('/') // <3>
+    HttpClient httpClient
+
+    void 'home controller is hidden'() {
+        when:
+        String yml = httpClient.toBlocking().retrieve('/swagger/micronaut-guides-1.0.yml')
+
+        then:
+        !yml.contains('operationId: home') // <4>
+    }
+}

--- a/guides/micronaut-openapi-base/groovy/src/test/groovy/example/micronaut/LatestGuidesControllerSpec.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/test/groovy/example/micronaut/LatestGuidesControllerSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest // <1>
+class LatestGuidesControllerSpec extends Specification {
+
+    @Inject
+    @Client('/') // <2>
+    HttpClient httpClient
+
+    void 'guides endpoint'() {
+        given:
+        URI uri = UriBuilder.of('/latest').path('guides.json').build()
+        HttpRequest<?> request = HttpRequest.GET(uri)
+
+        when:
+        String json = httpClient.toBlocking().retrieve(request)
+
+        then:
+        json.contains('2018-05-23')
+    }
+}

--- a/guides/micronaut-openapi-base/groovy/src/test/groovy/example/micronaut/OpenApiExposedSpec.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/test/groovy/example/micronaut/OpenApiExposedSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest // <1>
+class OpenApiExposedSpec extends Specification {
+
+    @Inject
+    @Client('/') // <2>
+    HttpClient httpClient
+
+    void 'open api'() {
+        when:
+        httpClient.toBlocking().exchange('/swagger/micronaut-guides-1.0.yml')
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/guides/micronaut-openapi-base/groovy/src/test/groovy/example/micronaut/OpenApiGeneratedSpec.groovy
+++ b/guides/micronaut-openapi-base/groovy/src/test/groovy/example/micronaut/OpenApiGeneratedSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut
+
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false) // <1>
+class OpenApiGeneratedSpec extends Specification {
+
+    @Inject
+    ResourceLoader resourceLoader
+
+    void 'build generates open api'() {
+        expect:
+        resourceLoader.getResource('META-INF/swagger/micronaut-guides-1.0.yml').present
+    }
+}

--- a/guides/micronaut-openapi-base/java/src/main/java/example/micronaut/LatestGuidesController.java
+++ b/guides/micronaut-openapi-base/java/src/main/java/example/micronaut/LatestGuidesController.java
@@ -27,7 +27,7 @@ class LatestGuidesController {
     private static final List<Guide> GUIDES = Collections.singletonList(
             new Guide("Creating your first Micronaut application",
                     "Learn how to create a Hello World Micronaut application with a controller and a functional test.",
-                    List.of("Iván López", "Sergio dle Amo"),
+                    List.of("Iván López", "Sergio del Amo"),
                     List.of("junit","getting_started","graalvm"),
                     List.of("Getting Started"),
                     LocalDate.of(2018, 5, 23),

--- a/guides/micronaut-openapi-base/openapi-intro.adoc
+++ b/guides/micronaut-openapi-base/openapi-intro.adoc
@@ -30,7 +30,7 @@ source:Option[]
 callout:serdeable[]
 callout:constraints[]
 
-The following Java record represents a Micronaut Guide:
+The following type represents a Micronaut Guide:
 
 source:Guide[]
 callout:serdeable[]
@@ -52,7 +52,7 @@ callout:http-client[]
 
 == @OpenApiSpecification
 
-The Micronaut OpenAPI integration requires a class to be annotated with `@OpenApiSpecification`. Modify `Application.java` and annotate it.
+The Micronaut OpenAPI integration requires a class to be annotated with `@OpenApiSpecification`. Modify the application class and annotate it.
 
 source:Application[]
 

--- a/guides/micronaut-openapi-base/openapi-intro.adoc
+++ b/guides/micronaut-openapi-base/openapi-intro.adoc
@@ -50,15 +50,15 @@ test:LatestGuidesControllerTest[]
 callout:micronaut-test[]
 callout:http-client[]
 
-== @OpenApiSpecification
+== @OpenAPIDefinition
 
-The Micronaut OpenAPI integration requires a class to be annotated with `@OpenApiSpecification`. Modify the application class and annotate it.
+The Micronaut OpenAPI integration requires a class to be annotated with `@OpenAPIDefinition`. Modify the application class and annotate it.
 
 source:Application[]
 
 == OpenAPI Generated at Compile Time
 
-By adding the `@OpenApiSpecification` annotation to `Application`, an OpenAPI specification is generated at compile time. You can test it as follows:
+By adding the `@OpenAPIDefinition` annotation to `Application`, an OpenAPI specification is generated at compile time. You can test it as follows:
 
 test:OpenApiGeneratedTest[]
 callout:micronaut-test-start-application-false[]


### PR DESCRIPTION
## Summary

- Adds the Groovy implementation and Spock tests for `micronaut-openapi-adoc`.
- Adds the required Groovy sources/tests for the shared `micronaut-openapi-base` content inherited by the guide.
- Updates guide metadata to publish the Java and Groovy variants, removes Java-only wording from shared guide text, and fixes the OpenAPI annotation name and sample author spelling found during code review.

Closes #1732

## Verification

- `git diff --check origin/master...HEAD`
- `./gradlew micronautOpenapiAdocRunTestScript --stacktrace --rerun-tasks`
- `./gradlew micronautOpenapiAdocBuild -x micronautOpenapiAdocRunNativeTestScript --stacktrace --rerun-tasks`

The exact full build with native tests was previously blocked on this host by the existing GraalVM/native-build-tools reachability metadata schema mismatch before Groovy native tests run; the non-native guide build and generated Java/Groovy test script pass on the final branch.

## Release Target

- Target branch: `master`
- Type label: `type: docs`
- Micronaut organization project: `5.0.1 Release`
- Live project link: attempted, but GitHub rejected the project mutation because this token has `read:project` instead of the required `project` write scope.
- Ambiguity: `micronaut-guides` has no stable GitHub Releases, so this project selection follows `version.txt`, default-branch content, and the open Micronaut Platform release boards recorded during QA intake.

## PR Assets

- [Rendered Groovy guide](https://raw.githubusercontent.com/micronaut-projects/micronaut-guides/ab7276ab1e60841568ef6b9494d253773d0cb27b/assets/pr-1840/cc630c9d53eb/mng-395-micronaut-openapi-adoc-gradle-groovy.html)

---
###### ✨ This message was AI-generated using gpt-5