### PR TITLE
Make Rocker code generation reproducible so :buildSrc:compileJava can hit the build cache

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -71,6 +71,12 @@ rocker {
     version = rockerVersion
     configurations{
         main {
+            // Without this, Rocker emits `getModifiedAt() { return <template mtime>; }` into every
+            // generated class. On CI each checkout gives the templates fresh modification times, so
+            // all 32 generated sources differ on every build and :buildSrc:compileJava can never hit
+            // the build cache. `optimize` drops that method (it only exists to support runtime
+            // template reloading, which this build does not use), making generation reproducible.
+            optimize = true
             discardLogicWhitespace = true
             templateDir = file('src/rocker')
             outputDir = file('src/generated/rocker')


### PR DESCRIPTION
## Problem

`:buildSrc:compileJava` never hits the Gradle build cache on CI, and neither does
`:buildSrc:compileGroovy`.

The `nu.studer.rocker` plugin runs Rocker's generator with `optimize = false` (the
default), and in that mode [Rocker emits the template file's modification time into
every generated class](https://github.com/fizzed/rocker/blob/master/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java):

```java
static public long getModifiedAt() { return 1786626728275L; }
```

`buildSrc/src/generated/rocker` is gitignored, so it is regenerated from scratch on
every CI build, and a fresh checkout gives the 32 templates fresh modification times.
All 32 generated `.java` files therefore differ on every build. That changes the
`stableSources` input of `:buildSrc:compileJava`, and the resulting output change
propagates to the `astTransformationClasspath` input of `:buildSrc:compileGroovy`.

Comparing two `testsGroup` builds of the same commit (`f8485cb6`, identical
`git status`) confirms it — `:buildSrc:compileJava` has no value-input or
implementation change, only `stableSources`, with all 32 files reported as
"File has different contents".

## Fix

Set `optimize = true` on the `rocker` main configuration. That drops
`getModifiedAt()` from the generated code, which is the only non-reproducible part
of Rocker's output.

`optimize` also disables Rocker's runtime template reloading. This build does not
use it — nothing references `getModifiedAt`, `RockerRuntime`, or `rocker.reloading`
— and the templates are rendered at build time by `buildSrc`, never hot-reloaded.

## Verification

Two simulated fresh checkouts, differing only in the templates' modification times,
with `--rerun-tasks` so generation really re-runs:

| | `:buildSrc:compileJava` cache key | `:buildSrc:compileGroovy` cache key |
|---|---|---|
| before, checkout A | `8b4cc8e1398b83669e806f25bd581711` | `d43683161675149c064ddb6d5b87f205` |
| before, checkout B | `0449062063f6c8b5d58f20e6114f01e6` | `ebaf5abe8fe48dc44d96948b3b3418e4` |
| after, checkout A | `90feab516dfc70ea31e84a6ad017c48e` | `d562e17a985cf6b1103fca949bbd32ad` |
| after, checkout B | `90feab516dfc70ea31e84a6ad017c48e` | `d562e17a985cf6b1103fca949bbd32ad` |

- Before the change, the full diff between the two generated trees is exactly
  32 `getModifiedAt()` lines and nothing else. After it, the two trees are
  byte-identical.
- Rendered template output is byte-for-byte unchanged (checked by rendering
  templates against the classes built with and without the change).
- `:buildSrc:test` — 112 tests, the same 4 pre-existing failures before and after
  the change (`GuideProjectGeneratorTest`, `JsonFeedGeneratorTest`,
  `TestScriptGeneratorTest` ×2); none are template-related.

## Scale

Small in absolute terms: the Develocity data puts this at roughly 0.1 CI hours per
week of avoidable work. It is a one-line change, so the ratio seemed worth it.

## Unrelated observation

Both compared builds report a 0% cache hit rate — 137 and 136 cache misses, zero
local and zero remote hits. This change fixes one uncacheable task, but something
appears to be preventing these CI builds from reading the cache at all, which is
worth a separate look.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
