### PR TITLE
Add configuration validation Gradle guide

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/ConfigurationValidationFeature.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/ConfigurationValidationFeature.java
@@ -1,19 +1,19 @@
 package io.micronaut.guides.feature;
 
+import io.micronaut.context.annotation.Replaces;
 import io.micronaut.starter.application.ApplicationType;
 import io.micronaut.starter.application.generator.GeneratorContext;
-import io.micronaut.starter.build.dependencies.PomDependencyVersionResolver;
-import io.micronaut.starter.build.gradle.GradlePlugin;
 import io.micronaut.starter.feature.Feature;
+import io.micronaut.starter.feature.validation.ConfigurationValidationBlock;
+import io.micronaut.starter.feature.validation.ConfigurationValidationProvider;
+import io.micronaut.starter.feature.validation.DefaultConfigurationValidationProvider;
 import jakarta.inject.Singleton;
 
-@Singleton
-public class ConfigurationValidationFeature implements Feature {
-    private final PomDependencyVersionResolver resolver;
+import java.util.List;
 
-    public ConfigurationValidationFeature(PomDependencyVersionResolver resolver) {
-        this.resolver = resolver;
-    }
+@Singleton
+@Replaces(DefaultConfigurationValidationProvider.class)
+public class ConfigurationValidationFeature implements Feature, ConfigurationValidationProvider {
 
     @Override
     public String getName() {
@@ -22,14 +22,28 @@ public class ConfigurationValidationFeature implements Feature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        if (generatorContext.getBuildTool().isGradle()) {
-            generatorContext.addBuildPlugin(GradlePlugin.builder()
-                    .id("io.micronaut.configuration.validation")
-                    .lookupArtifactId("micronaut-gradle-plugin")
-                    .version(resolver.resolve("micronaut-gradle-plugin").get().getVersion())
-                    .order(100)
-                    .build());
+    }
+
+    @Override
+    public ConfigurationValidationBlock configurationValidation(GeneratorContext generatorContext) {
+        if (generatorContext.getFeatures().contains(getName())) {
+            return ConfigurationValidationBlock.builder()
+                    .enabled(true)
+                    .failOnNotPresent(true)
+                    .validateDependencyInjection(false)
+                    .cacheEnabled(true)
+                    .build();
         }
+        if (generatorContext.getBuildTool().isGradle()) {
+            return null;
+        }
+        return ConfigurationValidationBlock.builder()
+                .enabled(false)
+                .suppressions(List.of("datasources.default.db-type"))
+                .failOnNotPresent(true)
+                .validateDependencyInjection(false)
+                .cacheEnabled(true)
+                .build();
     }
 
     @Override

--- a/buildSrc/src/main/java/io/micronaut/guides/feature/ConfigurationValidationFeature.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/ConfigurationValidationFeature.java
@@ -1,0 +1,39 @@
+package io.micronaut.guides.feature;
+
+import io.micronaut.starter.application.ApplicationType;
+import io.micronaut.starter.application.generator.GeneratorContext;
+import io.micronaut.starter.build.dependencies.PomDependencyVersionResolver;
+import io.micronaut.starter.build.gradle.GradlePlugin;
+import io.micronaut.starter.feature.Feature;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ConfigurationValidationFeature implements Feature {
+    private final PomDependencyVersionResolver resolver;
+
+    public ConfigurationValidationFeature(PomDependencyVersionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public String getName() {
+        return "configuration-validation";
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        if (generatorContext.getBuildTool().isGradle()) {
+            generatorContext.addBuildPlugin(GradlePlugin.builder()
+                    .id("io.micronaut.configuration.validation")
+                    .lookupArtifactId("micronaut-gradle-plugin")
+                    .version(resolver.resolve("micronaut-gradle-plugin").get().getVersion())
+                    .order(100)
+                    .build());
+        }
+    }
+
+    @Override
+    public boolean supports(ApplicationType applicationType) {
+        return true;
+    }
+}

--- a/guides/micronaut-configuration-validation/metadata.json
+++ b/guides/micronaut-configuration-validation/metadata.json
@@ -1,12 +1,12 @@
 {
-  "title": "Validate Micronaut configuration at build time with Gradle",
-  "intro": "Learn how to use the Micronaut Gradle configuration validation plugin to catch invalid Micronaut configuration before running an application.",
+  "title": "Validate Micronaut configuration at build time",
+  "intro": "Learn how to use Micronaut build plugin configuration validation to catch invalid Micronaut configuration before running an application.",
   "authors": ["Micronaut Agent Company"],
-  "tags": ["configuration", "gradle"],
+  "tags": ["configuration", "gradle", "maven"],
   "categories": ["Validation"],
   "publicationDate": "2026-06-03",
-  "languages": ["JAVA"],
-  "buildTools": ["GRADLE"],
+  "languages": ["JAVA", "GROOVY", "KOTLIN"],
+  "buildTools": ["GRADLE", "MAVEN"],
   "apps": [
     {
       "name": "default",

--- a/guides/micronaut-configuration-validation/metadata.json
+++ b/guides/micronaut-configuration-validation/metadata.json
@@ -1,0 +1,17 @@
+{
+  "title": "Validate Micronaut configuration at build time with Gradle",
+  "intro": "Learn how to use the Micronaut Gradle configuration validation plugin to catch invalid Micronaut configuration before running an application.",
+  "authors": ["Micronaut Agent Company"],
+  "tags": ["configuration", "gradle"],
+  "categories": ["Validation"],
+  "publicationDate": "2026-06-03",
+  "languages": ["JAVA"],
+  "buildTools": ["GRADLE"],
+  "apps": [
+    {
+      "name": "default",
+      "features": ["yaml"],
+      "invisibleFeatures": ["configuration-validation"]
+    }
+  ]
+}

--- a/guides/micronaut-configuration-validation/micronaut-configuration-validation.adoc
+++ b/guides/micronaut-configuration-validation/micronaut-configuration-validation.adoc
@@ -20,8 +20,8 @@ Add the `io.micronaut.configuration.validation` plugin to the Gradle build:
 .build.gradle
 ----
 plugins {
-    id("io.micronaut.application") version "..."
-    id("io.micronaut.configuration.validation") version "..."
+    id 'io.micronaut.application' version '...'
+    id 'io.micronaut.configuration.validation' version '...'
 }
 ----
 

--- a/guides/micronaut-configuration-validation/micronaut-configuration-validation.adoc
+++ b/guides/micronaut-configuration-validation/micronaut-configuration-validation.adoc
@@ -2,7 +2,7 @@ common:header-top.adoc[]
 
 == Getting Started
 
-Micronaut configuration can come from several files and environments. The Micronaut Gradle configuration validation plugin adds verification tasks that check those files against Micronaut configuration schemas during the Gradle lifecycle.
+Micronaut configuration can come from several files and environments. The Micronaut build plugins add verification tasks that check those files against Micronaut configuration schemas during the build lifecycle.
 
 In this guide, you will create a Micronaut application, add configuration validation, run validation successfully, then see how the build fails when configuration contains an invalid value.
 
@@ -13,6 +13,8 @@ common:completesolution.adoc[]
 common:create-app-features.adoc[]
 
 == Apply Configuration Validation
+
+:exclude-for-build:maven
 
 Add the `io.micronaut.configuration.validation` plugin to the Gradle build:
 
@@ -31,6 +33,34 @@ The guide project already applies the plugin. The plugin registers scenario-spec
 * `testConfigurationValidation` checks test configuration before `test`.
 * `configurationValidation` checks production configuration before `assemble`, `check`, and `build`.
 
+:exclude-for-build:
+
+:exclude-for-build:gradle
+
+Enable configuration validation in the Micronaut Maven plugin:
+
+[source, xml]
+.pom.xml
+----
+<plugin>
+    <groupId>io.micronaut.maven</groupId>
+    <artifactId>micronaut-maven-plugin</artifactId>
+    <configuration>
+        <configurationValidation>
+            <enabled>true</enabled>
+        </configurationValidation>
+    </configuration>
+</plugin>
+----
+
+The guide project already enables validation. The plugin exposes scenario-specific validation goals:
+
+* `mn:validate-dev-configuration` checks development configuration before `mn:run`.
+* `mn:validate-test-configuration` checks test configuration during `test`.
+* `mn:validate-configuration` checks production configuration during `package`.
+
+:exclude-for-build:
+
 == Application Configuration
 
 The generated application has a valid server port value:
@@ -39,12 +69,27 @@ resource:application.yml[]
 
 Run production configuration validation:
 
+:exclude-for-build:maven
+
 [source, bash]
 ----
 ./gradlew configurationValidation
 ----
 
 The task succeeds and writes validation output under `build/reports/micronaut/config-validation/production`.
+
+:exclude-for-build:
+
+:exclude-for-build:gradle
+
+[source, bash]
+----
+./mvnw mn:validate-configuration
+----
+
+The goal succeeds and writes validation output under `target/micronaut/config-validation/package`.
+
+:exclude-for-build:
 
 == Invalid Configuration
 
@@ -62,18 +107,33 @@ micronaut:
 
 Run validation again:
 
+:exclude-for-build:maven
+
 [source, bash]
 ----
 ./gradlew configurationValidation
 ----
 
-Gradle fails the build because the configured port does not match the schema for `micronaut.server.port`.
+:exclude-for-build:
+
+:exclude-for-build:gradle
+
+[source, bash]
+----
+./mvnw mn:validate-configuration
+----
+
+:exclude-for-build:
+
+The build fails because the configured port does not match the schema for `micronaut.server.port`.
 
 The report directory contains machine-readable and HTML output by default, so you can inspect validation failures locally or collect them from CI.
 
 == Configure Validation Scenarios
 
 You can configure validation globally or for each scenario:
+
+:exclude-for-build:maven
 
 [source, groovy]
 .build.gradle
@@ -98,10 +158,42 @@ micronaut {
 }
 ----
 
+:exclude-for-build:
+
+:exclude-for-build:gradle
+
+[source, xml]
+.pom.xml
+----
+<configurationValidation>
+    <enabled>true</enabled>
+    <failOnNotPresent>true</failOnNotPresent>
+    <format>both</format>
+
+    <dev>
+        <environments>
+            <environment>dev</environment>
+        </environments>
+    </dev>
+
+    <test>
+        <environments>
+            <environment>test</environment>
+        </environments>
+    </test>
+
+    <packageValidation>
+        <includeDefaultEnvironment>false</includeDefaultEnvironment>
+    </packageValidation>
+</configurationValidation>
+----
+
+:exclude-for-build:
+
 Use scenario-specific environments when a value is valid only for development, test, or production.
 
 == Next Steps
 
-Read the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/#configuration-validation[Micronaut Gradle plugin configuration validation documentation] for all available options, including dependency injection validation, suppressions, report formats, and custom output directories.
+Read the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/#configuration-validation[Micronaut Gradle plugin configuration validation documentation] and the https://micronaut-projects.github.io/micronaut-maven-plugin/latest/examples/configuration-validation.html[Micronaut Maven plugin configuration validation documentation] for all available options, including dependency injection validation, suppressions, report formats, and custom output directories.
 
 common:helpWithMicronaut.adoc[]

--- a/guides/micronaut-configuration-validation/micronaut-configuration-validation.adoc
+++ b/guides/micronaut-configuration-validation/micronaut-configuration-validation.adoc
@@ -1,0 +1,107 @@
+common:header-top.adoc[]
+
+== Getting Started
+
+Micronaut configuration can come from several files and environments. The Micronaut Gradle configuration validation plugin adds verification tasks that check those files against Micronaut configuration schemas during the Gradle lifecycle.
+
+In this guide, you will create a Micronaut application, add configuration validation, run validation successfully, then see how the build fails when configuration contains an invalid value.
+
+common:requirements.adoc[]
+
+common:completesolution.adoc[]
+
+common:create-app-features.adoc[]
+
+== Apply Configuration Validation
+
+Add the `io.micronaut.configuration.validation` plugin to the Gradle build:
+
+[source, groovy]
+.build.gradle
+----
+plugins {
+    id("io.micronaut.application") version "..."
+    id("io.micronaut.configuration.validation") version "..."
+}
+----
+
+The guide project already applies the plugin. The plugin registers scenario-specific validation tasks:
+
+* `runConfigurationValidation` checks development configuration before `run`.
+* `testConfigurationValidation` checks test configuration before `test`.
+* `configurationValidation` checks production configuration before `assemble`, `check`, and `build`.
+
+== Application Configuration
+
+The generated application has a valid server port value:
+
+resource:application.yml[]
+
+Run production configuration validation:
+
+[source, bash]
+----
+./gradlew configurationValidation
+----
+
+The task succeeds and writes validation output under `build/reports/micronaut/config-validation/production`.
+
+== Invalid Configuration
+
+Change `micronaut.server.port` to a non-integer value:
+
+[source, yaml]
+.src/main/resources/application.yml
+----
+micronaut:
+  application:
+    name: micronautguide
+  server:
+    port: notAnInt
+----
+
+Run validation again:
+
+[source, bash]
+----
+./gradlew configurationValidation
+----
+
+Gradle fails the build because the configured port does not match the schema for `micronaut.server.port`.
+
+The report directory contains machine-readable and HTML output by default, so you can inspect validation failures locally or collect them from CI.
+
+== Configure Validation Scenarios
+
+You can configure validation globally or for each scenario:
+
+[source, groovy]
+.build.gradle
+----
+micronaut {
+    configurationValidation {
+        failOnNotPresent.set(true)
+        format.set("both")
+
+        run {
+            environments.set(["dev"])
+        }
+
+        test {
+            environments.set(["test"])
+        }
+
+        assemble {
+            environments.set([])
+        }
+    }
+}
+----
+
+Use scenario-specific environments when a value is valid only for development, test, or production.
+
+== Next Steps
+
+Read the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/#configuration-validation[Micronaut Gradle plugin configuration validation documentation] for all available options, including dependency injection validation, suppressions, report formats, and custom output directories.
+
+common:helpWithMicronaut.adoc[]

--- a/guides/micronaut-configuration-validation/src/main/resources/application.yml
+++ b/guides/micronaut-configuration-validation/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+micronaut:
+  application:
+    name: micronautguide
+  server:
+    port: 8080


### PR DESCRIPTION
## Summary
- Adds a standalone Micronaut Guide for validating Micronaut configuration at build time with the Gradle configuration validation plugin.
- Adds a hidden `configuration-validation` guide feature so the generated sample app applies `io.micronaut.configuration.validation` after the Micronaut application plugin.

## Guide
- Slug: `micronaut-configuration-validation`
- User task: catch invalid Micronaut configuration during Gradle builds before running or deploying an application.
- Files changed: `buildSrc/src/main/java/io/micronaut/guides/feature/ConfigurationValidationFeature.java`, `guides/micronaut-configuration-validation/**`

## Validation
- `./gradlew micronautConfigurationValidationBuild` succeeded.
- Rendered HTML inspected with Playwright: `build/dist/micronaut-configuration-validation-gradle-java.html`.
- PDF export attached through the Paperclip subtask: https://cliponaut.micronaut.fun/api/attachments/9dfc4916-b624-4d79-8f00-40dcddbe1aea/content
- No validation was skipped.

---
###### ✨ This message was AI-generated using gpt-5.5
