### PR TITLE
Add Oracle Vector RAG guide

### DIFF
--- a/buildSrc/src/main/java/io/micronaut/guides/feature/Langchain4jAllMiniLm.java
+++ b/buildSrc/src/main/java/io/micronaut/guides/feature/Langchain4jAllMiniLm.java
@@ -1,0 +1,17 @@
+package io.micronaut.guides.feature;
+
+import io.micronaut.starter.application.generator.GeneratorContext;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Langchain4jAllMiniLm extends AbstractFeature {
+
+    public Langchain4jAllMiniLm() {
+        super("langchain4j-all-minilm", "langchain4j-embeddings-all-minilm-l6-v2");
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        addDependencyWithoutLookup(generatorContext, "dev.langchain4j");
+    }
+}

--- a/guides/micronaut-data-vector-rag/java/src/main/java/example/micronaut/Document.java
+++ b/guides/micronaut-data-vector-rag/java/src/main/java/example/micronaut/Document.java
@@ -1,0 +1,15 @@
+package example.micronaut;
+
+import io.micronaut.data.annotation.GeneratedValue;
+import io.micronaut.data.annotation.Id;
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.VectorStorage;
+import io.micronaut.data.model.vector.FloatVector;
+
+@MappedEntity("documents")
+public record Document(
+        @Id @GeneratedValue(GeneratedValue.Type.IDENTITY) Long id,
+        String content,
+        @VectorStorage(length = Embeddings.DIMENSIONS) FloatVector embedding
+) {
+}

