### PR TITLE
Pin guides publish deploy action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,9 +35,9 @@ jobs:
           current_version=`cat version.txt`
           tmp_version=( ${current_version//./ } )
           version=`echo "${tmp_version[0]}.${tmp_version[1]}.x"`
-          echo ::set-output name=guides_version::${version}
+          echo "guides_version=${version}" >> "$GITHUB_OUTPUT"
       - name: Publish to Github Pages
-        uses: micronaut-projects/github-pages-deploy-action@master
+        uses: micronaut-projects/github-pages-deploy-action@76d63aafbab7108d74e83be4e5b3b0501382e829 # master
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           tmp_version=( ${current_version//./ } )
           version=`echo "${tmp_version[0]}.${tmp_version[1]}.x"`
           echo "guides_version=${version}" >> "$GITHUB_OUTPUT"
-      - name: Publish to Github Pages
+      - name: Publish to GitHub Pages
         uses: micronaut-projects/github-pages-deploy-action@6fc377d4236ae6f456ff7d1884f30b7547cd5248 # DEV-1143-pin-wolfi-base
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           version=`echo "${tmp_version[0]}.${tmp_version[1]}.x"`
           echo "guides_version=${version}" >> "$GITHUB_OUTPUT"
       - name: Publish to Github Pages
-        uses: micronaut-projects/github-pages-deploy-action@76d63aafbab7108d74e83be4e5b3b0501382e829 # master
+        uses: micronaut-projects/github-pages-deploy-action@6fc377d4236ae6f456ff7d1884f30b7547cd5248 # DEV-1143-pin-wolfi-base
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
## Summary

- Pin the `micronaut-guides` publish workflow to reviewed `micronaut-projects/github-pages-deploy-action` commit `6fc377d4236ae6f456ff7d1884f30b7547cd5248` instead of `master`.
- Keep the existing `gh-pages` publish target and `build/dist` source unchanged.
- Replace the deprecated `::set-output` usage with `$GITHUB_OUTPUT` while touching the workflow.

## Review Notes

- Paperclip issue: [DEV-1143](https://cliponaut.micronaut.fun/DEV/issues/DEV-1143)
- Release target: docs/site publishing workflow on `master`; no Micronaut runtime release line or public API impact.
- Micronaut organization projects: no upstream `qa-intake` project selection was present for this docs/site workflow change; no release-board project was linked.
- Linked GitHub issue: none found, so there is no GitHub closing keyword or issue creator reviewer to request.
- Supporting action commit reviewed by QA and Security pins its Wolfi base image to digest `sha256:b78bb982194828b6c9c214230bf34d51944e2102ea8468f01ac21e5f99328efd`.

## Verification

- `git diff --check origin/master...HEAD -- .github/workflows/publish.yml`
- Reviewed `origin/master...HEAD -- .github/workflows/publish.yml`.
- Verified the pinned action commit's `Dockerfile`, `action.yml`, and `entrypoint.sh` through the GitHub API.
- Searched for duplicate GitHub issues/PRs in `micronaut-projects/micronaut-guides`; none found.

---
###### ✨ This message was AI-generated using openai/gpt-5.5