--- a/guides/micronaut-data-vector-rag/java/src/main/java/example/micronaut/DocumentController.java
+++ b/guides/micronaut-data-vector-rag/java/src/main/java/example/micronaut/DocumentController.java
@@ -31,7 +31,7 @@ final class DocumentController {
 
     @Post
     HttpResponse<DocumentCreated> create(@Body DocumentRequest request) {
-        var content = required(request.content());
+        var content = required(request.content()); // <1>
         var saved = documents.save(new Document(null, content, embeddings.embed(content)));
         return HttpResponse.created(new DocumentCreated(saved.id(), saved.content()));
     }
@@ -39,9 +39,9 @@ final class DocumentController {
     @Get("/search")
     List<Match> search(@QueryValue String q) {
         return documents.searchTop3ByEmbeddingNear(
-                        embeddings.embed(required(q)),
+                        embeddings.embed(required(q)), // <2>
                         new Score(2),
-                        ScoringFunction.COSINE
+                        ScoringFunction.COSINE // <3>
                 ).results().stream()
                 .map(result -> new Match(
                         result.entity().id(),

--- a/guides/micronaut-data-vector-rag/java/src/main/java/example/micronaut/DocumentController.java
+++ b/guides/micronaut-data-vector-rag/java/src/main/java/example/micronaut/DocumentController.java
@@ -1,0 +1,72 @@
+package example.micronaut;
+
+import io.micronaut.data.model.vector.FloatVector;
+import io.micronaut.data.model.vector.search.Score;
+import io.micronaut.data.model.vector.search.ScoringFunction;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.List;
+
+@ExecuteOn(TaskExecutors.BLOCKING)
+@Controller("/documents")
+final class DocumentController {
+
+    private final DocumentRepository documents;
+    private final Embeddings embeddings;
+
+    DocumentController(DocumentRepository documents, Embeddings embeddings) {
+        this.documents = documents;
+        this.embeddings = embeddings;
+    }
+
+    @Post
+    HttpResponse<DocumentCreated> create(@Body DocumentRequest request) {
+        var content = required(request.content());
+        var saved = documents.save(new Document(null, content, embeddings.embed(content)));
+        return HttpResponse.created(new DocumentCreated(saved.id(), saved.content()));
+    }
+
+    @Get("/search")
+    List<Match> search(@QueryValue String q) {
+        return documents.searchTop3ByEmbeddingNear(
+                        embeddings.embed(required(q)),
+                        new Score(2),
+                        ScoringFunction.COSINE
+                ).results().stream()
+                .map(result -> new Match(
+                        result.entity().id(),
+                        result.entity().content(),
+                        result.similarity().value()
+                ))
+                .toList();
+    }
+
+    private static String required(String text) {
+        if (text == null || text.isBlank()) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "text is required");
+        }
+        return text;
+    }
+
+    @Serdeable
+    record DocumentRequest(String content) {
+    }
+
+    @Serdeable
+    record DocumentCreated(Long id, String content) {
+    }
+
+    @Serdeable
+    record Match(Long id, String content, double similarity) {
+    }
+}

--- a/guides/micronaut-data-vector-rag/java/src/main/java/example/micronaut/DocumentRepository.java
+++ b/guides/micronaut-data-vector-rag/java/src/main/java/example/micronaut/DocumentRepository.java
@@ -1,0 +1,19 @@
+package example.micronaut;
+
+import io.micronaut.data.jdbc.annotation.JdbcRepository;
+import io.micronaut.data.model.query.builder.sql.Dialect;
+import io.micronaut.data.model.vector.FloatVector;
+import io.micronaut.data.model.vector.search.Score;
+import io.micronaut.data.model.vector.search.ScoringFunction;
+import io.micronaut.data.model.vector.search.SearchResults;
+import io.micronaut.data.repository.CrudRepository;
+
+@JdbcRepository(dialect = Dialect.ORACLE)
+interface DocumentRepository extends CrudRepository<Document, Long> {
+
+    SearchResults<Document> searchTop3ByEmbeddingNear(
+            FloatVector vector,
+            Score maxDistance,
+            ScoringFunction scoringFunction
+    );
+}

--- a/guides/micronaut-data-vector-rag/java/src/main/java/example/micronaut/Embeddings.java
+++ b/guides/micronaut-data-vector-rag/java/src/main/java/example/micronaut/Embeddings.java
@@ -1,0 +1,17 @@
+package example.micronaut;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
+import io.micronaut.data.model.vector.FloatVector;
+import jakarta.inject.Singleton;
+
+@Singleton
+final class Embeddings {
+
+    static final int DIMENSIONS = 384;
+    private final EmbeddingModel model = new AllMiniLmL6V2EmbeddingModel();
+
+    FloatVector embed(String text) {
+        return new FloatVector(model.embed(text).content().vector());
+    }
+}

--- a/guides/micronaut-data-vector-rag/java/src/main/resources/META-INF/native-image/resource-config.json
+++ b/guides/micronaut-data-vector-rag/java/src/main/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources": [
+    {"pattern": "ai/onnxruntime/native/.*"},
+    {"pattern": "all-minilm-l6-v2-tokenizer.json"},
+    {"pattern": "all-minilm-l6-v2.onnx"},
+    {"pattern": "native/lib/.*"}
+  ]
+}

--- a/guides/micronaut-data-vector-rag/java/src/test/java/example/micronaut/EmbeddingsTest.java
+++ b/guides/micronaut-data-vector-rag/java/src/test/java/example/micronaut/EmbeddingsTest.java
@@ -1,0 +1,39 @@
+package example.micronaut;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assumptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmbeddingsTest {
+
+    @Test
+    void createsMiniLmEmbedding() {
+        skipNativeImage();
+        assertEquals(Embeddings.DIMENSIONS, new Embeddings().embed("Micronaut Data").toFloatArray().length);
+    }
+
+    @Test
+    void recognizesSemanticSimilarity() {
+        skipNativeImage();
+        var embeddings = new Embeddings();
+        var query = embeddings.embed("lightweight Java toolkit for backend services").toFloatArray();
+        var framework = embeddings.embed("Micronaut is a JVM framework for fast microservices").toFloatArray();
+        var gardening = embeddings.embed("Tomatoes grow well in sunny gardens").toFloatArray();
+
+        assertTrue(dot(query, framework) > dot(query, gardening));
+    }
+
+    private static double dot(float[] left, float[] right) {
+        double result = 0;
+        for (int i = 0; i < left.length; i++) {
+            result += left[i] * right[i];
+        }
+        return result;
+    }
+
+    private static void skipNativeImage() {
+        Assumptions.assumeFalse(System.getProperty("org.graalvm.nativeimage.imagecode") != null);
+    }
+}

--- a/guides/micronaut-data-vector-rag/java/src/test/java/example/micronaut/VectordemoTest.java
+++ b/guides/micronaut-data-vector-rag/java/src/test/java/example/micronaut/VectordemoTest.java
@@ -1,0 +1,46 @@
+package example.micronaut;
+
+import io.micronaut.data.model.vector.search.Score;
+import io.micronaut.data.model.vector.search.ScoringFunction;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assumptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest(transactional = false)
+class VectordemoTest {
+
+    @Inject
+    DocumentRepository documents;
+
+    @Inject
+    Embeddings embeddings;
+
+    @Test
+    void storesAndFindsNearestVectors() {
+        Assumptions.assumeFalse(System.getProperty("org.graalvm.nativeimage.imagecode") != null);
+        documents.deleteAll();
+        documents.save(document("Micronaut is a JVM framework for fast microservices"));
+        documents.save(document("Micronaut Data generates database queries at compile time"));
+        documents.save(document("Tomatoes grow well in sunny gardens"));
+
+        var matches = documents.searchTop3ByEmbeddingNear(
+                embeddings.embed("JVM framework for microservices"),
+                new Score(0.7),
+                ScoringFunction.COSINE
+        ).results();
+
+        assertEquals(
+                "Micronaut is a JVM framework for fast microservices",
+                matches.getFirst().entity().content()
+        );
+        assertTrue(matches.getFirst().similarity().value() > .7);
+    }
+
+    private Document document(String content) {
+        return new Document(null, content, embeddings.embed(content));
+    }
+}

--- a/guides/micronaut-data-vector-rag/metadata.json
+++ b/guides/micronaut-data-vector-rag/metadata.json
@@ -1,0 +1,17 @@
+{
+  "title": "Build a RAG Retrieval Service with Micronaut Data and Oracle Vector",
+  "intro": "Learn how to create local embeddings and use Micronaut Data JDBC with Oracle VECTOR for semantic retrieval, the retrieval step of a RAG application.",
+  "authors": ["Nemanja Mikic"],
+  "tags": ["database", "micronaut-data", "jdbc", "oracle", "vector", "rag", "embeddings"],
+  "categories": ["Data JDBC"],
+  "publicationDate": "2026-08-19",
+  "languages": ["JAVA"],
+  "minimumJavaVersion": 21,
+  "apps": [
+    {
+      "name": "default",
+      "invisibleFeatures": ["langchain4j-all-minilm", "test-resources-long-timeout"],
+      "features": ["data-jdbc", "oracle", "serialization-jackson"]
+    }
+  ]
+}

--- a/guides/micronaut-data-vector-rag/micronaut-data-vector-rag.adoc
+++ b/guides/micronaut-data-vector-rag/micronaut-data-vector-rag.adoc
@@ -1,0 +1,107 @@
+common:header.adoc[]
+
+In this guide, you will build the retrieval part of a Retrieval-Augmented Generation (RAG) service. The application creates a local embedding for each document, stores the embedding in an Oracle `VECTOR` column, and retrieves the most relevant documents for a natural-language query.
+
+The guide uses the `all-MiniLM-L6-v2` model through LangChain4j. It runs in the application, produces 384-dimensional vectors, and does not require an API key. The returned documents are the context a later generation step can send to an LLM.
+
+common:requirements.adoc[]
+
+* https://www.docker.io/gettingstarted/#h_installation[Docker] installed to run Oracle Database with https://micronaut-projects.github.io/micronaut-test-resources/latest/guide/[Micronaut Test Resources].
+
+common:completesolution.adoc[]
+
+common:create-app-features.adoc[]
+
+common:oracle-driver.adoc[]
+
+The `langchain4j-all-minilm` Java feature adds the local embedding model:
+
+dependency:langchain4j-embeddings-all-minilm-l6-v2[groupId=dev.langchain4j]
+
+== Configure the datasource
+
+resource:application.properties[]
+
+The application uses Micronaut Test Resources to start Oracle Database Free. `schema-generate=CREATE_DROP` lets Micronaut Data create and remove the table for this sample.
+
+== Create embeddings
+
+An embedding is a numeric representation of text. Similar text produces vectors that are close together in vector space. Create an `Embeddings` singleton that wraps the local MiniLM model:
+
+source:Embeddings[]
+
+The model produces 384-dimensional vectors, so the database column must use the same dimension.
+
+== Store documents and their vectors
+
+Create a `Document` entity with a `VECTOR` column:
+
+source:Document[]
+
+`@VectorStorage` tells Micronaut Data to map `FloatVector` to the database's native vector type. The embedding is generated before the entity is saved.
+
+== Query by semantic similarity
+
+Create a repository with a derived nearest-neighbor query:
+
+source:DocumentRepository[]
+
+Micronaut Data generates the JDBC implementation at compile time. The `Near` predicate becomes a database vector search, so Oracle compares and orders the vectors without loading every document into the application.
+
+== Expose ingestion and retrieval
+
+Create a controller that embeds incoming text, stores documents, and returns the most relevant context:
+
+source:DocumentController[]
+
+<1> Generate an embedding for the document before persisting it.
+<2> Search with the embedding for the query text.
+<3> Use cosine similarity to compare semantic meaning rather than exact words.
+
+== Test the retrieval flow
+
+Verify that the model creates vectors with the expected dimension:
+
+test:EmbeddingsTest[]
+
+Then verify storage and nearest-neighbor ordering against Oracle:
+
+test:VectordemoTest[]
+
+common:testApp.adoc[]
+
+When you run the test, Micronaut Test Resources starts an Oracle Database container and configures the JDBC datasource automatically.
+
+== Run the application
+
+common:runapp.adoc[]
+
+Add a few documents:
+
+[source,bash]
+----
+curl -X POST localhost:8080/documents -H 'Content-Type: application/json' \\
+  -d '{"content":"Micronaut is a JVM framework for fast microservices"}'
+
+curl -X POST localhost:8080/documents -H 'Content-Type: application/json' \\
+  -d '{"content":"Micronaut Data generates database queries at compile time"}'
+
+curl -X POST localhost:8080/documents -H 'Content-Type: application/json' \\
+  -d '{"content":"Tomatoes grow well in sunny gardens"}'
+----
+
+Search with different words:
+
+[source,bash]
+----
+curl --get localhost:8080/documents/search \\
+  --data-urlencode 'q=lightweight Java toolkit for backend services'
+----
+
+The Micronaut document should be returned first even though the query uses different words. Its content can be passed to a generation model as RAG context.
+
+== Next steps
+
+Read more about https://micronaut-projects.github.io/micronaut-data/latest/guide/#vector[Micronaut Data vector support] and https://docs.oracle.com/en/database/oracle/oracle-database/23/vecse/[Oracle AI Vector Search].
+
+common:helpWithMicronaut.adoc[]

--- a/guides/micronaut-data-vector-rag/micronaut-data-vector-rag.adoc
+++ b/guides/micronaut-data-vector-rag/micronaut-data-vector-rag.adoc
@@ -12,7 +12,11 @@ common:completesolution.adoc[]
 
 common:create-app-features.adoc[]
 
-common:oracle-driver.adoc[]
+=== Configure Oracle and embedding dependencies
+
+Add the Oracle JDBC driver:
+
+dependency:ojdbc11[groupId=com.oracle.database.jdbc,scope=runtimeOnly]
 
 The `langchain4j-all-minilm` Java feature adds the local embedding model:
 

--- a/guides/micronaut-data-vector-rag/micronaut-data-vector-rag.adoc
+++ b/guides/micronaut-data-vector-rag/micronaut-data-vector-rag.adoc
@@ -72,8 +72,6 @@ common:testApp.adoc[]
 
 When you run the test, Micronaut Test Resources starts an Oracle Database container and configures the JDBC datasource automatically.
 
-== Run the application
-
 common:runapp.adoc[]
 
 Add a few documents:

--- a/guides/micronaut-data-vector-rag/src/main/resources/application.properties
+++ b/guides/micronaut-data-vector-rag/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+micronaut.application.name=micronautguide
+datasources.default.db-type=oracle
+datasources.default.dialect=ORACLE
+datasources.default.driver-class-name=oracle.jdbc.OracleDriver
+datasources.default.schema-generate=CREATE_DROP
+test-resources.containers.oracle.image-name=gvenzl/oracle-free:23-slim-faststart
+test-resources.containers.oracle.startup-timeout=600s


### PR DESCRIPTION
Adds a Micronaut Data JDBC guide showing local LangChain4j embeddings, Oracle VECTOR storage, semantic nearest-neighbor retrieval, and RAG context preparation. Includes generated-project tests for embeddings and Oracle vector search. Verified with micronautDataVectorRagGenerateDocs, :buildSrc:compileJava, and the generated Gradle JVM integration tests.